### PR TITLE
AP-443 Define logging and response

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -47,12 +47,13 @@ group :development do
   gem 'spring-watcher-listen', '~> 2.0.0'
 end
 
-# group :test do
-#   gem 'factory_bot_rails'
-#   gem 'shoulda-matchers'
-#   gem 'faker'
-#   gem 'database_cleaner'
-# end
+group :test do
+  gem 'factory_bot_rails'
+  gem 'shoulda-matchers'
+  gem 'faker'
+  gem 'database_cleaner'
+  gem 'webmock'
+end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -52,12 +52,23 @@ GEM
     builder (3.2.3)
     byebug (11.0.1)
     concurrent-ruby (1.1.5)
+    crack (0.4.3)
+      safe_yaml (~> 1.0.0)
     crass (1.0.4)
+    database_cleaner (1.7.0)
     diff-lcs (1.3)
     erubi (1.8.0)
+    factory_bot (5.0.2)
+      activesupport (>= 4.2.0)
+    factory_bot_rails (5.0.2)
+      factory_bot (~> 5.0.2)
+      railties (>= 4.2.0)
+    faker (1.9.3)
+      i18n (>= 0.7)
     ffi (1.10.0)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
+    hashdiff (0.3.9)
     i18n (1.6.0)
       concurrent-ruby (~> 1.0)
     jaro_winkler (1.5.2)
@@ -149,6 +160,9 @@ GEM
       rubocop (>= 0.68.0)
     ruby-progressbar (1.10.0)
     ruby_dep (1.5.0)
+    safe_yaml (1.0.5)
+    shoulda-matchers (4.0.1)
+      activesupport (>= 4.2.0)
     spring (2.0.2)
       activesupport (>= 4.2)
     spring-watcher-listen (2.0.1)
@@ -166,6 +180,10 @@ GEM
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
     unicode-display_width (1.5.0)
+    webmock (3.5.1)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff
     websocket-driver (0.7.0)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.3)
@@ -177,6 +195,9 @@ DEPENDENCIES
   awesome_print
   bootsnap (>= 1.1.0)
   byebug
+  database_cleaner
+  factory_bot_rails
+  faker
   json-schema
   listen (>= 3.0.5, < 3.2)
   pg (>= 0.18, < 2.0)
@@ -185,9 +206,11 @@ DEPENDENCIES
   rspec-rails (~> 3.8)
   rubocop
   rubocop-performance
+  shoulda-matchers
   spring
   spring-watcher-listen (~> 2.0.0)
   tzinfo-data
+  webmock
 
 RUBY VERSION
    ruby 2.5.3p105

--- a/app/models/assessment.rb
+++ b/app/models/assessment.rb
@@ -1,4 +1,2 @@
 class Assessment < ApplicationRecord
-  validates :remote_ip, presence: true
-  validates :request_payload, presence: true
 end

--- a/app/models/assessment.rb
+++ b/app/models/assessment.rb
@@ -1,0 +1,4 @@
+class Assessment < ApplicationRecord
+  validates :remote_ip, presence: true
+  validates :request_payload, presence: true
+end

--- a/app/services/json_schema_validator.rb
+++ b/app/services/json_schema_validator.rb
@@ -1,5 +1,5 @@
 class JsonSchemaValidator
-  SCHEMA_PATH = File.join(Rails.root, 'config', 'api', 'assessment_schema.json')
+  SCHEMA_PATH = Rails.root.join('public/schemas/assessment_request.json').to_s
 
   def initialize(payload)
     @payload = payload

--- a/db/migrate/20190517092600_enable_pgcrypto_extension.rb
+++ b/db/migrate/20190517092600_enable_pgcrypto_extension.rb
@@ -1,0 +1,5 @@
+class EnablePgcryptoExtension < ActiveRecord::Migration[5.1]
+  def change
+    enable_extension 'pgcrypto'
+  end
+end

--- a/db/migrate/20190517092721_create_assessments.rb
+++ b/db/migrate/20190517092721_create_assessments.rb
@@ -1,0 +1,13 @@
+class CreateAssessments < ActiveRecord::Migration[5.2]
+  def change
+    create_table :assessments, id: :uuid do |t|
+      t.string :client_reference_id
+      t.inet :remote_ip
+      t.json :request_payload
+      t.json :response_payload
+      t.string :result
+      t.timestamps
+    end
+    add_index :assessments, :client_reference_id, unique: false
+  end
+end

--- a/db/migrate/20190517092721_create_assessments.rb
+++ b/db/migrate/20190517092721_create_assessments.rb
@@ -2,8 +2,8 @@ class CreateAssessments < ActiveRecord::Migration[5.2]
   def change
     create_table :assessments, id: :uuid do |t|
       t.string :client_reference_id
-      t.inet :remote_ip
-      t.json :request_payload
+      t.inet :remote_ip, null: false
+      t.json :request_payload, null: false
       t.json :response_payload
       t.string :result
       t.timestamps

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -18,8 +18,8 @@ ActiveRecord::Schema.define(version: 2019_05_17_092721) do
 
   create_table "assessments", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "client_reference_id"
-    t.inet "remote_ip"
-    t.json "request_payload"
+    t.inet "remote_ip", null: false
+    t.json "request_payload", null: false
     t.json "response_payload"
     t.string "result"
     t.datetime "created_at", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,22 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_04_17_114315) do
+ActiveRecord::Schema.define(version: 2019_05_17_092721) do
 
   # These are extensions that must be enabled in order to support this database
+  enable_extension "pgcrypto"
   enable_extension "plpgsql"
+
+  create_table "assessments", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "client_reference_id"
+    t.inet "remote_ip"
+    t.json "request_payload"
+    t.json "response_payload"
+    t.string "result"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["client_reference_id"], name: "index_assessments_on_client_reference_id"
+  end
 
   create_table "statuses", force: :cascade do |t|
     t.string "response"

--- a/public/schemas/assessment_request.json
+++ b/public/schemas/assessment_request.json
@@ -1,8 +1,8 @@
 {
-  "id": "#{Rails.root}/config/api/assessment_schema.json",
+  "id": "http://localhost:3000/schemas/assessment_request.json",
   "$schema": "http://json-schema.org/draft-04/schema#",
   "title": "Legal Aid Check Financial Eligibility payload schema",
-  "description": " defines the payload required to submit data to the Legal Aid Check Financial Eligibility API",
+  "description": "This schema defines the payload required to submit data to the Legal Aid Check Financial Eligibility API",
 
 
   "type": "object",
@@ -17,6 +17,11 @@
 
 
   "definitions": {
+    "uuid": {
+      "description": "Unique universal identifier",
+      "type": "string",
+      "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
+    },
     "date": {
       "description": "Date in format YYYY-MM-DD in range 1900-01-01 to 2999-12-31",
       "type": "string",

--- a/public/schemas/assessment_response.json
+++ b/public/schemas/assessment_response.json
@@ -1,0 +1,113 @@
+{
+  "id": "http://localhost:3000/schemas/assessment_response_schema.json",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Legal Aid Check Financial Eligibility response schema",
+  "description": "This schema defines the response to an eligibility assessment request",
+
+  "type": "object",
+  "required": [
+    "assessment_id",
+    "details"
+  ],
+  "additionalProperties": false,
+
+  "definitions": {
+    "assessment_result": {
+      "type": "string",
+      "enum": [
+        "eligible",
+        "not_eligible",
+        "contribution_required",
+        "out_of_scope"
+      ]
+    }
+  },
+  "properties": {
+    "assessment_id": {
+      "description": "A unique id for this eligibilty check",
+      "$ref": "http://localhost:3000/schemas/assessment_request.json#definitions/uuid"
+    },
+    "client_reference_id": {
+      "description": "The client reference id specified in the request, if present",
+      "type": "string"
+    },
+    "result": {
+      "description": "The result of the eligibility check as  follows:\neligible: Eligible for legal aid\nnot_eligible: Not eligible for legal aid\ncontribution_required: The applicant is eligible for legal aid, but a monthly contribution and/or a capital contribution as specified in the details is required\nout_of_scope: This applicant is out of scope for automatic determination of eligibility",
+      "$ref": "#/definitions/assessment_result"
+    },
+    "details": {
+      "description": "Interim values used in the calculation",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "passported",
+        "self_employed",
+        "monthly_gross_income",
+        "upper_income_threshold",
+        "monthly_disposable_income",
+        "disposable_income_lower_threshold",
+        "disposable_income_upper_threshold",
+        "total_capital_assessment",
+        "total_capital_lower_threshold",
+        "total_capital_upper_threshold",
+        "disposable_capital_assessment",
+        "monthly_contribution",
+        "capital_contribution"
+      ],
+      "properties": {
+        "passported": {
+          "description": "Whether or not the applicant receives a qualifying benefit",
+          "type": "boolean"
+        },
+        "self_employed": {
+          "description": "Whether or not the applicant is self-employed",
+          "type": "boolean"
+        },
+        "monthly_gross_income": {
+          "description": "The monthly gross income calculated from the individual income values given",
+          "$ref": "http://localhost:3000/schemas/assessment_request.json#definitions/number_with_two_decimals"
+        },
+        "upper_income_threshold": {
+          "description": "The upper income threshold that was used (valies according to the circumstances of the applicant)",
+          "$ref": "http://localhost:3000/schemas/assessment_request.json#definitions/number_with_two_decimals"
+        },
+        "monthly_disposable_income": {
+          "description": "The monthly dispasable income calculated from the individual income values given and allowable expenses",
+          "$ref": "http://localhost:3000/schemas/assessment_request.json#definitions/number_with_two_decimals"
+        },
+        "disposable_income_lower_threshold": {
+          "description": "The lower threshold of the monthly disposable income used in the calculation",
+          "$ref": "http://localhost:3000/schemas/assessment_request.json#definitions/number_with_two_decimals"
+        },
+        "disposable_income_upper_threshold": {
+          "description": "The upper threshold of the monthly disposable income used in the calculation",
+          "$ref": "http://localhost:3000/schemas/assessment_request.json#definitions/number_with_two_decimals"
+        },
+        "total_capital_assessment": {
+          "description": "The total capital assets of the applicant calculated from all the values given",
+          "$ref": "http://localhost:3000/schemas/assessment_request.json#definitions/number_with_two_decimals"
+        },
+        "total_capital_lower_threshold": {
+          "description": "The lower threshold of the capital allowance used in the calculation",
+          "$ref": "http://localhost:3000/schemas/assessment_request.json#definitions/number_with_two_decimals"
+        },
+        "total_capital_upper_threshold": {
+          "description": "The upper threshold of the capital allowance used in the calculation",
+          "$ref": "http://localhost:3000/schemas/assessment_request.json#definitions/number_with_two_decimals"
+        },
+        "disposable_capital_assessment": {
+          "description": "The applicant's disposable capital calculated after subtracting allowable items from the list of capital assets given",
+          "$ref": "http://localhost:3000/schemas/assessment_request.json#definitions/number_with_two_decimals"
+        },
+        "monthly_contribution": {
+          "description": "The monthly contribution required from the applicant",
+          "$ref": "http://localhost:3000/schemas/assessment_request.json#definitions/number_with_two_decimals"
+        },
+        "capital_contribution": {
+          "description": "The capital contribution required from the applicant",
+          "$ref": "http://localhost:3000/schemas/assessment_request.json#definitions/number_with_two_decimals"
+        }
+      }
+    }
+  }
+}

--- a/spec/fixtures/assessment_fixture.rb
+++ b/spec/fixtures/assessment_fixture.rb
@@ -1,4 +1,4 @@
-class AssessmentFixture
+class AssessmentFixture < BaseAssessmentFixture
   def self.ruby_hash
     {
       client_reference_id: 'my-eligibility-check-01',

--- a/spec/fixtures/assessment_response_fixture.rb
+++ b/spec/fixtures/assessment_response_fixture.rb
@@ -1,0 +1,24 @@
+class AssessmentResponseFixture < BaseAssessmentFixture
+  def self.ruby_hash
+    {
+      assessment_id: 'e34ce98e-8cfa-4a41-a011-7a15a6724b82',
+      client_reference_id: 'client-ref-1',
+      result: 'eligible',
+      details: {
+        passported: true,
+        self_employed: false,
+        monthly_gross_income: 2_565.33,
+        upper_income_threshold: 2_567.00,
+        monthly_disposable_income: 220.55,
+        disposable_income_lower_threshold: 310.00,
+        disposable_income_upper_threshold: 733.00,
+        total_capital_assessment: 2_855.55,
+        total_capital_lower_threshold: 3_000.00,
+        total_capital_upper_threshold: 8_000.00,
+        disposable_capital_assessment: 100.00,
+        monthly_contribution: 0.00,
+        capital_contribution: 0.00
+      }
+    }
+  end
+end

--- a/spec/fixtures/base_assessment_fixture.rb
+++ b/spec/fixtures/base_assessment_fixture.rb
@@ -1,0 +1,13 @@
+class BaseAssessmentFixture
+  def self.json
+    ruby_hash.to_json
+  end
+
+  def self.pretty_json
+    JSON.pretty_generate(ruby_hash)
+  end
+
+  def ruby_hash
+    # define this in the derived class
+  end
+end

--- a/spec/models/assessment_spec.rb
+++ b/spec/models/assessment_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Assessment, type: :model do
         expect {
           Assessment.create!(client_reference_id: 'client-ref-1',
                              request_payload: payload)
-        }.to raise_error ActiveRecord::RecordInvalid, "Validation failed: Remote ip can't be blank"
+        }.to raise_error ActiveRecord::NotNullViolation, /null value in column "remote_ip"/
       end
     end
 
@@ -28,7 +28,7 @@ RSpec.describe Assessment, type: :model do
         expect {
           Assessment.create!(client_reference_id: 'client-ref-1',
                              remote_ip: '192.168.9.8')
-        }.to raise_error ActiveRecord::RecordInvalid, "Validation failed: Request payload can't be blank"
+        }.to raise_error ActiveRecord::NotNullViolation, /null value in column "request_payload"/
       end
     end
   end

--- a/spec/models/assessment_spec.rb
+++ b/spec/models/assessment_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+require Rails.root.join('spec/fixtures/assessment_fixture.rb')
+
+RSpec.describe Assessment, type: :model do
+  context 'saving request before result is known' do
+    let(:payload) { AssessmentFixture.json }
+
+    context 'all fields supplied' do
+      it 'saves ok' do
+        assessment = Assessment.create!(client_reference_id: 'client-ref-1',
+                                        remote_ip: '192.168.9.8',
+                                        request_payload: payload)
+        expect(assessment.request_payload).to eq payload
+      end
+    end
+
+    context 'missing ip address' do
+      it 'raises' do
+        expect {
+          Assessment.create!(client_reference_id: 'client-ref-1',
+                             request_payload: payload)
+        }.to raise_error ActiveRecord::RecordInvalid, "Validation failed: Remote ip can't be blank"
+      end
+    end
+
+    context 'missing request payload' do
+      it 'raises' do
+        expect {
+          Assessment.create!(client_reference_id: 'client-ref-1',
+                             remote_ip: '192.168.9.8')
+        }.to raise_error ActiveRecord::RecordInvalid, "Validation failed: Request payload can't be blank"
+      end
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -59,3 +59,7 @@ RSpec.configure do |config|
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
 end
+
+require_relative 'fixtures/base_assessment_fixture'
+require_relative 'fixtures/assessment_fixture'
+require_relative 'fixtures/assessment_response_fixture'

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -60,6 +60,8 @@ RSpec.configure do |config|
   # config.filter_gems_from_backtrace("gem name")
 end
 
-require_relative 'fixtures/base_assessment_fixture'
-require_relative 'fixtures/assessment_fixture'
-require_relative 'fixtures/assessment_response_fixture'
+require 'webmock/rspec'
+
+require Rails.root.join('spec/fixtures/base_assessment_fixture')
+require Rails.root.join('spec/fixtures/assessment_fixture')
+require Rails.root.join('spec/fixtures/assessment_response_fixture')

--- a/spec/services/json_assessment_response_validator_spec.rb
+++ b/spec/services/json_assessment_response_validator_spec.rb
@@ -5,15 +5,14 @@ describe 'JSON Assessment response' do
     # The response schema references the request schema definitions through an HTTP request, so
     # stub it out here.
     assessment_request_schema = File.read(Rails.root.join('public/schemas/assessment_request.json'))
-    stub_request(:get, "http://localhost:3000/schemas/assessment_request.json").
-      to_return(:body => assessment_request_schema)
+    stub_request(:get, 'http://localhost:3000/schemas/assessment_request.json')
+      .to_return(body: assessment_request_schema)
   end
 
   context 'A valid response' do
     it 'does not create any errors' do
       schema_path = Rails.root.join('public/schemas/assessment_response.json').to_s
-      response_hash = AssessmentResponseFixture.ruby_hash
-      payload = JSON.pretty_generate(response_hash)
+      payload = JSON.pretty_generate(AssessmentResponseFixture.ruby_hash)
       errors = JSON::Validator.fully_validate(schema_path, payload)
       expect(errors).to be_empty
     end

--- a/spec/services/json_assessment_response_validator_spec.rb
+++ b/spec/services/json_assessment_response_validator_spec.rb
@@ -1,6 +1,14 @@
 require 'rails_helper'
 
 describe 'JSON Assessment response' do
+  before do
+    # The response schema references the request schema definitions through an HTTP request, so
+    # stub it out here.
+    assessment_request_schema = File.read(Rails.root.join('public/schemas/assessment_request.json'))
+    stub_request(:get, "http://localhost:3000/schemas/assessment_request.json").
+      to_return(:body => assessment_request_schema)
+  end
+
   context 'A valid response' do
     it 'does not create any errors' do
       schema_path = Rails.root.join('public/schemas/assessment_response.json').to_s

--- a/spec/services/json_assessment_response_validator_spec.rb
+++ b/spec/services/json_assessment_response_validator_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+
+describe 'JSON Assessment response' do
+  context 'A valid response' do
+    it 'does not create any errors' do
+      schema_path = Rails.root.join('public/schemas/assessment_response.json').to_s
+      response_hash = AssessmentResponseFixture.ruby_hash
+      payload = JSON.pretty_generate(response_hash)
+      errors = JSON::Validator.fully_validate(schema_path, payload)
+      expect(errors).to be_empty
+    end
+  end
+end

--- a/spec/services/json_schema_validator_spec.rb
+++ b/spec/services/json_schema_validator_spec.rb
@@ -1,5 +1,4 @@
 require 'rails_helper'
-require_relative '../fixtures/assessment_fixture'
 
 describe JsonSchemaValidator do
   let(:assessment_hash) { AssessmentFixture.ruby_hash }


### PR DESCRIPTION
This defines the response from an eligibility check request.

Also included in this PR:

 - move the assessment_request schema to public/schemas so that they can be served by an http request
 - write a schema for the response for documentation purposes
 - a spec to check that the assessment_response schema works
 - create a model to record the request and response.  This will be the log of the activity
0e09375
