### PR TITLE
AP-621a - Refactor Assessment services

### DIFF
--- a/app/models/assessment_particulars.rb
+++ b/app/models/assessment_particulars.rb
@@ -89,7 +89,7 @@ class AssessmentParticulars
     {
       liquid_capital_assessment: 0.0,
       property: {
-        main_dwelling: AssessmentParticulars.initial_property_details,
+        main_home: AssessmentParticulars.initial_property_details,
         additional_properties: []
       },
       vehicles: [],

--- a/app/services/workflow_service/disposable_capital_assessment.rb
+++ b/app/services/workflow_service/disposable_capital_assessment.rb
@@ -1,7 +1,9 @@
 module WorkflowService
   class DisposableCapitalAssessment < BaseWorkflowService
     def call
-      calculate_liquid_capital
+      response.details.capital.liquid_capital_assessment = calculate_liquid_capital
+      # TODO: refactor this to pass in just the bit of interest and receive back just the bit of interest
+
       PropertyAssessment.new(@particulars).call
       VehicleAssessment.new(@particulars).call
       true
@@ -10,12 +12,7 @@ module WorkflowService
     private
 
     def calculate_liquid_capital
-      total_liquid_capital = 0.0
-
-      applicant_capital.liquid_capital.bank_accounts.each do |acct|
-        total_liquid_capital += acct.lowest_balance if acct.lowest_balance.positive?
-      end
-      response.details.liquid_capital_assessment = total_liquid_capital.round(2)
+      LiquidCapitalAssessment.new(applicant_capital.liquid_capital).call
     end
   end
 end

--- a/app/services/workflow_service/disposable_capital_assessment.rb
+++ b/app/services/workflow_service/disposable_capital_assessment.rb
@@ -2,10 +2,8 @@ module WorkflowService
   class DisposableCapitalAssessment < BaseWorkflowService
     def call
       response.details.capital.liquid_capital_assessment = calculate_liquid_capital
-      # TODO: refactor this to pass in just the bit of interest and receive back just the bit of interest
-
-      PropertyAssessment.new(@particulars).call
-      VehicleAssessment.new(@particulars).call
+      response.details.capital.property = calculate_property
+      response.details.capital.vehicles = calculate_vehicles
       true
     end
 
@@ -13,6 +11,14 @@ module WorkflowService
 
     def calculate_liquid_capital
       LiquidCapitalAssessment.new(applicant_capital.liquid_capital).call
+    end
+
+    def calculate_property
+      PropertyAssessment.new(applicant_capital.property, @submission_date).call
+    end
+
+    def calculate_vehicles
+      VehicleAssessment.new(applicant_capital.vehicles, @submission_date).call
     end
   end
 end

--- a/app/services/workflow_service/liquid_capital_assessment.rb
+++ b/app/services/workflow_service/liquid_capital_assessment.rb
@@ -1,0 +1,15 @@
+module WorkflowService
+  class LiquidCapitalAssessment
+    def initialize(request)
+      @request = request
+    end
+
+    def call
+      total_liquid_capital = 0.0
+      @request.bank_accounts.each do |acct|
+        total_liquid_capital += acct.lowest_balance if acct.lowest_balance.positive?
+      end
+      total_liquid_capital.round(2)
+    end
+  end
+end

--- a/app/services/workflow_service/vehicle_assessment.rb
+++ b/app/services/workflow_service/vehicle_assessment.rb
@@ -1,17 +1,23 @@
 module WorkflowService
-  class VehicleAssessment < BaseWorkflowService
+  class VehicleAssessment
+    def initialize(vehicles, submission_date)
+      @vehicles = vehicles
+      @submission_date = submission_date
+      @response = []
+    end
+
     def call
-      applicant_capital.liquid_capital.vehicles.each { |v| assess(v) }
-      true
+      @vehicles.each { |v| assess(v) }
+      @response
     end
 
     private
 
     def assess(vehicle)
-      result = OpenStruct.new(AssessmentParticulars.initial_vehicle_details)
+      result = DatedStruct.new(AssessmentParticulars.initial_vehicle_details)
       copy_request_details_to_result(vehicle, result)
       result.assessed_value = assessed_value(vehicle)
-      response.details.capital.vehicles << result
+      @response << result
     end
 
     def vehicle_disregard

--- a/config/thresholds/8-Apr-2018.yml
+++ b/config/thresholds/8-Apr-2018.yml
@@ -11,7 +11,7 @@ capital_upper: 10000
 property_notional_sale_costs_percentage: 3.0
 property_maximum_mortgage_allowance: 100_000
 property_disregard:
-  main_dwelling: 100_000
+  main_home: 100_000
   additional_property: 0.0
 vehicle_disregard: 15_000
 vehicle_out_of_scope_months: 36

--- a/config/thresholds/8-Apr-2019.yml
+++ b/config/thresholds/8-Apr-2019.yml
@@ -12,7 +12,7 @@ capital_upper: 30000
 property_notional_sale_costs_percentage: 3.0
 property_maximum_mortgage_allowance: 100_000
 property_disregard:
-  main_dwelling: 100_000
+  main_home: 100_000
   additional_property: 0.0
 vehicle_disregard: 15_000
 vehicle_out_of_scope_months: 36

--- a/config/thresholds/8-Apr-2020.yml
+++ b/config/thresholds/8-Apr-2020.yml
@@ -10,7 +10,7 @@ capital_upper: 20000
 property_notional_sale_costs_percentage: 3.0
 property_maximum_mortgage_allowance: 100_000
 property_disregard:
-  main_dwelling: 100_000
+  main_home: 100_000
   additional_property: 0.0
 vehicle_disregard: 15_000
 vehicle_out_of_scope_months: 36

--- a/public/schemas/assessment_request.json
+++ b/public/schemas/assessment_request.json
@@ -231,14 +231,13 @@
         }
       }
     },
-    "applicant_vehicleXXXX": {
+    "applicant_vehicle": {
       "description": "Details of an individual vehicle",
       "required": [
         "value",
         "loan_amount_outstanding",
         "date_of_purchase",
-        "in_regular_use",
-        "xxx"
+        "in_regular_use"
       ],
       "additionalProperties": false,
       "properties": {
@@ -405,7 +404,9 @@
         },
         "vehicles": {
           "type": "array",
-          "items": "#/definitions/applicant_vehiclezzz"
+          "items": {
+            "$ref": "#/definitions/applicant_vehicle"
+          }
         },
         "liquid_capital": {
           "$ref": "#/definitions/applicant_liquid_capital"

--- a/public/schemas/assessment_request.json
+++ b/public/schemas/assessment_request.json
@@ -231,13 +231,14 @@
         }
       }
     },
-    "applicant_vehicle": {
+    "applicant_vehicleXXXX": {
       "description": "Details of an individual vehicle",
       "required": [
         "value",
         "loan_amount_outstanding",
         "date_of_purchase",
-        "in_regular_use"
+        "in_regular_use",
+        "xxx"
       ],
       "additionalProperties": false,
       "properties": {
@@ -290,13 +291,6 @@
           "minItems": 1,
           "items": {
             "$ref": "#/definitions/bank_accounts"
-          }
-        },
-        "vehicles": {
-          "description": "Details of applicant vehicles",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/applicant_vehicle"
           }
         }
       }
@@ -408,6 +402,10 @@
       "properties": {
         "property": {
           "$ref": "#/definitions/applicant_property"
+        },
+        "vehicles": {
+          "type": "array",
+          "items": "#/definitions/applicant_vehiclezzz"
         },
         "liquid_capital": {
           "$ref": "#/definitions/applicant_liquid_capital"

--- a/public/schemas/assessment_response.json
+++ b/public/schemas/assessment_response.json
@@ -129,9 +129,9 @@
     },
     "property_details": {
       "type": "object",
-      "required": ["main_dwelling", "additional_properties"],
+      "required": ["main_home", "additional_properties"],
       "properties": {
-        "main_dwelling": {
+        "main_home": {
           "description": "Details of value, equity, mortgage and allowances for the main dwelling",
           "$ref": "#/definitions/dwelling"
         },

--- a/spec/fixtures/assessment_request_fixture.rb
+++ b/spec/fixtures/assessment_request_fixture.rb
@@ -95,6 +95,14 @@ class AssessmentRequestFixture < BaseAssessmentFixture # rubocop:disable Metrics
             }
           ]
         },
+        vehicles: [
+          {
+            value: 9500,
+            loan_amount_outstanding: 6000,
+            date_of_purchase: Date.parse('13 Aug 2015'),
+            in_regular_use: true
+          }
+        ],
         liquid_capital: {
           bank_accounts: [
             {
@@ -110,14 +118,6 @@ class AssessmentRequestFixture < BaseAssessmentFixture # rubocop:disable Metrics
             {
               item_description: 'jewellery',
               value: 34_000
-            }
-          ],
-          vehicles: [
-            {
-              value: 9500,
-              loan_amount_outstanding: 6000,
-              date_of_purchase: Date.parse('13 Aug 2015'),
-              in_regular_use: true
             }
           ]
         },

--- a/spec/fixtures/assessment_response_fixture.rb
+++ b/spec/fixtures/assessment_response_fixture.rb
@@ -17,7 +17,7 @@ class AssessmentResponseFixture < BaseAssessmentFixture
         capital: {
           liquid_capital_assessment: 45.00,
           property: {
-            main_dwelling: {
+            main_home: {
               notional_sale_costs_pctg: 3.0,
               net_value_after_deduction: 485_000.0,
               maximum_mortgage_allowance: 100_000.0,

--- a/spec/services/json_schema_validator_spec.rb
+++ b/spec/services/json_schema_validator_spec.rb
@@ -515,6 +515,48 @@ describe JsonSchemaValidator do
         end
       end
 
+      context 'vehicles' do
+        context 'it is not present' do
+          before do
+            assessment_hash[:applicant_capital].delete(:vehicles)
+          end
+
+          it 'is valid' do
+            expect(validator).to be_valid
+          end
+        end
+
+        context 'it has an extra attribute' do
+          before do
+            assessment_hash[:applicant_capital][:vehicles].first[:name] = 'Michael'
+          end
+
+          xit 'is invalid' do
+            expect(validator).not_to be_valid
+          end
+
+          xit 'has an error message' do
+            expected_error = "The property '#/applicant_capital/liquid_capital/vehicles/0' contains additional properties .*name"
+            expect(validator.errors.first).to match(/#{expected_error}/)
+          end
+        end
+
+        context 'it has a missing attribute' do
+          before do
+            assessment_hash[:applicant_capital][:liquid_capital][:bank_accounts].first.delete(:value)
+          end
+
+          xit 'is invalid' do
+            expect(validator).not_to be_valid
+          end
+
+          xit 'has an error message' do
+            expected_error = "The property '#/applicant_capital/liquid_capital/vehicles/0' did not contain a required property of 'value'"
+            expect(validator.errors.first).to match(/#{expected_error}/)
+          end
+        end
+      end
+
       context 'liquid_capital' do
         context 'it is not present' do
           before do
@@ -593,47 +635,47 @@ describe JsonSchemaValidator do
           end
         end
 
-        context 'vehicles' do
-          context 'it is not present' do
-            before do
-              assessment_hash[:applicant_capital][:liquid_capital].delete(:vehicles)
-            end
-
-            it 'is valid' do
-              expect(validator).to be_valid
-            end
-          end
-
-          context 'it has an extra attribute' do
-            before do
-              assessment_hash[:applicant_capital][:liquid_capital][:vehicles].first[:name] = 'Michael'
-            end
-
-            it 'is invalid' do
-              expect(validator).not_to be_valid
-            end
-
-            it 'has an error message' do
-              expected_error = "The property '#/applicant_capital/liquid_capital/vehicles/0' contains additional properties .*name"
-              expect(validator.errors.first).to match(/#{expected_error}/)
-            end
-          end
-
-          context 'it has a missing attribute' do
-            before do
-              assessment_hash[:applicant_capital][:liquid_capital][:vehicles].first.delete(:value)
-            end
-
-            it 'is invalid' do
-              expect(validator).not_to be_valid
-            end
-
-            it 'has an error message' do
-              expected_error = "The property '#/applicant_capital/liquid_capital/vehicles/0' did not contain a required property of 'value'"
-              expect(validator.errors.first).to match(/#{expected_error}/)
-            end
-          end
-        end
+        # context 'vehicles' do
+        #   context 'it is not present' do
+        #     before do
+        #       assessment_hash[:applicant_capital][:liquid_capital].delete(:vehicles)
+        #     end
+        #
+        #     it 'is valid' do
+        #       expect(validator).to be_valid
+        #     end
+        #   end
+        #
+        #   context 'it has an extra attribute' do
+        #     before do
+        #       assessment_hash[:applicant_capital][:liquid_capital][:vehicles].first[:name] = 'Michael'
+        #     end
+        #
+        #     it 'is invalid' do
+        #       expect(validator).not_to be_valid
+        #     end
+        #
+        #     it 'has an error message' do
+        #       expected_error = "The property '#/applicant_capital/liquid_capital/vehicles/0' contains additional properties .*name"
+        #       expect(validator.errors.first).to match(/#{expected_error}/)
+        #     end
+        #   end
+        #
+        #   context 'it has a missing attribute' do
+        #     before do
+        #       assessment_hash[:applicant_capital][:liquid_capital][:bank_accounts].first.delete(:value)
+        #     end
+        #
+        #     it 'is invalid' do
+        #       expect(validator).not_to be_valid
+        #     end
+        #
+        #     it 'has an error message' do
+        #       expected_error = "The property '#/applicant_capital/liquid_capital/vehicles/0' did not contain a required property of 'value'"
+        #       expect(validator.errors.first).to match(/#{expected_error}/)
+        #     end
+        #   end
+        # end
       end
 
       context 'non_liquid_capital' do

--- a/spec/services/json_schema_validator_spec.rb
+++ b/spec/services/json_schema_validator_spec.rb
@@ -634,48 +634,6 @@ describe JsonSchemaValidator do
             end
           end
         end
-
-        # context 'vehicles' do
-        #   context 'it is not present' do
-        #     before do
-        #       assessment_hash[:applicant_capital][:liquid_capital].delete(:vehicles)
-        #     end
-        #
-        #     it 'is valid' do
-        #       expect(validator).to be_valid
-        #     end
-        #   end
-        #
-        #   context 'it has an extra attribute' do
-        #     before do
-        #       assessment_hash[:applicant_capital][:liquid_capital][:vehicles].first[:name] = 'Michael'
-        #     end
-        #
-        #     it 'is invalid' do
-        #       expect(validator).not_to be_valid
-        #     end
-        #
-        #     it 'has an error message' do
-        #       expected_error = "The property '#/applicant_capital/liquid_capital/vehicles/0' contains additional properties .*name"
-        #       expect(validator.errors.first).to match(/#{expected_error}/)
-        #     end
-        #   end
-        #
-        #   context 'it has a missing attribute' do
-        #     before do
-        #       assessment_hash[:applicant_capital][:liquid_capital][:bank_accounts].first.delete(:value)
-        #     end
-        #
-        #     it 'is invalid' do
-        #       expect(validator).not_to be_valid
-        #     end
-        #
-        #     it 'has an error message' do
-        #       expected_error = "The property '#/applicant_capital/liquid_capital/vehicles/0' did not contain a required property of 'value'"
-        #       expect(validator.errors.first).to match(/#{expected_error}/)
-        #     end
-        #   end
-        # end
       end
 
       context 'non_liquid_capital' do

--- a/spec/services/json_schema_validator_spec.rb
+++ b/spec/services/json_schema_validator_spec.rb
@@ -531,27 +531,27 @@ describe JsonSchemaValidator do
             assessment_hash[:applicant_capital][:vehicles].first[:name] = 'Michael'
           end
 
-          xit 'is invalid' do
+          it 'is invalid' do
             expect(validator).not_to be_valid
           end
 
-          xit 'has an error message' do
-            expected_error = "The property '#/applicant_capital/liquid_capital/vehicles/0' contains additional properties .*name"
+          it 'has an error message' do
+            expected_error = "The property '#/applicant_capital/vehicles/0' contains additional properties .*name"
             expect(validator.errors.first).to match(/#{expected_error}/)
           end
         end
 
         context 'it has a missing attribute' do
           before do
-            assessment_hash[:applicant_capital][:liquid_capital][:bank_accounts].first.delete(:value)
+            assessment_hash[:applicant_capital][:vehicles].first.delete(:value)
           end
 
-          xit 'is invalid' do
+          it 'is invalid' do
             expect(validator).not_to be_valid
           end
 
-          xit 'has an error message' do
-            expected_error = "The property '#/applicant_capital/liquid_capital/vehicles/0' did not contain a required property of 'value'"
+          it 'has an error message' do
+            expected_error = "The property '#/applicant_capital/vehicles/0' did not contain a required property of 'value'"
             expect(validator.errors.first).to match(/#{expected_error}/)
           end
         end

--- a/spec/services/workflow_service/disposable_capital_assessment_spec.rb
+++ b/spec/services/workflow_service/disposable_capital_assessment_spec.rb
@@ -14,7 +14,7 @@ module WorkflowService
       end
 
       context 'liquid capital' do
-        it 'instantiates and calls the Property Assessment service' do
+        it 'instantiates and calls the Liquid Capital Assessment service' do
           lcas = double LiquidCapitalAssessment
           expect(LiquidCapitalAssessment).to receive(:new)
             .with(particulars.request.applicant_capital.liquid_capital)

--- a/spec/services/workflow_service/disposable_capital_assessment_spec.rb
+++ b/spec/services/workflow_service/disposable_capital_assessment_spec.rb
@@ -13,28 +13,14 @@ module WorkflowService # rubocop:disable Metrics/ModuleLength
       end
 
       context 'liquid capital' do
-        context 'all positive supplied' do
-          it 'adds them all together' do
-            particulars.request.applicant_capital.liquid_capital.bank_accounts = open_structify(all_positive_bank_accounts)
-            expect(service.call).to be true
-            expect(particulars.response.details.liquid_capital_assessment).to eq 136.87
-          end
-        end
-
-        context 'mixture of positive and negative supplied' do
-          it 'ignores negative values' do
-            particulars.request.applicant_capital.liquid_capital.bank_accounts = open_structify(mixture_of_negative_and_positive_bank_accounts)
-            expect(service.call).to be true
-            expect(particulars.response.details.liquid_capital_assessment).to eq 35.88
-          end
-        end
-
-        context 'all negative supplied' do
-          it 'ignores negative values' do
-            particulars.request.applicant_capital.liquid_capital.bank_accounts = open_structify(all_negative_bank_accounts)
-            expect(service.call).to be true
-            expect(particulars.response.details.liquid_capital_assessment).to eq 0.0
-          end
+        it 'instantiates and calls the Property Assessment service' do
+          lcas = double LiquidCapitalAssessment
+          expect(LiquidCapitalAssessment).to receive(:new)
+            .with(particulars.request.applicant_capital.liquid_capital)
+            .and_return(lcas)
+          expect(lcas).to receive(:call).and_return(156.26)
+          expect(particulars.response.details.capital).to receive(:liquid_capital_assessment=).with(156.26)
+          service.call
         end
       end
 
@@ -55,30 +41,6 @@ module WorkflowService # rubocop:disable Metrics/ModuleLength
           service.call
         end
       end
-    end
-
-    def all_positive_bank_accounts
-      [
-        { account_name: 'Account 1', lowest_balance: 35.66 },
-        { account_name: 'Account 2', lowest_balance: 100.99 },
-        { account_name: 'Account 3', lowest_balance: 0.22 }
-      ]
-    end
-
-    def mixture_of_negative_and_positive_bank_accounts
-      [
-        { account_name: 'Account 1', lowest_balance: 35.66 },
-        { account_name: 'Account 2', lowest_balance: - 100.99 },
-        { account_name: 'Account 3', lowest_balance: 0.22 }
-      ]
-    end
-
-    def all_negative_bank_accounts
-      [
-        { account_name: 'Account 1', lowest_balance: -35.66 },
-        { account_name: 'Account 2', lowest_balance: - 100.99 },
-        { account_name: 'Account 3', lowest_balance: -0.22 }
-      ]
     end
 
     def main_dwelling_big_mortgage_wholly_owned

--- a/spec/services/workflow_service/disposable_capital_assessment_spec.rb
+++ b/spec/services/workflow_service/disposable_capital_assessment_spec.rb
@@ -1,11 +1,12 @@
 require 'rails_helper'
 
-module WorkflowService # rubocop:disable Metrics/ModuleLength
+module WorkflowService
   RSpec.describe DisposableCapitalAssessment do
     let(:service) { DisposableCapitalAssessment.new(particulars) }
     let(:request_hash) { AssessmentRequestFixture.ruby_hash }
     let(:assessment) { create :assessment, request_payload: request_hash.to_json }
     let(:particulars) { AssessmentParticulars.new(assessment) }
+    let(:today) { Date.new(2019, 4, 2) }
 
     describe '#call' do
       it 'always returns true' do
@@ -27,105 +28,25 @@ module WorkflowService # rubocop:disable Metrics/ModuleLength
       context 'property_assessment' do
         it 'instantiates and calls the Property Assessment service' do
           property_service = double PropertyAssessment
-          expect(PropertyAssessment).to receive(:new).with(particulars).and_return(property_service)
-          expect(property_service).to receive(:call).and_return(true)
+          property_details = particulars.request.applicant_capital.property
+          expect(PropertyAssessment).to receive(:new).with(property_details, today).and_return(property_service)
+          expect(property_service).to receive(:call).and_return('Property Result')
+
           service.call
+          expect(particulars.response.details.capital.property).to eq 'Property Result'
         end
       end
 
       context 'vehicle assessment' do
-        it 'instantiates and calles the Vehicle Assesment service' do
+        it 'instantiates and calls the Vehicle Assesment service' do
           vehicle_service = double VehicleAssessment
-          expect(VehicleAssessment).to receive(:new).with(particulars).and_return(vehicle_service)
-          expect(vehicle_service).to receive(:call).and_return(true)
+          vehicle_details = particulars.request.applicant_capital.vehicles
+          expect(VehicleAssessment).to receive(:new).with(vehicle_details, today).and_return(vehicle_service)
+          expect(vehicle_service).to receive(:call).and_return('Vehicle Result')
           service.call
+          expect(particulars.response.details.capital.vehicles).to eq 'Vehicle Result'
         end
       end
-    end
-
-    def main_dwelling_big_mortgage_wholly_owned
-      {
-        main_home: {
-          value: 466_993,
-          outstanding_mortgage: 266_000,
-          percentage_owned: 100.0,
-          shared_with_housing_assoc: false
-        },
-        additional_properties: []
-      }
-    end
-
-    def main_dwelling_small_mortgage_wholly_owned
-      {
-        main_home: {
-          value: 466_993,
-          outstanding_mortgage: 37_256.44,
-          percentage_owned: 100.0,
-          shared_with_housing_assoc: false
-        },
-        additional_properties: []
-      }
-    end
-
-    def main_dwelling_big_mortgage_partly_owned
-      {
-        main_home: {
-          value: 466_993,
-          outstanding_mortgage: 266_000,
-          percentage_owned: 66.66,
-          shared_with_housing_assoc: false
-        },
-        additional_properties: []
-      }
-    end
-
-    def main_dwelling_small_mortgage_partly_owned
-      {
-        main_home: {
-          value: 466_993,
-          outstanding_mortgage: 37_256.44,
-          percentage_owned: 66.66,
-          shared_with_housing_assoc: false
-        },
-        additional_properties: []
-      }
-    end
-
-    def main_dwelling_shared_with_housing_association
-      {
-        main_home: {
-          value: 160_000,
-          outstanding_mortgage: 70_000,
-          percentage_owned: 50.0,
-          shared_with_housing_assoc: true
-        },
-        additional_properties: []
-      }
-    end
-
-    def main_dwelling_and_addtional_properties_wholly_owned
-      {
-        main_home: {
-          value: 220_000,
-          outstanding_mortgage: 35_000,
-          percentage_owned: 100.0,
-          shared_with_housing_assoc: false
-        },
-        additional_properties: [
-          {
-            value: 350_000,
-            outstanding_mortgage: 55_000,
-            percentage_owned: 100,
-            shared_with_housing_assoc: false
-          },
-          {
-            value: 270_000,
-            outstanding_mortgage: 40_000,
-            percentage_owned: 100,
-            shared_with_housing_assoc: false
-          }
-        ]
-      }
     end
   end
 end

--- a/spec/services/workflow_service/liquid_capital_assessment_spec.rb
+++ b/spec/services/workflow_service/liquid_capital_assessment_spec.rb
@@ -1,0 +1,58 @@
+require 'rails_helper'
+
+module WorkflowService
+  RSpec.describe LiquidCapitalAssessment do
+    let(:service) { described_class.new(liquid_capital_request) }
+
+    context 'all positive supplied' do
+      let(:liquid_capital_request) { open_structify(all_positive_bank_accounts) }
+      it 'adds them all together' do
+        expect(service.call).to eq 136.87
+      end
+    end
+
+    context 'mixture of positive and negative supplied' do
+      let(:liquid_capital_request) { open_structify(mixture_of_negative_and_positive_bank_accounts) }
+      it 'ignores negative values' do
+        expect(service.call).to eq 35.88
+      end
+    end
+
+    context 'all negative supplied' do
+      let(:liquid_capital_request) { open_structify(all_negative_bank_accounts) }
+      it 'ignores negative values' do
+        expect(service.call).to eq 0.0
+      end
+    end
+
+    def all_positive_bank_accounts
+      {
+        bank_accounts: [
+          { account_name: 'Account 1', lowest_balance: 35.66 },
+          { account_name: 'Account 2', lowest_balance: 100.99 },
+          { account_name: 'Account 3', lowest_balance: 0.22 }
+        ]
+      }
+    end
+
+    def mixture_of_negative_and_positive_bank_accounts
+      {
+        bank_accounts: [
+          { account_name: 'Account 1', lowest_balance: 35.66 },
+          { account_name: 'Account 2', lowest_balance: -100.99 },
+          { account_name: 'Account 3', lowest_balance: 0.22 }
+        ]
+      }
+    end
+
+    def all_negative_bank_accounts
+      {
+        bank_accounts: [
+          { account_name: 'Account 1', lowest_balance: -35.66 },
+          { account_name: 'Account 2', lowest_balance: - 100.99 },
+          { account_name: 'Account 3', lowest_balance: -0.22 }
+        ]
+      }
+    end
+  end
+end

--- a/spec/services/workflow_service/property_assessment_spec.rb
+++ b/spec/services/workflow_service/property_assessment_spec.rb
@@ -117,15 +117,15 @@ module WorkflowService # rubocop:disable Metrics/ModuleLength
             expect(ap2.property_disregard).to eq 0.0
             expect(ap2.assessed_capital_value).to eq 221_900.0
 
-            md = result.main_home
-            expect(md.notional_sale_costs_pctg).to eq 3.0
-            expect(md.net_value_after_deduction).to eq 213_400
-            expect(md.maximum_mortgage_allowance).to eq 5_000.0
-            expect(md.net_value_after_mortgage).to eq 208_400.0
-            expect(md.percentage_owned).to eq 100.0
-            expect(md.net_equity_value).to eq 208_400.0
-            expect(md.property_disregard).to eq 100_000.0
-            expect(md.assessed_capital_value).to eq 108_400.0
+            mh = result.main_home
+            expect(mh.notional_sale_costs_pctg).to eq 3.0
+            expect(mh.net_value_after_deduction).to eq 213_400
+            expect(mh.maximum_mortgage_allowance).to eq 5_000.0
+            expect(mh.net_value_after_mortgage).to eq 208_400.0
+            expect(mh.percentage_owned).to eq 100.0
+            expect(mh.net_equity_value).to eq 208_400.0
+            expect(mh.property_disregard).to eq 100_000.0
+            expect(mh.assessed_capital_value).to eq 108_400.0
           end
         end
       end

--- a/spec/services/workflow_service/property_assessment_spec.rb
+++ b/spec/services/workflow_service/property_assessment_spec.rb
@@ -2,108 +2,102 @@ require 'rails_helper'
 
 module WorkflowService # rubocop:disable Metrics/ModuleLength
   RSpec.describe PropertyAssessment do
-    let(:service) { PropertyAssessment.new(particulars) }
-    let(:request_hash) { AssessmentRequestFixture.ruby_hash }
-    let(:assessment) { create :assessment, request_payload: request_hash.to_json }
-    let(:particulars) { AssessmentParticulars.new(assessment) }
+    let(:today) { Date.today }
+    let(:service) { PropertyAssessment.new(request, today) }
 
     describe '#call' do
-      it 'always returns true' do
-        expect(service.call).to be true
-      end
-
-      context 'main_dwelling_only' do
+      context 'main_home_only' do
         context '100% owned' do
           context 'with mortgage > £100,000' do
+            let(:request) { open_structify(main_home_big_mortgage_wholly_owned) }
             it 'only deducts first 100k of mortgage' do
-              particulars.request.applicant_capital.property = open_structify(main_dwelling_big_mortgage_wholly_owned)
-              expect(service.call).to be true
-              result = particulars.response.details.capital.property.main_dwelling
-              expect(result.notional_sale_costs_pctg).to eq 3.0
-              expect(result.net_value_after_deduction).to eq 452_983.21
-              expect(result.maximum_mortgage_allowance).to eq 100_000.0
-              expect(result.net_value_after_mortgage).to eq 352_983.21
-              expect(result.percentage_owned).to eq 100.0
-              expect(result.net_equity_value).to eq 352_983.21
-              expect(result.property_disregard).to eq 100_000.0
-              expect(result.assessed_capital_value).to eq 252_983.21
+              result = service.call
+              main_home = result.main_home
+              expect(main_home.notional_sale_costs_pctg).to eq 3.0
+              expect(main_home.net_value_after_deduction).to eq 452_983.21
+              expect(main_home.maximum_mortgage_allowance).to eq 100_000.0
+              expect(main_home.net_value_after_mortgage).to eq 352_983.21
+              expect(main_home.percentage_owned).to eq 100.0
+              expect(main_home.net_equity_value).to eq 352_983.21
+              expect(main_home.property_disregard).to eq 100_000.0
+              expect(main_home.assessed_capital_value).to eq 252_983.21
             end
           end
 
           context 'with_mortgage less than 100k' do
+            let(:request) { open_structify(main_home_small_mortgage_wholly_owned) }
             it 'only deducts the actual outstanding amount' do
-              particulars.request.applicant_capital.property = open_structify(main_dwelling_small_mortgage_wholly_owned)
-              expect(service.call).to be true
-              result = particulars.response.details.capital.property.main_dwelling
-              expect(result.notional_sale_costs_pctg).to eq 3.0
-              expect(result.net_value_after_deduction).to eq 452_983.21
-              expect(result.maximum_mortgage_allowance).to eq 37_256.44
-              expect(result.net_value_after_mortgage).to eq 415_726.77
-              expect(result.percentage_owned).to eq 100.0
-              expect(result.net_equity_value).to eq 415_726.77
-              expect(result.property_disregard).to eq 100_000.0
-              expect(result.assessed_capital_value).to eq 315_726.77
+              result = service.call
+              main_home = result.main_home
+              expect(main_home.notional_sale_costs_pctg).to eq 3.0
+              expect(main_home.net_value_after_deduction).to eq 452_983.21
+              expect(main_home.maximum_mortgage_allowance).to eq 37_256.44
+              expect(main_home.net_value_after_mortgage).to eq 415_726.77
+              expect(main_home.percentage_owned).to eq 100.0
+              expect(main_home.net_equity_value).to eq 415_726.77
+              expect(main_home.property_disregard).to eq 100_000.0
+              expect(main_home.assessed_capital_value).to eq 315_726.77
             end
           end
         end
 
         context '66.66% owned' do
           context 'with mortgage > £100,000' do
+            let(:request) { open_structify(main_home_big_mortgage_partly_owned) }
             it 'only deducts first 100k of mortgage' do
-              particulars.request.applicant_capital.property = open_structify(main_dwelling_big_mortgage_partly_owned)
-              expect(service.call).to be true
-              result = particulars.response.details.capital.property.main_dwelling
-              expect(result.notional_sale_costs_pctg).to eq 3.0
-              expect(result.net_value_after_deduction).to eq 452_983.21
-              expect(result.maximum_mortgage_allowance).to eq 100_000.0
-              expect(result.net_value_after_mortgage).to eq 352_983.21
-              expect(result.percentage_owned).to eq 66.66
-              expect(result.net_equity_value).to eq 235_298.61
-              expect(result.property_disregard).to eq 100_000.0
-              expect(result.assessed_capital_value).to eq 135_298.61
+              result = service.call
+              main_home = result.main_home
+              expect(main_home.notional_sale_costs_pctg).to eq 3.0
+              expect(main_home.net_value_after_deduction).to eq 452_983.21
+              expect(main_home.maximum_mortgage_allowance).to eq 100_000.0
+              expect(main_home.net_value_after_mortgage).to eq 352_983.21
+              expect(main_home.percentage_owned).to eq 66.66
+              expect(main_home.net_equity_value).to eq 235_298.61
+              expect(main_home.property_disregard).to eq 100_000.0
+              expect(main_home.assessed_capital_value).to eq 135_298.61
             end
           end
 
           context 'with mortgage < £100,000' do
+            let(:request) { open_structify(main_home_small_mortgage_partly_owned) }
             it 'only deducts the actual outstanding amount' do
-              particulars.request.applicant_capital.property = open_structify(main_dwelling_small_mortgage_partly_owned)
-              expect(service.call).to be true
-              result = particulars.response.details.capital.property.main_dwelling
-              expect(result.notional_sale_costs_pctg).to eq 3.0
-              expect(result.net_value_after_deduction).to eq 452_983.21
-              expect(result.maximum_mortgage_allowance).to eq 37_256.44
-              expect(result.net_value_after_mortgage).to eq 415_726.77
-              expect(result.percentage_owned).to eq 66.66
-              expect(result.net_equity_value).to eq 277_123.46
-              expect(result.property_disregard).to eq 100_000.0
-              expect(result.assessed_capital_value).to eq 177_123.46
+              result = service.call
+              main_home = result.main_home
+              expect(main_home.notional_sale_costs_pctg).to eq 3.0
+              expect(main_home.net_value_after_deduction).to eq 452_983.21
+              expect(main_home.maximum_mortgage_allowance).to eq 37_256.44
+              expect(main_home.net_value_after_mortgage).to eq 415_726.77
+              expect(main_home.percentage_owned).to eq 66.66
+              expect(main_home.net_equity_value).to eq 277_123.46
+              expect(main_home.property_disregard).to eq 100_000.0
+              expect(main_home.assessed_capital_value).to eq 177_123.46
             end
           end
         end
 
         context '50% shared with housing association' do
+          let(:request) { open_structify(main_home_shared_with_housing_association) }
           it 'subtracts outstanding mortgage only from the share owned by applicant' do
-            particulars.request.applicant_capital.property = open_structify(main_dwelling_shared_with_housing_association)
-            expect(service.call).to be true
-            result = particulars.response.details.capital.property.main_dwelling
-            expect(result.notional_sale_costs_pctg).to eq 3.0
-            expect(result.net_value_after_deduction).to eq 155_200.0
-            expect(result.maximum_mortgage_allowance).to eq 70_000.0
-            expect(result.net_value_after_mortgage).to eq 85_200.0
-            expect(result.percentage_owned).to eq 50.0
-            expect(result.net_equity_value).to eq 5_200.0
-            expect(result.property_disregard).to eq 100_000.0
-            expect(result.assessed_capital_value).to eq 0.0
+            result = service.call
+            main_home = result.main_home
+            expect(main_home.notional_sale_costs_pctg).to eq 3.0
+            expect(main_home.net_value_after_deduction).to eq 155_200.0
+            expect(main_home.maximum_mortgage_allowance).to eq 70_000.0
+            expect(main_home.net_value_after_mortgage).to eq 85_200.0
+            expect(main_home.percentage_owned).to eq 50.0
+            expect(main_home.net_equity_value).to eq 5_200.0
+            expect(main_home.property_disregard).to eq 100_000.0
+            expect(main_home.assessed_capital_value).to eq 0.0
           end
         end
       end
 
       context 'additional_properties and main dwelling' do
         context 'main dwelling wholly owned and additional properties wholly owned' do
+          let(:request) { open_structify(main_home_and_addtional_properties_wholly_owned) }
           it 'deducts a maximum of £100k mortgage' do
-            particulars.request.applicant_capital.property = open_structify(main_dwelling_and_addtional_properties_wholly_owned)
-            expect(service.call).to be true
-            ap1 = particulars.response.details.capital.property.additional_properties.first
+            result = service.call
+            ap1 = result.additional_properties.first
             expect(ap1.notional_sale_costs_pctg).to eq 3.0
             expect(ap1.net_value_after_deduction).to eq 339_500.0
             expect(ap1.maximum_mortgage_allowance).to eq 55_000.0
@@ -113,7 +107,7 @@ module WorkflowService # rubocop:disable Metrics/ModuleLength
             expect(ap1.property_disregard).to eq 0.0
             expect(ap1.assessed_capital_value).to eq 284_500.0
 
-            ap2 = particulars.response.details.capital.property.additional_properties[1]
+            ap2 = result.additional_properties[1]
             expect(ap2.notional_sale_costs_pctg).to eq 3.0
             expect(ap2.net_value_after_deduction).to eq 261_900.0
             expect(ap2.maximum_mortgage_allowance).to eq 40_000.0
@@ -123,7 +117,7 @@ module WorkflowService # rubocop:disable Metrics/ModuleLength
             expect(ap2.property_disregard).to eq 0.0
             expect(ap2.assessed_capital_value).to eq 221_900.0
 
-            md = particulars.response.details.capital.property.main_dwelling
+            md = result.main_home
             expect(md.notional_sale_costs_pctg).to eq 3.0
             expect(md.net_value_after_deduction).to eq 213_400
             expect(md.maximum_mortgage_allowance).to eq 5_000.0
@@ -137,7 +131,7 @@ module WorkflowService # rubocop:disable Metrics/ModuleLength
       end
     end
 
-    def main_dwelling_big_mortgage_wholly_owned
+    def main_home_big_mortgage_wholly_owned
       {
         main_home: {
           value: 466_993,
@@ -149,7 +143,7 @@ module WorkflowService # rubocop:disable Metrics/ModuleLength
       }
     end
 
-    def main_dwelling_small_mortgage_wholly_owned
+    def main_home_small_mortgage_wholly_owned
       {
         main_home: {
           value: 466_993,
@@ -161,7 +155,7 @@ module WorkflowService # rubocop:disable Metrics/ModuleLength
       }
     end
 
-    def main_dwelling_big_mortgage_partly_owned
+    def main_home_big_mortgage_partly_owned
       {
         main_home: {
           value: 466_993,
@@ -173,7 +167,7 @@ module WorkflowService # rubocop:disable Metrics/ModuleLength
       }
     end
 
-    def main_dwelling_small_mortgage_partly_owned
+    def main_home_small_mortgage_partly_owned
       {
         main_home: {
           value: 466_993,
@@ -185,7 +179,7 @@ module WorkflowService # rubocop:disable Metrics/ModuleLength
       }
     end
 
-    def main_dwelling_shared_with_housing_association
+    def main_home_shared_with_housing_association
       {
         main_home: {
           value: 160_000,
@@ -197,7 +191,7 @@ module WorkflowService # rubocop:disable Metrics/ModuleLength
       }
     end
 
-    def main_dwelling_and_addtional_properties_wholly_owned
+    def main_home_and_addtional_properties_wholly_owned
       {
         main_home: {
           value: 220_000,

--- a/spec/services/workflow_service/vehicle_assessment_spec.rb
+++ b/spec/services/workflow_service/vehicle_assessment_spec.rb
@@ -2,104 +2,77 @@ require 'rails_helper'
 
 module WorkflowService # rubocop:disable Metrics/ModuleLength
   RSpec.describe VehicleAssessment do
-    let(:service) { VehicleAssessment.new(particulars) }
-    let(:request_hash) { AssessmentRequestFixture.ruby_hash }
-    let(:assessment) { create :assessment, request_payload: request_hash.to_json }
-    let(:particulars) { AssessmentParticulars.new(assessment) }
+    let(:service) { VehicleAssessment.new(request, today) }
+    let(:today) { Date.today }
 
     describe '#call' do
-      it 'always returns true' do
-        expect(service.call).to be true
-      end
-
       context 'vehicle in use' do
         context 'valued less than threshold' do
+          let(:request) { open_structify(in_use_less_than_threshold) }
           it 'is assessed at zero' do
-            request_detail = open_structify(in_use_less_than_threshold)
-            particulars.request.applicant_capital.liquid_capital.vehicles = request_detail
-            expect(service.call).to be true
-            result = particulars.response.details.capital.vehicles.first
-
-            expect(result).to have_matching_attributes(request_detail.first, common_attributes)
-            expect(result.assessed_value).to eq 0.0
+            result = service.call
+            expect(result.first).to have_matching_attributes(request.first, common_attributes)
+            expect(result.first.assessed_value).to eq 0.0
           end
         end
 
         context 'valued at more than threshold' do
           context 'more than 3 years old' do
+            let(:request) { open_structify(in_use_more_than_three_yeas_old) }
             it 'is assessed at zero' do
-              request_detail = open_structify(in_use_more_than_three_yeas_old)
-              particulars.request.applicant_capital.liquid_capital.vehicles = request_detail
-              expect(service.call).to be true
-              result = particulars.response.details.capital.vehicles.first
-
-              expect(result).to have_matching_attributes(request_detail.first, common_attributes)
-              expect(result.assessed_value).to eq 0.0
+              result = service.call
+              expect(result.first).to have_matching_attributes(request.first, common_attributes)
+              expect(result.first.assessed_value).to eq 0.0
             end
           end
 
           context 'less than 1 year old' do
             context 'with an outstanding loan' do
+              let(:request) { open_structify(in_use_less_than_1_year) }
               it 'is assessed at value less loan less threshold' do
-                request_detail = open_structify(in_use_less_than_1_year)
-                particulars.request.applicant_capital.liquid_capital.vehicles = request_detail
-                expect(service.call).to be true
-                result = particulars.response.details.capital.vehicles.first
-
-                expect(result).to have_matching_attributes(request_detail.first, common_attributes)
-                expect(result.assessed_value).to eq 6_450.0
+                result = service.call
+                expect(result.first).to have_matching_attributes(request.first, common_attributes)
+                expect(result.first.assessed_value).to eq 6_450.0
               end
             end
 
             context 'without an outstanding loan' do
+              let(:request) { open_structify(in_use_less_than_1_year_no_loan) }
               it 'is assessed at value less threshold' do
-                request_detail = open_structify(in_use_less_than_1_year_no_loan)
-                particulars.request.applicant_capital.liquid_capital.vehicles = request_detail
-                expect(service.call).to be true
-                result = particulars.response.details.capital.vehicles.first
-
-                expect(result).to have_matching_attributes(request_detail.first, common_attributes)
-                expect(result.assessed_value).to eq 8_700.0
+                result = service.call
+                expect(result.first).to have_matching_attributes(request.first, common_attributes)
+                expect(result.first.assessed_value).to eq 8_700.0
               end
             end
           end
 
           context 'more than 1 year less than 2 years old' do
             context 'with an outstanding loan' do
+              let(:request) { open_structify(in_use_15_months) }
               it 'is assessed at 80% of value less outstanding loan' do
-                request_detail = open_structify(in_use_15_months)
-                particulars.request.applicant_capital.liquid_capital.vehicles = request_detail
-                expect(service.call).to be true
-                result = particulars.response.details.capital.vehicles.first
-
-                expect(result).to have_matching_attributes(request_detail.first, common_attributes)
-                expect(result.assessed_value).to eq 2_160.0
+                result = service.call
+                expect(result.first).to have_matching_attributes(request.first, common_attributes)
+                expect(result.first.assessed_value).to eq 2_160.0
               end
             end
 
             context 'without an oustanding loan' do
+              let(:request) { open_structify(in_use_15_months_no_loan) }
               it 'is assesssed at 80% of value' do
-                request_detail = open_structify(in_use_15_months_no_loan)
-                particulars.request.applicant_capital.liquid_capital.vehicles = request_detail
-                expect(service.call).to be true
-                result = particulars.response.details.capital.vehicles.first
-
-                expect(result).to have_matching_attributes(request_detail.first, common_attributes)
-                expect(result.assessed_value).to eq 3_960.0
+                result = service.call
+                expect(result.first).to have_matching_attributes(request.first, common_attributes)
+                expect(result.first.assessed_value).to eq 3_960.0
               end
             end
           end
 
           context 'more than 2 years less than 3 years old' do
             context 'with an outstanding loan' do
+              let(:request) { open_structify(in_use_26_months) }
               it 'is assessed at 60% of value less outstanding loan' do
-                request_detail = open_structify(in_use_26_months)
-                particulars.request.applicant_capital.liquid_capital.vehicles = request_detail
-                expect(service.call).to be true
-                result = particulars.response.details.capital.vehicles.first
-
-                expect(result).to have_matching_attributes(request_detail.first, common_attributes)
-                expect(result.assessed_value).to eq 0.0
+                result = service.call
+                expect(result.first).to have_matching_attributes(request.first, common_attributes)
+                expect(result.first.assessed_value).to eq 0.0
               end
             end
           end
@@ -107,14 +80,11 @@ module WorkflowService # rubocop:disable Metrics/ModuleLength
       end
 
       context 'vehicle not in regular use' do
+        let(:request) { open_structify(not_in_regular_use) }
         it 'is assessed at full value' do
-          request_detail = open_structify(not_in_regular_use)
-          particulars.request.applicant_capital.liquid_capital.vehicles = request_detail
-          expect(service.call).to be true
-          result = particulars.response.details.capital.vehicles.first
-
-          expect(result).to have_matching_attributes(request_detail.first, common_attributes)
-          expect(result.assessed_value).to eq 23_700.00
+          result = service.call
+          expect(result.first).to have_matching_attributes(request.first, common_attributes)
+          expect(result.first.assessed_value).to eq 23_700.0
         end
       end
 

--- a/spec/services/workflow_service/vehicle_assessment_spec.rb
+++ b/spec/services/workflow_service/vehicle_assessment_spec.rb
@@ -18,7 +18,7 @@ module WorkflowService # rubocop:disable Metrics/ModuleLength
 
         context 'valued at more than threshold' do
           context 'more than 3 years old' do
-            let(:request) { open_structify(in_use_more_than_three_yeas_old) }
+            let(:request) { open_structify(in_use_more_than_three_years_old) }
             it 'is assessed at zero' do
               result = service.call
               expect(result.first).to have_matching_attributes(request.first, common_attributes)
@@ -106,7 +106,7 @@ module WorkflowService # rubocop:disable Metrics/ModuleLength
         ]
       end
 
-      def in_use_more_than_three_yeas_old
+      def in_use_more_than_three_years_old
         [
           {
             value: 18_700,


### PR DESCRIPTION
## Refactor Assessment Services

The`WorkflowService::DisposableCapitalAssessment` service calls other services to work out the assessed value of various categories of capital:

- `LiquidCapitalAssessment`
- `PropertyAssessment`
- `VehicleAssessment`

Previously, it was passing the whole `AssessmentParticulars` object to the sub-services and they were updating that object themselves.  This has the disadvantage that if the structure of the `AssessmentParticulars` object changes (which it will), it means that a lot of classes have to be changed.

This PR changes that behaviour so that just a small relevant section of the structure is passed to the sub service, which returns the result for `DisposableCapitalAssessment` to slot into the right place itself.

## Checklist

Before you ask people to review this PR:

- [ ] Tests and rubocop should be passing: `bundle exec rake`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [ ] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [ ] The PR description should say what you changed and why, with a link to the JIRA story.
- [ ] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
