### PR TITLE
AP-621 (b) non liquid cap, pensioner disregard and populate results in Disposable Capital Assessment

### DIFF
--- a/app/models/assessment_particulars.rb
+++ b/app/models/assessment_particulars.rb
@@ -93,6 +93,7 @@ class AssessmentParticulars
         additional_properties: []
       },
       vehicles: [],
+      non_liquid_capital_assessment: 0.0,
       total_capital_lower_threshold: 0.0,
       total_capital_upper_threshold: 0.0,
       disposable_capital_assessment: 0.0

--- a/app/models/dated_struct.rb
+++ b/app/models/dated_struct.rb
@@ -1,7 +1,11 @@
 class DatedStruct < OpenStruct
   DATE_REGEX = /^([12][9|0][0-9]{2}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01]))$/.freeze
 
-  def initialize(hash = nil)
+  # Initialize with options serialize_as_open_struct: true if you want the #to_json method
+  # to generate an intermediate "table" key, as does OpenStruct
+  #
+  def initialize(hash = nil, options = {})
+    @options = options
     @table = {}
     hash&.each_pair do |k, v|
       k = k.to_sym
@@ -11,6 +15,17 @@ class DatedStruct < OpenStruct
 
   def []=(name, value)
     modifiable?[new_ostruct_member!(name)] = value_or_time(value)
+  end
+
+  # OpenStruct will normally serialize to JSON with an intermediate key 'table'.
+  # DatedStruct will only do it if created with option {serialize_as_open_struct: true}
+  def to_hash
+    if @options[:serialize_as_open_struct]
+      instance_values.except!('options').as_json
+    else
+      to_h
+    end
+    # @options[:serialize_as_open_struct] ? super : to_h
   end
 
   private

--- a/app/models/dated_struct.rb
+++ b/app/models/dated_struct.rb
@@ -25,7 +25,6 @@ class DatedStruct < OpenStruct
     else
       to_h
     end
-    # @options[:serialize_as_open_struct] ? super : to_h
   end
 
   private

--- a/app/services/workflow_service/disposable_capital_assessment.rb
+++ b/app/services/workflow_service/disposable_capital_assessment.rb
@@ -1,9 +1,10 @@
 module WorkflowService
   class DisposableCapitalAssessment < BaseWorkflowService
-    def call
+    def call # rubocop:disable Metrics/AbcSize
       response.details.capital.liquid_capital_assessment = calculate_liquid_capital
       response.details.capital.property = calculate_property
       response.details.capital.vehicles = calculate_vehicles
+      response.details.capital.non_liquid_capital_assessment = calculate_non_liquid_capital
       true
     end
 
@@ -11,6 +12,10 @@ module WorkflowService
 
     def calculate_liquid_capital
       LiquidCapitalAssessment.new(applicant_capital.liquid_capital).call
+    end
+
+    def calculate_non_liquid_capital
+      NonLiquidCapitalAssessment.new(applicant_capital.non_liquid_capital).call
     end
 
     def calculate_property

--- a/app/services/workflow_service/disposable_capital_assessment.rb
+++ b/app/services/workflow_service/disposable_capital_assessment.rb
@@ -31,11 +31,11 @@ module WorkflowService
     end
 
     def sum_assessed_values(capital)
-      capital.liquid_capital_assessment +
+      (capital.liquid_capital_assessment +
         capital.property.main_home.assessed_capital_value +
-        capital.property.additional_properties.sum(&:asssessed_capital_value) +
+        capital.property.additional_properties.sum(&:assessed_capital_value) +
         capital.vehicles.sum(&:assessed_value) +
-        capital.non_liquid_capital_assessment
+        capital.non_liquid_capital_assessment).round(2)
     end
   end
 end

--- a/app/services/workflow_service/disposable_capital_assessment.rb
+++ b/app/services/workflow_service/disposable_capital_assessment.rb
@@ -9,6 +9,8 @@ module WorkflowService
       capital.single_capital_assessment = sum_assessed_values(capital)
       capital.pensioner_disregard = PensionerCapitalDisregard.new(@particulars).value
       capital.disposable_capital_assessment = capital.single_capital_assessment - capital.pensioner_disregard
+      capital.total_capital_lower_threshold = Threshold.value_for(:capital_lower, at: @submission_date)
+      capital.total_capital_upper_threshold = Threshold.value_for(:capital_upper, at: @submission_date)
       true
     end
 

--- a/app/services/workflow_service/non_liquid_capital_assessment.rb
+++ b/app/services/workflow_service/non_liquid_capital_assessment.rb
@@ -1,0 +1,15 @@
+module WorkflowService
+  class NonLiquidCapitalAssessment
+    def initialize(request)
+      @request = request
+    end
+
+    def call
+      total_value = 0.0
+      @request&.each do |item|
+        total_value += item.value
+      end
+      total_value.round(2)
+    end
+  end
+end

--- a/app/services/workflow_service/pensioner_capital_disregard.rb
+++ b/app/services/workflow_service/pensioner_capital_disregard.rb
@@ -11,7 +11,7 @@ module WorkflowService
 
       return passported_value if passported?
 
-      raise "No disposable income specified for non-passported applicant" if disposable_income.nil?
+      raise 'No disposable income specified for non-passported applicant' if disposable_income.nil?
 
       disregard_value(disposable_income)
     end
@@ -52,7 +52,5 @@ module WorkflowService
       threshold = income_vals.keys.select { |k| income >= k }.max
       income_vals[threshold]
     end
-
-
   end
 end

--- a/app/services/workflow_service/pensioner_capital_disregard.rb
+++ b/app/services/workflow_service/pensioner_capital_disregard.rb
@@ -1,0 +1,58 @@
+module WorkflowService
+  class PensionerCapitalDisregard
+    def initialize(particulars)
+      @particulars = particulars
+      @submission_date = @particulars.request.meta_data.submission_date
+      @thresholds = Threshold.value_for(:pensioner_capital_disregard, at: @submission_date)
+    end
+
+    def value
+      return 0 unless pensioner?
+
+      return passported_value if passported?
+
+      raise "No disposable income specified for non-passported applicant" if disposable_income.nil?
+
+      disregard_value(disposable_income)
+    end
+
+    private
+
+    def pensioner?
+      earliest_dob_for_pensioner
+      @submission_date - minimum_pensioner_age.years >= applicant_dob
+    end
+
+    def earliest_dob_for_pensioner
+      @submission_date - minimum_pensioner_age.years
+    end
+
+    def minimum_pensioner_age
+      @thresholds[:minimum_age_in_years]
+    end
+
+    def applicant_dob
+      @particulars.request.applicant.date_of_birth
+    end
+
+    def passported?
+      WorkflowPredicate::DeterminePassported.new(@particulars).call
+    end
+
+    def passported_value
+      @thresholds[:passported]
+    end
+
+    def disposable_income
+      @particulars.response.details.income.monthly_disposable_income
+    end
+
+    def disregard_value(income)
+      income_vals = @thresholds[:monthly_income_values]
+      threshold = income_vals.keys.select { |k| income >= k }.max
+      income_vals[threshold]
+    end
+
+
+  end
+end

--- a/app/services/workflow_service/pensioner_capital_disregard.rb
+++ b/app/services/workflow_service/pensioner_capital_disregard.rb
@@ -19,7 +19,6 @@ module WorkflowService
     private
 
     def pensioner?
-      earliest_dob_for_pensioner
       @submission_date - minimum_pensioner_age.years >= applicant_dob
     end
 

--- a/app/services/workflow_service/pensioner_capital_disregard.rb
+++ b/app/services/workflow_service/pensioner_capital_disregard.rb
@@ -19,7 +19,7 @@ module WorkflowService
     private
 
     def pensioner?
-      @submission_date - minimum_pensioner_age.years >= applicant_dob
+      earliest_dob_for_pensioner >= applicant_dob
     end
 
     def earliest_dob_for_pensioner

--- a/app/services/workflow_service/property_assessment.rb
+++ b/app/services/workflow_service/property_assessment.rb
@@ -47,11 +47,19 @@ module WorkflowService
 
     def net_equity_value(property:, assessment:)
       if property.shared_with_housing_assoc
-        housing_assoc_pctg = 100 - property.percentage_owned
-        assessment.net_value_after_mortgage - (property.value * housing_assoc_pctg / 100).round(2)
+        net_equity_from_housing_asoc(property: property, assessment: assessment)
       else
-        (assessment.net_value_after_mortgage * (assessment.percentage_owned / 100)).round(2)
+        net_equity_from_co_owner(assessment: assessment)
       end
+    end
+
+    def net_equity_from_housing_asoc(property:, assessment:)
+      housing_assoc_pctg = 100 - property.percentage_owned
+      assessment.net_value_after_mortgage - (property.value * housing_assoc_pctg.to_f / 100.0).round(2)
+    end
+
+    def net_equity_from_co_owner(assessment:)
+      (assessment.net_value_after_mortgage * (assessment.percentage_owned.to_f / 100.0)).round(2)
     end
 
     def assessed_capital_value(assessment:)

--- a/config/thresholds/8-Apr-2018.yml
+++ b/config/thresholds/8-Apr-2018.yml
@@ -11,7 +11,7 @@ capital_upper: 8_000
 pensioner_capital_disregard:
   minimum_age_in_years: 60
   passported: 100_000
-    # disregard to use if monthly disposable income (excluding income derived from capital) is eqqual to or below these figures
+  # capital to disregard if monthly disposable income (excluding income derived from capital) is below these figures
   monthly_income_values:
     0: 100_000
     25.01: 90_000

--- a/config/thresholds/8-Apr-2018.yml
+++ b/config/thresholds/8-Apr-2018.yml
@@ -6,8 +6,8 @@ gross_income_upper:
     many: 7
 disposable_income_lower: 1000
 disposable_income_upper: 10000
-capital_lower: 10
-capital_upper: 10000
+capital_lower: 3_000
+capital_upper: 8_000
 pensioner_capital_disregard:
   minimum_age_in_years: 60
   passported: 100_000

--- a/config/thresholds/8-Apr-2018.yml
+++ b/config/thresholds/8-Apr-2018.yml
@@ -8,6 +8,23 @@ disposable_income_lower: 1000
 disposable_income_upper: 10000
 capital_lower: 10
 capital_upper: 10000
+pensioner_capital_disregard:
+  minimum_age_in_years: 60
+  passported: 100_000
+    # disregard to use if monthly disposable income (excluding income derived from capital) is eqqual to or below these figures
+  monthly_income_values:
+    0: 100_000
+    25.01: 90_000
+    50.01: 80_000
+    75.01: 70_000
+    100.01: 60_000
+    125.01: 50_000
+    150.01: 40_000
+    175.01: 30_000
+    200.01: 20_000
+    225.01: 10_000
+    315.01: 0
+
 property_notional_sale_costs_percentage: 3.0
 property_maximum_mortgage_allowance: 100_000
 property_disregard:

--- a/config/thresholds/8-Apr-2019.yml
+++ b/config/thresholds/8-Apr-2019.yml
@@ -9,6 +9,21 @@ disposable_income_lower: 100
 disposable_income_upper: 50000
 capital_lower: 1
 capital_upper: 30000
+pensioner_capital_disregard:
+  passported: 100_000
+  # disregard to use if monthly disposable income (excluding income derived from capital) is eqqual to or below these figures
+  monthly_income_values:
+    0: 100_000
+    25.01: 90_000
+    50.01: 80_000
+    75.01: 70_000
+    100.01: 60_000
+    125.01: 50_000
+    150.01: 40_000
+    175.01: 30_000
+    200.01: 20_000
+    225.01: 10_000
+    315.01: 0
 property_notional_sale_costs_percentage: 3.0
 property_maximum_mortgage_allowance: 100_000
 property_disregard:

--- a/config/thresholds/8-Apr-2019.yml
+++ b/config/thresholds/8-Apr-2019.yml
@@ -11,7 +11,7 @@ capital_lower: 1
 capital_upper: 30000
 pensioner_capital_disregard:
   passported: 100_000
-  # disregard to use if monthly disposable income (excluding income derived from capital) is eqqual to or below these figures
+  # capital to disregard if monthly disposable income (excluding income derived from capital) is below these figures
   monthly_income_values:
     0: 100_000
     25.01: 90_000

--- a/config/thresholds/8-Apr-2020.yml
+++ b/config/thresholds/8-Apr-2020.yml
@@ -7,6 +7,21 @@ disposable_income_lower: 2000
 disposable_income_upper: 20000
 capital_lower: 5
 capital_upper: 20000
+pensioner_capital_disregard:
+  passported: 100_000
+  # disregard to use if monthly disposable income (excluding income derived from capital) is eqqual to or below these figures
+  monthly_income_values:
+    0: 100_000
+    25.01: 90_000
+    50.01: 80_000
+    75.01: 70_000
+    100.01: 60_000
+    125.01: 50_000
+    150.01: 40_000
+    175.01: 30_000
+    200.01: 20_000
+    225.01: 10_000
+    315.01: 0
 property_notional_sale_costs_percentage: 3.0
 property_maximum_mortgage_allowance: 100_000
 property_disregard:

--- a/config/thresholds/8-Apr-2020.yml
+++ b/config/thresholds/8-Apr-2020.yml
@@ -9,7 +9,7 @@ capital_lower: 5
 capital_upper: 20000
 pensioner_capital_disregard:
   passported: 100_000
-  # disregard to use if monthly disposable income (excluding income derived from capital) is eqqual to or below these figures
+  # capital to disregard if monthly disposable income (excluding income derived from capital) is below these figures
   monthly_income_values:
     0: 100_000
     25.01: 90_000

--- a/public/schemas/assessment_request.json
+++ b/public/schemas/assessment_request.json
@@ -274,17 +274,11 @@
       }
     },
     "applicant_liquid_capital": {
-      "description": "Describes valuable items, residual balances in bank accounts and vehicles",
+      "description": "Describes residual balances in bank accounts and vehicles",
       "type": "object",
       "additionalProperties": false,
       "required": ["bank_accounts"],
       "properties": {
-        "valuable_items": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/capital_item"
-          }
-        },
         "bank_accounts": {
           "type": "array",
           "minItems": 1,
@@ -412,7 +406,7 @@
           "$ref": "#/definitions/applicant_liquid_capital"
         },
         "non_liquid_capital": {
-          "description": "An array of objects describing applicant's non-liquid capital items (excluding property)",
+          "description": "An array of objects describing applicant's non-liquid capital items (excluding property), e.g. valuable items, jewellery, trusts, other investments",
           "type": "array",
           "items": {
             "$ref": "#/definitions/capital_item"

--- a/public/schemas/assessment_response.json
+++ b/public/schemas/assessment_response.json
@@ -76,7 +76,7 @@
           "$ref": "http://localhost:3000/schemas/assessment_request.json#definitions/positive_number_with_two_decimals"
         },
         "non_liquid_capital_assessment": {
-          "description": "Aggregate value of all non-liquid capital itesm excluding property and vehicles, e.g. stocks and shares, valuable items, jewellery",
+          "description": "Aggregate value of all non-liquid capital items excluding property and vehicles, e.g. stocks and shares, valuable items, jewellery",
           "$ref": "http://localhost:3000/schemas/assessment_request.json#definitions/positive_number_with_two_decimals"
         },
         "property": {

--- a/public/schemas/assessment_response.json
+++ b/public/schemas/assessment_response.json
@@ -63,6 +63,8 @@
         "non_liquid_capital_assessment",
         "vehicles",
         "property",
+        "single_capital_assessment",
+        "pensioner_disregard",
         "total_capital_lower_threshold",
         "total_capital_upper_threshold",
         "disposable_capital_assessment"
@@ -86,6 +88,14 @@
           "items": {
             "$ref": "#/definitions/vehicle_detail"
           }
+        },
+        "single_capital_assessment": {
+          "description": "The sum of all capital assets before any disregards are applied",
+          "$ref": "http://localhost:3000/schemas/assessment_request.json#definitions/positive_number_with_two_decimals"
+        },
+        "pensioner_disregard": {
+          "description": "The capital that will be disregarded for over-60s before comparison with the capital thresholds",
+          "$ref": "http://localhost:3000/schemas/assessment_request.json#definitions/positive_number_with_two_decimals"
         },
         "disposable_capital_assessment": {
           "description": "The applicant's disposable capital calculated after subtracting allowable items from the list of capital assets given",

--- a/public/schemas/assessment_response.json
+++ b/public/schemas/assessment_response.json
@@ -60,6 +60,7 @@
       "type": "object",
       "required": [
         "liquid_capital_assessment",
+        "non_liquid_capital_assessment",
         "vehicles",
         "property",
         "total_capital_lower_threshold",
@@ -70,6 +71,10 @@
       "properties": {
         "liquid_capital_assessment": {
           "description": "Aggregate value of lowest balances of bank accounts during the calculation period",
+          "$ref": "http://localhost:3000/schemas/assessment_request.json#definitions/positive_number_with_two_decimals"
+        },
+        "non_liquid_capital_assessment": {
+          "description": "Aggregate value of all non-liquid capital itesm excluding property and vehicles, e.g. stocks and shares, valuable items, jewellery",
           "$ref": "http://localhost:3000/schemas/assessment_request.json#definitions/positive_number_with_two_decimals"
         },
         "property": {

--- a/spec/fixtures/assessment_request_fixture.rb
+++ b/spec/fixtures/assessment_request_fixture.rb
@@ -113,12 +113,6 @@ class AssessmentRequestFixture < BaseAssessmentFixture # rubocop:disable Metrics
               account_name: 'Account #2',
               lowest_balance: 256.44
             }
-          ],
-          valuable_items: [
-            {
-              item_description: 'jewellery',
-              value: 34_000
-            }
           ]
         },
         non_liquid_capital: [
@@ -129,6 +123,10 @@ class AssessmentRequestFixture < BaseAssessmentFixture # rubocop:disable Metrics
           {
             item_description: 'trust fund',
             value: 34_000
+          },
+          {
+            item_description: 'jewllery',
+            value: 2_225
           }
         ]
       }

--- a/spec/fixtures/assessment_response_fixture.rb
+++ b/spec/fixtures/assessment_response_fixture.rb
@@ -69,6 +69,7 @@ class AssessmentResponseFixture < BaseAssessmentFixture
               assessed_value: 0
             }
           ],
+          non_liquid_capital_assessment: 3664.0,
           total_capital_lower_threshold: 3_000.00,
           total_capital_upper_threshold: 8_000.00,
           disposable_capital_assessment: 100.00

--- a/spec/fixtures/assessment_response_fixture.rb
+++ b/spec/fixtures/assessment_response_fixture.rb
@@ -1,10 +1,10 @@
-class x. < BaseAssessmentFixture
+class AssessmentResponseFixture < BaseAssessmentFixture
   def self.ruby_hash
     {
       assessment_id: 'e34ce98e-8cfa-4a41-a011-7a15a6724b82',
       client_reference_id: 'client-ref-1',
       result: 'eligible',
-      details: {x.deta
+      details: {
         passported: true,
         self_employed: false,
         income: {
@@ -16,6 +16,7 @@ class x. < BaseAssessmentFixture
         },
         capital: {
           liquid_capital_assessment: 45.00,
+          non_liquid_capital_assessment: 3_664.0,
           property: {
             main_home: {
               notional_sale_costs_pctg: 3.0,
@@ -69,13 +70,11 @@ class x. < BaseAssessmentFixture
               assessed_value: 0
             }
           ],
-          non_liquid_capital_assessment: 3664.0,
           single_capital_assessment: 75_000.0,
           pensioner_disregard: 100_000.0,
           disposable_capital_assessment: 25_000,
           total_capital_lower_threshold: 3_000.00,
-          total_capital_upper_threshold: 8_000.00,
-
+          total_capital_upper_threshold: 8_000.00
         },
         contributions: {
           monthly_contribution: 0.00,

--- a/spec/fixtures/assessment_response_fixture.rb
+++ b/spec/fixtures/assessment_response_fixture.rb
@@ -72,9 +72,9 @@ class AssessmentResponseFixture < BaseAssessmentFixture
           ],
           single_capital_assessment: 75_000.0,
           pensioner_disregard: 100_000.0,
-          disposable_capital_assessment: 25_000,
-          total_capital_lower_threshold: 3_000.00,
-          total_capital_upper_threshold: 8_000.00
+          disposable_capital_assessment: 25_000.0,
+          total_capital_lower_threshold: 3_000.0,
+          total_capital_upper_threshold: 8_000.0
         },
         contributions: {
           monthly_contribution: 0.00,

--- a/spec/fixtures/assessment_response_fixture.rb
+++ b/spec/fixtures/assessment_response_fixture.rb
@@ -1,10 +1,10 @@
-class AssessmentResponseFixture < BaseAssessmentFixture
+class x. < BaseAssessmentFixture
   def self.ruby_hash
     {
       assessment_id: 'e34ce98e-8cfa-4a41-a011-7a15a6724b82',
       client_reference_id: 'client-ref-1',
       result: 'eligible',
-      details: {
+      details: {x.deta
         passported: true,
         self_employed: false,
         income: {
@@ -70,9 +70,12 @@ class AssessmentResponseFixture < BaseAssessmentFixture
             }
           ],
           non_liquid_capital_assessment: 3664.0,
+          single_capital_assessment: 75_000.0,
+          pensioner_disregard: 100_000.0,
+          disposable_capital_assessment: 25_000,
           total_capital_lower_threshold: 3_000.00,
           total_capital_upper_threshold: 8_000.00,
-          disposable_capital_assessment: 100.00
+
         },
         contributions: {
           monthly_contribution: 0.00,

--- a/spec/models/dated_struct_spec.rb
+++ b/spec/models/dated_struct_spec.rb
@@ -1,0 +1,38 @@
+require 'rails_helper'
+
+RSpec.describe DatedStruct do
+  subject { DatedStruct.new(dob: '1918-07-12', name: 'John', nationality: 'UK') }
+
+  describe '.new' do
+    it 'creates an OpensStruct-like structure' do
+      expect(subject.name).to eq 'John'
+      expect(subject.nationality).to eq 'UK'
+    end
+
+    it 'converts date strings into Date objects' do
+      expect(subject.dob).to be_instance_of(Date)
+      expect(subject.dob).to eq Date.new(1918, 7, 12)
+    end
+  end
+
+  describe '#to_h' do
+    it 'converts back to hash with symobolized keys' do
+      expect(subject.to_h).to eq(dob: Date.new(1918, 7, 12), name: 'John', nationality: 'UK')
+    end
+  end
+
+  describe '#to_json' do
+    context 'without serialized as open struct option' do
+      it 'converts back to json string' do
+        expect(subject.to_json).to eq %({"dob":"1918-07-12","name":"John","nationality":"UK"})
+      end
+    end
+
+    context 'with serialized as open struct option' do
+      it 'converts back to json string with intermediate table key' do
+        ds = DatedStruct.new({ dob: '1918-07-12', name: 'John', nationality: 'UK' }, serialize_as_open_struct: true)
+        expect(ds.to_json(serialize_as_open_struct: true)).to eq %({"table":{"dob":"1918-07-12","name":"John","nationality":"UK"}})
+      end
+    end
+  end
+end

--- a/spec/services/json_schema_validator_spec.rb
+++ b/spec/services/json_schema_validator_spec.rb
@@ -592,48 +592,6 @@ describe JsonSchemaValidator do
             end
           end
         end
-
-        context 'valuable_items' do
-          context 'it is not present' do
-            before do
-              assessment_hash[:applicant_capital][:liquid_capital].delete(:valuable_items)
-            end
-
-            it 'is valid' do
-              expect(validator).to be_valid
-            end
-          end
-
-          context 'it has an extra attribute' do
-            before do
-              assessment_hash[:applicant_capital][:liquid_capital][:valuable_items].first[:name] = 'Michael'
-            end
-
-            it 'is invalid' do
-              expect(validator).not_to be_valid
-            end
-
-            it 'has an error message' do
-              expected_error = "The property '#/applicant_capital/liquid_capital/valuable_items/0' contains additional properties .*name"
-              expect(validator.errors.first).to match(/#{expected_error}/)
-            end
-          end
-
-          context 'it has a missing attribute' do
-            before do
-              assessment_hash[:applicant_capital][:liquid_capital][:valuable_items].first.delete(:value)
-            end
-
-            it 'is invalid' do
-              expect(validator).not_to be_valid
-            end
-
-            it 'has an error message' do
-              expected_error = "The property '#/applicant_capital/liquid_capital/valuable_items/0' did not contain a required property of 'value'"
-              expect(validator.errors.first).to match(/#{expected_error}/)
-            end
-          end
-        end
       end
 
       context 'non_liquid_capital' do
@@ -646,6 +604,7 @@ describe JsonSchemaValidator do
             expect(validator).to be_valid
           end
         end
+
         context 'it has an extra attribute' do
           before do
             assessment_hash[:applicant_capital][:non_liquid_capital].first[:name] = 'Michael'

--- a/spec/services/workflow_service/disposable_capital_assessment_spec.rb
+++ b/spec/services/workflow_service/disposable_capital_assessment_spec.rb
@@ -30,10 +30,9 @@ module WorkflowService
           property_service = double PropertyAssessment
           property_details = particulars.request.applicant_capital.property
           expect(PropertyAssessment).to receive(:new).with(property_details, today).and_return(property_service)
-          expect(property_service).to receive(:call).and_return('Property Result')
-
+          expect(property_service).to receive(:call).and_return(property_assessment_result)
           service.call
-          expect(particulars.response.details.capital.property).to eq 'Property Result'
+          expect(particulars.response.details.capital.property).to eq property_assessment_result
         end
       end
 
@@ -59,6 +58,10 @@ module WorkflowService
           service.call
         end
       end
+    end
+
+    def property_assessment_result
+      @property_assessment_result ||= JSON.parse(AssessmentResponseFixture.ruby_hash[:details][:capital][:property].to_json, object_class: DatedStruct)
     end
   end
 end

--- a/spec/services/workflow_service/disposable_capital_assessment_spec.rb
+++ b/spec/services/workflow_service/disposable_capital_assessment_spec.rb
@@ -47,6 +47,18 @@ module WorkflowService
           expect(particulars.response.details.capital.vehicles).to eq 'Vehicle Result'
         end
       end
+
+      context 'non_liquid_capital_assessment' do
+        it 'instantiates and calls NonLiquidCapitalAssessment' do
+          nlcas = double NonLiquidCapitalAssessment
+          expect(NonLiquidCapitalAssessment).to receive(:new)
+            .with(particulars.request.applicant_capital.non_liquid_capital)
+            .and_return(nlcas)
+          expect(nlcas).to receive(:call).and_return(26_733.77)
+          expect(particulars.response.details.capital).to receive(:non_liquid_capital_assessment=).with(26_733.77)
+          service.call
+        end
+      end
     end
   end
 end

--- a/spec/services/workflow_service/non_liquid_capital_assessment_spec.rb
+++ b/spec/services/workflow_service/non_liquid_capital_assessment_spec.rb
@@ -1,0 +1,45 @@
+require 'rails_helper'
+
+module WorkflowService
+  RSpec.describe NonLiquidCapitalAssessment do
+    let(:service) { described_class.new(non_liquid_capital_request) }
+
+    context 'all positive supplied' do
+      let(:non_liquid_capital_request) { open_structify(non_liquid_capital) }
+      it 'adds them all together' do
+        expect(service.call).to eq 179_664.44
+      end
+    end
+
+    context 'empty array supplied' do
+      let(:non_liquid_capital_request) { open_structify([]) }
+      it 'returns zero' do
+        expect(service.call).to eq 0.0
+      end
+    end
+
+    context 'nil supplied' do
+      let(:non_liquid_capital_request) { open_structify(nil) }
+      it 'returns zero' do
+        expect(service.call).to eq 0.0
+      end
+    end
+
+    def non_liquid_capital
+      [
+        {
+          item_description: 'trust_fund',
+          value: 100_000.0
+        },
+        {
+          item_description: 'Ming Vase',
+          value: 30_000
+        },
+        {
+          item_description: 'Portfolie of stocks and shares',
+          value: 49_664.44
+        }
+      ]
+    end
+  end
+end

--- a/spec/services/workflow_service/pensioner_capital_disregard_spec.rb
+++ b/spec/services/workflow_service/pensioner_capital_disregard_spec.rb
@@ -1,0 +1,91 @@
+require 'rails_helper'
+
+module WorkflowService
+  RSpec.describe PensionerCapitalDisregard do
+    let(:service) { described_class.new(particulars) }
+    let(:request_hash) { AssessmentRequestFixture.ruby_hash }
+    let(:assessment) { create :assessment, request_payload: request_hash.to_json }
+    let(:particulars) { AssessmentParticulars.new(assessment) }
+
+    describe '#value' do
+      context 'not a pensioner' do
+        before do
+          particulars.request.applicant.date_of_birth = 59.years.ago.to_date
+        end
+        it 'returns zero' do
+         expect(service.value).to eq 0.0
+        end
+      end
+
+      context 'a pensioner' do
+        context 'passported' do
+          before do
+            particulars.request.applicant.receives_qualifying_benefit = true
+          end
+          it 'returns the passported value' do
+            expect(service.value).to eq 100_000.0
+          end
+        end
+
+        context 'un-passported' do
+          before do
+            particulars.request.applicant.receives_qualifying_benefit = false
+          end
+
+          context 'monthly income above 315' do
+            before do
+              particulars.response.details.income.monthly_disposable_income = 315.01
+            end
+            it 'returns zero' do
+              expect(service.value).to eq 0
+            end
+          end
+
+          context 'monthly income 315' do
+            before do
+              particulars.response.details.income.monthly_disposable_income = 315.0
+            end
+            it 'returns 10_000' do
+              expect(service.value).to eq 10_000
+            end
+          end
+
+          context 'monthly_income 314.99' do
+            before do
+              particulars.response.details.income.monthly_disposable_income = 314.99
+            end
+            it 'returns 20_000' do
+              expect(service.value).to eq 10_000
+            end
+          end
+
+          context 'monthly_income 52' do
+            before do
+              particulars.response.details.income.monthly_disposable_income = 52
+            end
+            it 'returns 80_000' do
+              expect(service.value).to eq 80_000
+            end
+          end
+
+          context 'monthly_income 0' do
+            it 'returns 100_000' do
+              expect(service.value).to eq 100_000
+            end
+          end
+
+          context 'monthly income not set' do
+            before do
+              particulars.response.details.income.delete_field(:monthly_disposable_income)
+            end
+            it 'raises' do
+              expect {
+                service.value
+              }.to raise_error RuntimeError, 'No disposable income specified for non-passported applicant'
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/services/workflow_service/pensioner_capital_disregard_spec.rb
+++ b/spec/services/workflow_service/pensioner_capital_disregard_spec.rb
@@ -13,7 +13,7 @@ module WorkflowService
           particulars.request.applicant.date_of_birth = 59.years.ago.to_date
         end
         it 'returns zero' do
-         expect(service.value).to eq 0.0
+          expect(service.value).to eq 0.0
         end
       end
 


### PR DESCRIPTION
## Finalise Disposable Capital Asssessment service

[Link to story](https://dsdmoj.atlassian.net/browse/AP-621)

- Changed DatedStruct to output JSON without the intermediary `table:` key that is output by its parent `OpenStruct`
- Added the `NonLiquidCapitalAssessment` service
- Added the pensioner disregard values to the thresholds config files
- Added the `PensionerCapitalDisregard` service
- Added code to the `DisposableCapitalAssessment` service to add up the populate the results and thresholds in the response structure

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
