### PR TITLE
AP-544 Add open api doc compatible with Swagger editor

### DIFF
--- a/public/schemas/open_api_doc.yaml
+++ b/public/schemas/open_api_doc.yaml
@@ -1,0 +1,511 @@
+swagger: "2.0"
+info:
+  description: "This is a [Ministry of Justice](https://www.gov.uk/government/organisations/ministry-of-justice) API for checking financial eligibility."
+  version: "1.0.0"
+  title: "Check Financial Eligibility"
+  termsOfService: "http://swagger.io/terms/"
+  contact:
+    email: "apiteam@swagger.io"
+  license:
+    name: "Apache 2.0"
+    url: "http://www.apache.org/licenses/LICENSE-2.0.html"
+host: "petstore.swagger.io"
+basePath: "/v1"
+schemes:
+- "https"
+paths:
+  /assessments:
+    post:
+      tags:
+      - "assessment"
+      summary: "Create an accessment"
+      operationId: "createAssessment"
+      consumes:
+      - "application/json"
+      produces:
+      - "application/json"
+      parameters:
+      - in: "body"
+        name: "body"
+        description: "Data required to make assessment"
+        required: true
+        schema:
+          $ref: "#/definitions/request_data"
+      responses:
+        200:
+          $ref: "#/definitions/response_data"
+        405:
+          description: "Invalid input"
+definitions:
+  assessment_result:
+    type: string
+    enum:
+    - eligible
+    - not_eligible
+    - contribution_required
+    - out_of_scope
+    - invalid_request
+  uuid:
+    description: Unique universal identifier
+    type: string
+    pattern: "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
+  date:
+    description: Date in format YYYY-MM-DD in range 1900-01-01 to 2999-12-31
+    type: string
+    pattern: "^([12][9|0][0-9]{2}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01]))$"
+  matter_proceeding_type:
+    description: The matter proceeding type
+    type: string
+    enum:
+    - domestic_abuse
+  applicant_involvement_type:
+    description: The type of involvement of the applicant in the case.
+    type: string
+    enum:
+    - applicant
+    - defendant
+  positive_number_with_two_decimals:
+    description: Non-negative number (including zero) with two decimal places
+    type: number
+    multipleOf: 0.01
+    minimum: 0
+  neg_or_pos_number_with_two_decimals:
+    description: A negative or positive number (including zero) with two decimal places
+    type: number
+    multipleOf: 0.01
+  benefit_name:
+    description: Name of benefit received - must be one of the values listed in the
+      enum below
+    type: string
+    enum:
+    - child_allowance
+    - jobseekers_allowance
+  dependant:
+    type: object
+    required:
+    - date_of_birth
+    - in_full_time_education
+    additionalProperties: false
+    properties:
+      date_of_birth:
+        description: Date of birth of the dependant
+        "$ref": "#/definitions/date"
+      in_full_time_education:
+        description: Whether or not the dependant is in full time education
+        type: boolean
+      income:
+        description: Optional array of income objects defining the income the dependant
+          received during the calculation period
+        type: array
+        items:
+          "$ref": "#/definitions/dependant_income"
+  dependant_income:
+    type: object
+    required:
+    - date_of_payment
+    - amount
+    properties:
+      date_of_payment:
+        description: the date upon which the dependant received this income
+        "$ref": "#/definitions/date"
+      amount:
+        "$ref": "#/definitions/positive_number_with_two_decimals"
+  applicant_wage_slip:
+    type: object
+    required:
+    - date
+    - gross_pay
+    - paye
+    - national_insurance_contribution
+    additionalProperties: false
+    properties:
+      date:
+        "$ref": "#/definitions/date"
+      gross_pay:
+        "$ref": "#/definitions/positive_number_with_two_decimals"
+      paye:
+        "$ref": "#/definitions/positive_number_with_two_decimals"
+      national_insurance_contribution:
+        "$ref": "#/definitions/positive_number_with_two_decimals"
+  applicant_benefit_payment:
+    type: object
+    required:
+    - benefit_name
+    - payment_date
+    - amount
+    additionalProperties: false
+    properties:
+      benefit_name:
+        "$ref": "#/definitions/benefit_name"
+      payment_date:
+        "$ref": "#/definitions/date"
+      amount:
+        "$ref": "#/definitions/positive_number_with_two_decimals"
+  applicant_outgoing:
+    description: Describes an allowable outgoing during the calculation period
+    required:
+    - type_of_outgoing
+    - payment_date
+    - amount
+    additionalProperties: false
+    properties:
+      type_of_outgoing:
+        description: The type of allowable outgoing - must be one of the values listed
+          below
+        type: string
+        enum:
+        - mortgage
+        - maintenance
+      payment_date:
+        description: The date the payment was made
+        "$ref": "#/definitions/date"
+      amount:
+        description: the amount paid in pounds and pence, e.g. 45.22
+        "$ref": "#/definitions/positive_number_with_two_decimals"
+  percentage_with_two_decimals:
+    description: Percentage in range 0.01 - 100.00
+    type: number
+    multipleOf: 0.01
+    minimum: 0.01
+    maximum: 100
+  property_details:
+    description: Defines value and ownership of the main dwelling or other property
+    type: object
+    required:
+    - value
+    - outstanding_mortgage
+    - percentage_owned
+    - shared_with_housing_assoc
+    additionalProperties: false
+    properties:
+      value:
+        description: The current value of the property
+        "$ref": "#/definitions/positive_number_with_two_decimals"
+      outstanding_mortgage:
+        description: The value of the outstanding mortgage
+        "$ref": "#/definitions/positive_number_with_two_decimals"
+      percentage_owned:
+        description: The percentage owned, e.g. '33.33' or '100'
+        "$ref": "#/definitions/percentage_with_two_decimals"
+      shared_with_housing_assoc:
+        description: Defines whether the property is in shared ownership with Local
+          Authority or Housing Association
+        type: boolean
+  applicant_property:
+    description: Describes the applicant's main home and additional properties
+    type: object
+    additionalProperties: false
+    properties:
+      main_home:
+        "$ref": "#/definitions/property_details"
+      additional_properties:
+        description: An array of property descriptions for any additional properties
+        type: array
+        items:
+          "$ref": "#/definitions/property_details"
+  capital_item:
+    description: Definition of a liquid or non-liquid capital item
+    type: object
+    required:
+    - item_description
+    - value
+    additionalProperties: false
+    properties:
+      item_description:
+        type: string
+      value:
+        "$ref": "#/definitions/positive_number_with_two_decimals"
+  applicant_vehicle:
+    description: Details of an individual vehicle
+    required:
+    - value
+    - loan_amount_outstanding
+    - date_of_purchase
+    - in_regular_use
+    additionalProperties: false
+    properties:
+      value:
+        "$ref": "#/definitions/positive_number_with_two_decimals"
+      loan_amount_outstanding:
+        "$ref": "#/definitions/positive_number_with_two_decimals"
+      date_of_purchase:
+        description: The date the vehicle was purchased
+        "$ref": "#/definitions/date"
+      in_regular_use:
+        description: Whether or not the vehicle is in regular use by the applicant
+          or their partner
+        type: boolean
+  bank_accounts:
+    description: Describes the name of the bank account and the lowest balance during
+      the computation period
+    type: object
+    additionalProperties: false
+    required:
+    - account_name
+    - lowest_balance
+    properties:
+      account_name:
+        description: The name of the bank account
+        type: string
+      lowest_balance:
+        description: The lowest balance on the account during the caluclation period
+        "$ref": "#/definitions/neg_or_pos_number_with_two_decimals"
+  applicant_liquid_capital:
+    description: Describes residual balances in bank accounts and vehicles
+    type: object
+    additionalProperties: false
+    required:
+    - bank_accounts
+    properties:
+      bank_accounts:
+        type: array
+        minItems: 1
+        items:
+          "$ref": "#/definitions/bank_accounts"
+  request_data:
+    description: Request Data
+    type: object
+    properties:
+      client_reference_id:
+        description: optional reference id by which the client can identify this request.  This
+          value, if present, will be included in  the response along with a unique id
+          generated by the Check Financial Eligibility service
+        type: string
+      submission_date:
+        "$ref": "#/definitions/date"
+      meta_data:
+        type: object
+        required:
+        - submission_date
+        - matter_proceeding_type
+        additionalProperties: false
+        properties:
+          submission_date:
+            "$ref": "#/definitions/date"
+          matter_proceeding_type:
+            "$ref": "#/definitions/matter_proceeding_type"
+      applicant:
+        type: object
+        required:
+        - date_of_birth
+        - involvement_type
+        - has_partner_opponent
+        - receives_qualifying_benefit
+        - dependants
+        additionalProperties: false
+        properties:
+          date_of_birth:
+            "$ref": "#/definitions/date"
+          involvement_type:
+            "$ref": "#/definitions/applicant_involvement_type"
+          has_partner_opponent:
+            type: boolean
+            description: Whether or not the partner of the applicant is an opponent in
+              the case
+          receives_qualifying_benefit:
+            type: boolean
+            description: Whether or not the applicant recieves a qualifying DWP benefit
+          dependants:
+            type: array
+            items:
+              "$ref": "#/definitions/dependant"
+      applicant_income:
+        description: 'Describes applicant income.  Comprises of two options objects: wage_slips
+          and benefits'
+        type: object
+        properties:
+          wage_slips:
+            description: Optional. An array of items describing each instance of employment
+              income, tax and NI received during the calculation period
+            type: array
+            items:
+              "$ref": "#/definitions/applicant_wage_slip"
+          benefits:
+            description: Optional. An array of items describing each benefit payment received
+              during the calculation period
+            type: array
+            items:
+              "$ref": "#/definitions/applicant_benefit_payment"
+      applicant_outgoings:
+        description: An array of objects describing the type of allowable outgoings
+        type: array
+        minItems: 1
+        items:
+          "$ref": "#/definitions/applicant_outgoing"
+      applicant_capital:
+        description: Describes the property and capital of the applicant
+        additionalProperties: false
+        required:
+        - liquid_capital
+        properties:
+          property:
+            "$ref": "#/definitions/applicant_property"
+          vehicles:
+            type: array
+            items:
+              "$ref": "#/definitions/applicant_vehicle"
+          liquid_capital:
+            "$ref": "#/definitions/applicant_liquid_capital"
+          non_liquid_capital:
+            description: An array of objects describing applicant's non-liquid capital
+              items (excluding property), e.g. valuable items, jewellery, trusts, other
+              investments
+            type: array
+            items:
+              "$ref": "#/definitions/capital_item"
+  income_details:
+      type: object
+      required:
+      - monthly_gross_income
+      - upper_income_threshold
+      - monthly_disposable_income
+      - disposable_income_lower_threshold
+      - disposable_income_upper_threshold
+      additionalProperties: false
+      properties:
+        monthly_gross_income:
+          description: The monthly gross income calculated from the individual income
+            values given
+          "$ref": "#/definitions/positive_number_with_two_decimals"
+        upper_income_threshold:
+          description: The upper income threshold that was used (valies according to
+            the circumstances of the applicant)
+          "$ref": "#/definitions/positive_number_with_two_decimals"
+        monthly_disposable_income:
+          description: The monthly dispasable income calculated from the individual
+            income values given and allowable expenses
+          "$ref": "#/definitions/positive_number_with_two_decimals"
+        disposable_income_lower_threshold:
+          description: The lower threshold of the monthly disposable income used in
+            the calculation
+          "$ref": "#/definitions/positive_number_with_two_decimals"
+        disposable_income_upper_threshold:
+          description: The upper threshold of the monthly disposable income used in
+            the calculation
+          "$ref": "#/definitions/positive_number_with_two_decimals"
+  vehicle_detail:
+    description: Details of an individual vehicle
+    required:
+    - value
+    - loan_amount_outstanding
+    - date_of_purchase
+    - in_regular_use
+    - assessed_value
+    additionalProperties: false
+    properties:
+      value:
+        "$ref": "#/definitions/positive_number_with_two_decimals"
+      loan_amount_outstanding:
+        "$ref": "#/definitions/positive_number_with_two_decimals"
+      date_of_purchase:
+        description: The date the vehicle was purchased
+        "$ref": "#/definitions/date"
+      in_regular_use:
+        description: Whether or not the vehicle is in regular use by the applicant
+          or their partner
+        type: boolean
+      assessed_value:
+        description: The assessed value of the vehicle after deducting all allowances
+        "$ref": "#/definitions/positive_number_with_two_decimals"
+  capital_details:
+    type: object
+    required:
+    - liquid_capital_assessment
+    - non_liquid_capital_assessment
+    - vehicles
+    - property
+    - single_capital_assessment
+    - pensioner_disregard
+    - total_capital_lower_threshold
+    - total_capital_upper_threshold
+    - disposable_capital_assessment
+    additionalProperties: false
+    properties:
+      liquid_capital_assessment:
+        description: Aggregate value of lowest balances of bank accounts during the
+          calculation period
+        "$ref": "#/definitions/positive_number_with_two_decimals"
+      non_liquid_capital_assessment:
+        description: Aggregate value of all non-liquid capital items excluding property
+          and vehicles, e.g. stocks and shares, valuable items, jewellery
+        "$ref": "#/definitions/positive_number_with_two_decimals"
+      property:
+        description: Details of property values and calculations
+        "$ref": "#/definitions/property_details"
+      vehicles:
+        type: array
+        items:
+          "$ref": "#/definitions/vehicle_detail"
+      single_capital_assessment:
+        description: The sum of all capital assets before any disregards are applied
+        "$ref": "#/definitions/positive_number_with_two_decimals"
+      pensioner_disregard:
+        description: The capital that will be disregarded for over-60s before comparison
+          with the capital thresholds
+        "$ref": "#/definitions/positive_number_with_two_decimals"
+      disposable_capital_assessment:
+        description: The applicant's disposable capital calculated after subtracting
+          allowable items from the list of capital assets given
+        "$ref": "#/definitions/positive_number_with_two_decimals"
+      total_capital_lower_threshold:
+        description: The lower threshold of the capital allowance used in the calculation
+        "$ref": "#/definitions/positive_number_with_two_decimals"
+      total_capital_upper_threshold:
+        description: The upper threshold of the capital allowance used in the calculation
+        "$ref": "#/definitions/positive_number_with_two_decimals"
+  contribution_details:
+    type: object
+    required:
+    - monthly_contribution
+    - capital_contribution
+    properties:
+      monthly_contribution:
+        description: The monthly contribution required from the applicant
+        "$ref": "#/definitions/positive_number_with_two_decimals"
+      capital_contribution:
+        description: The capital contribution required from the applicant
+        "$ref": "#/definitions/positive_number_with_two_decimals"
+  response_data:
+    description: Response data
+    type: object
+    properties:
+      assessment_id:
+        description: A unique id for this eligibilty check
+        "$ref": "#/definitions/uuid"
+      client_reference_id:
+        description: The client reference id specified in the request, if present
+        type: string
+      result:
+        description: |-
+          The result of the eligibility check as  follows:
+          eligible: Eligible for legal aid
+          not_eligible: Not eligible for legal aid
+          contribution_required: The applicant is eligible for legal aid, but a monthly contribution and/or a capital contribution as specified in the details is required
+          out_of_scope: This applicant is out of scope for automatic determination of eligibility
+        "$ref": "#/definitions/assessment_result"
+      details:
+        description: Interim values used in the calculation
+        type: object
+        additionalProperties: false
+        required:
+        - passported
+        - self_employed
+        - income
+        - capital
+        - contributions
+        properties:
+          passported:
+            description: Whether or not the applicant receives a qualifying benefit
+            type: boolean
+          self_employed:
+            description: Whether or not the applicant is self-employed
+            type: boolean
+          income:
+            description: Aggregate income details and allowances used in calculation
+            "$ref": "#/definitions/income_details"
+          capital:
+            description: Aggregate capital details and allowances used in calculation
+            "$ref": "#/definitions/capital_details"
+          contributions:
+            description: Details of any contributions required, if any
+            "$ref": "#/definitions/contribution_details"


### PR DESCRIPTION
[Jira AP-544](https://dsdmoj.atlassian.net/browse/AP-544)

I've taken the existing JSON Schema, converted them to YAML and then incorporated them into a single OpenAPI document that I think should be compatible with most API documentation systems. 

If you paste `public/schemas/open_api_doc.yaml` into [Swagger Editor](https://swagger.io/tools/swagger-editor/) the output looks like this:
![swagger_view_of_assessments](https://user-images.githubusercontent.com/213040/59201419-4f187600-8b92-11e9-9d8f-0b51a84b916a.png)

There are a [number of compatible tools](https://apisyouwonthate.com/blog/turning-contracts-into-beautiful-documentation) that should be able to display this documentation. Some of the options include docker solutions (for example [ReDoc](https://github.com/Redocly/redoc#the-docker-way)). I'd suggest mounting that may be simpler than trying to extend the rails app with a gem.

There are tools that will generate JSON Schema from OpenAPI docs, but I struggle to find any that go the other way. Therefore it might make sense to maintain an OpenAPI document as the master description of the API, and use a tool to generate the matching JSON Schema.

Lastly, putting the schema into Swagger editor generated some error and warnings. I think I've fixed the errors, but it would be worth checking the warnings as they suggest there are some incorrectly formatted parts in the current schema.