### PR TITLE
AP728 Create Applicant

### DIFF
--- a/app/controllers/applicants_controller.rb
+++ b/app/controllers/applicants_controller.rb
@@ -1,0 +1,29 @@
+class ApplicantsController < ApplicationController
+  def create
+    if applicant_creation_service.success?
+      render json: success_response
+    else
+      render json: error_response, status: 422
+    end
+  end
+
+  private
+
+  def applicant_creation_service
+    @applicant_creation_service ||= ApplicantCreationService.new(request.raw_post)
+  end
+
+  def success_response
+    {
+      status: :ok,
+      assessment_id: applicant_creation_service.assessment.id
+    }.to_json
+  end
+
+  def error_response
+    {
+      status: :error,
+      errors: applicant_creation_service.errors
+    }.to_json
+  end
+end

--- a/app/controllers/applicants_controller.rb
+++ b/app/controllers/applicants_controller.rb
@@ -1,29 +1,23 @@
 class ApplicantsController < ApplicationController
   def create
-    if applicant_creation_service.success?
-      render json: success_response
+    if creation_service_result.success?
+      render json: {
+        success: true,
+        objects: creation_service_result.applicant,
+        errors: []
+      }
     else
-      render json: error_response, status: 422
+      render json: {
+        success: false,
+        objects: nil,
+        errors: creation_service_result.errors
+      }, status: 422
     end
   end
 
   private
 
-  def applicant_creation_service
-    @applicant_creation_service ||= ApplicantCreationService.new(request.raw_post)
-  end
-
-  def success_response
-    {
-      status: :ok,
-      assessment_id: applicant_creation_service.assessment.id
-    }
-  end
-
-  def error_response
-    {
-      status: :error,
-      errors: applicant_creation_service.errors
-    }
+  def creation_service_result
+    @creation_service_result ||= ApplicantCreationService.call(request.raw_post)
   end
 end

--- a/app/controllers/applicants_controller.rb
+++ b/app/controllers/applicants_controller.rb
@@ -17,13 +17,13 @@ class ApplicantsController < ApplicationController
     {
       status: :ok,
       assessment_id: applicant_creation_service.assessment.id
-    }.to_json
+    }
   end
 
   def error_response
     {
       status: :error,
       errors: applicant_creation_service.errors
-    }.to_json
+    }
   end
 end

--- a/app/models/applicant.rb
+++ b/app/models/applicant.rb
@@ -1,0 +1,9 @@
+class Applicant < ApplicationRecord
+  belongs_to :assessment
+
+  validate :date_of_birth_in_past
+
+  def date_of_birth_in_past
+    errors.add(:date_of_birth, 'cannot be in future') if date_of_birth > Date.today
+  end
+end

--- a/app/models/assessment.rb
+++ b/app/models/assessment.rb
@@ -4,6 +4,7 @@ class Assessment < ApplicationRecord
             :matter_proceeding_type,
             :client_reference_id, presence: true
 
+  has_one :applicant
   has_many :dependents
   has_many :properties
   has_many :wage_slips

--- a/app/services/applicant_creation_service.rb
+++ b/app/services/applicant_creation_service.rb
@@ -30,8 +30,10 @@ class ApplicantCreationService < BaseCreationService
   end
 
   def create_applicant
-    (raise CreationError, ['Applicant already exists']) if assessment.applicant.present?
+    (raise CreationError, ['There is already an applicant for this assesssment']) if assessment.applicant.present?
     @applicant ||= assessment.create_applicant!(payload[:applicant])
+  rescue ActiveRecord::RecordInvalid => e
+    raise CreationError, e.record.errors.full_messages
   end
 
   def assessment

--- a/app/services/applicant_creation_service.rb
+++ b/app/services/applicant_creation_service.rb
@@ -1,0 +1,30 @@
+class ApplicantCreationService
+  SCHEMA_PATH = Rails.root.join('public/schemas/applicant.json').to_s
+
+  def initialize(raw_post)
+    @raw_post = raw_post
+    @payload = JSON.parse(raw_post, symbolize_names: true)
+  end
+
+  def success?
+    errors.empty?
+  end
+
+  def errors
+    validator.valid? ? new_applicant.errors.full_messages : validator.errors
+  end
+
+  def assessment
+    @assessment ||= Assessment.find(@payload[:assessment_id])
+  end
+
+  private
+
+  def new_applicant
+    @new_applicant ||= assessment.create_applicant(@payload[:applicant])
+  end
+
+  def validator
+    @validator = JsonSchemaValidator.new(@raw_post, SCHEMA_PATH)
+  end
+end

--- a/app/services/applicant_creation_service.rb
+++ b/app/services/applicant_creation_service.rb
@@ -1,37 +1,44 @@
-class ApplicantCreationService
+class ApplicantCreationService < BaseCreationService
   SCHEMA_PATH = Rails.root.join('public/schemas/applicant.json').to_s
+
+  attr_accessor :raw_post, :applicant
 
   def initialize(raw_post)
     @raw_post = raw_post
-    @payload = JSON.parse(raw_post, symbolize_names: true)
-    @errors = nil
   end
 
-  def success?
-    errors.empty?
-  end
-
-  def errors
-    @errors ||= validator.valid? ? applicant_errors : validator.errors
-  end
-
-  def assessment
-    @assessment ||= Assessment.find_by(id: @payload[:assessment_id])
-    @errors = ['No such assessment ID'] if @assessment.nil?
-    @assessment
+  def call
+    validate_and_create
+    self
   end
 
   private
 
-  def applicant_errors
-    assessment.nil? ? @errors : new_applicant.errors.full_messages
+  def validate_and_create
+    validate_json
+    create_applicant
+  rescue CreationError => e
+    self.errors = e.errors
   end
 
-  def new_applicant
-    @new_applicant ||= assessment.create_applicant(@payload[:applicant])
+  def validate_json
+    raise CreationError, json_validator.errors unless json_validator.valid?
   end
 
-  def validator
-    @validator = JsonSchemaValidator.new(@raw_post, SCHEMA_PATH)
+  def json_validator
+    @json_validator ||= JsonSchemaValidator.new(raw_post, SCHEMA_PATH)
+  end
+
+  def create_applicant
+    # return (raise CreationError, ['Applicant already exists']) if assessment.applicant.present?
+    @applicant ||= assessment.create_applicant(payload[:applicant])
+  end
+
+  def assessment
+    @assessment ||= Assessment.find_by(id: payload[:assessment_id]) || (raise CreationError, ['No such assessment id'])
+  end
+
+  def payload
+    @payload ||= JSON.parse(raw_post, symbolize_names: true)
   end
 end

--- a/app/services/applicant_creation_service.rb
+++ b/app/services/applicant_creation_service.rb
@@ -30,8 +30,8 @@ class ApplicantCreationService < BaseCreationService
   end
 
   def create_applicant
-    # return (raise CreationError, ['Applicant already exists']) if assessment.applicant.present?
-    @applicant ||= assessment.create_applicant(payload[:applicant])
+    (raise CreationError, ['Applicant already exists']) if assessment.applicant.present?
+    @applicant ||= assessment.create_applicant!(payload[:applicant])
   end
 
   def assessment

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,6 @@
 Rails.application.routes.draw do
   resources :assessments, only: [:create] do
+    resources :applicants, only: [:create]
     resources :dependents, only: [:create]
     resources :properties, only: [:create]
     resource :income, only: [:create]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 Rails.application.routes.draw do
   resources :assessments, only: [:create] do
-    resources :applicants, only: [:create]
+    resource :applicant, only: [:create]
     resources :dependents, only: [:create]
     resources :properties, only: [:create]
     resource :income, only: [:create]

--- a/db/migrate/20190614123520_create_applicants.rb
+++ b/db/migrate/20190614123520_create_applicants.rb
@@ -1,0 +1,13 @@
+class CreateApplicants < ActiveRecord::Migration[5.2]
+  def change
+    create_table :applicants do |t|
+      t.uuid :assessment_id
+      t.datetime :date_of_birth
+      t.string :involvement_type
+      t.boolean :has_partner_opponent
+      t.boolean :receives_qualifying_benefit
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20190614123520_create_applicants.rb
+++ b/db/migrate/20190614123520_create_applicants.rb
@@ -1,8 +1,8 @@
 class CreateApplicants < ActiveRecord::Migration[5.2]
   def change
-    create_table :applicants do |t|
-      t.uuid :assessment_id
-      t.datetime :date_of_birth
+    create_table :applicants, id: :uuid do |t|
+      t.belongs_to :assessment, foreign_key: true, null: false, type: :uuid
+      t.date :date_of_birth
       t.string :involvement_type
       t.boolean :has_partner_opponent
       t.boolean :receives_qualifying_benefit

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,11 +10,21 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_06_20_114204) do
+ActiveRecord::Schema.define(version: 2019_06_14_123520) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
+
+  create_table "applicants", force: :cascade do |t|
+    t.uuid "assessment_id"
+    t.datetime "date_of_birth"
+    t.string "involvement_type"
+    t.boolean "has_partner_opponent"
+    t.boolean "receives_qualifying_benefit"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
 
   create_table "assessments", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "client_reference_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -16,14 +16,15 @@ ActiveRecord::Schema.define(version: 2019_06_14_123520) do
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
 
-  create_table "applicants", force: :cascade do |t|
-    t.uuid "assessment_id"
-    t.datetime "date_of_birth"
+  create_table "applicants", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "assessment_id", null: false
+    t.date "date_of_birth"
     t.string "involvement_type"
     t.boolean "has_partner_opponent"
     t.boolean "receives_qualifying_benefit"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["assessment_id"], name: "index_applicants_on_assessment_id"
   end
 
   create_table "assessments", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -98,32 +99,5 @@ ActiveRecord::Schema.define(version: 2019_06_14_123520) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "vehicles", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.uuid "assessment_id", null: false
-    t.decimal "value"
-    t.decimal "loan_amount_outstanding"
-    t.date "date_of_purchase"
-    t.boolean "in_regular_use"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["assessment_id"], name: "index_vehicles_on_assessment_id"
-  end
-
-  create_table "wage_slips", force: :cascade do |t|
-    t.uuid "assessment_id", null: false
-    t.date "payment_date"
-    t.decimal "gross_pay"
-    t.decimal "paye"
-    t.decimal "nic"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["assessment_id"], name: "index_wage_slips_on_assessment_id"
-  end
-
-  add_foreign_key "bank_accounts", "assessments"
-  add_foreign_key "benefit_receipts", "assessments"
-  add_foreign_key "non_liquid_assets", "assessments"
-  add_foreign_key "properties", "assessments"
-  add_foreign_key "vehicles", "assessments"
-  add_foreign_key "wage_slips", "assessments"
+  add_foreign_key "applicants", "assessments"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_06_14_123520) do
+ActiveRecord::Schema.define(version: 2019_06_20_114204) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -99,5 +99,33 @@ ActiveRecord::Schema.define(version: 2019_06_14_123520) do
     t.datetime "updated_at", null: false
   end
 
+  create_table "vehicles", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "assessment_id", null: false
+    t.decimal "value"
+    t.decimal "loan_amount_outstanding"
+    t.date "date_of_purchase"
+    t.boolean "in_regular_use"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["assessment_id"], name: "index_vehicles_on_assessment_id"
+  end
+
+  create_table "wage_slips", force: :cascade do |t|
+    t.uuid "assessment_id", null: false
+    t.date "payment_date"
+    t.decimal "gross_pay"
+    t.decimal "paye"
+    t.decimal "nic"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["assessment_id"], name: "index_wage_slips_on_assessment_id"
+  end
+
   add_foreign_key "applicants", "assessments"
+  add_foreign_key "bank_accounts", "assessments"
+  add_foreign_key "benefit_receipts", "assessments"
+  add_foreign_key "non_liquid_assets", "assessments"
+  add_foreign_key "properties", "assessments"
+  add_foreign_key "vehicles", "assessments"
+  add_foreign_key "wage_slips", "assessments"
 end

--- a/public/schemas/applicant.json
+++ b/public/schemas/applicant.json
@@ -29,7 +29,7 @@
           "$ref": "http://localhost:3000/schemas/assessment_request.json#definitions/date"
         },
         "involvement_type": {
-          "description": "The Legal Aid Applicant's involvment in the case e.g. defendant, applicant.",
+          "description": "The Legal Aid Applicant's involvement in the case e.g. defendant, applicant.",
           "type": "string",
           "enum": [
             "applicant", 

--- a/public/schemas/applicant.json
+++ b/public/schemas/applicant.json
@@ -25,7 +25,7 @@
       "additionalProperties": false,
       "properties": {
         "date_of_birth": {
-          "description": "Date of the original submission of this assessment",
+          "description": "The date of birth of the applicant",
           "$ref": "http://localhost:3000/schemas/assessment_request.json#definitions/date"
         },
         "involvement_type": {

--- a/public/schemas/applicant.json
+++ b/public/schemas/applicant.json
@@ -1,0 +1,51 @@
+{
+  "id": "http://localhost:3000/schemas/applicant.json",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Legal Aid Check Financial Eligibility create applicant payload schema",
+  "description": "This schema defines the payload required to create an applicant for the Legal Aid Check Financial Eligibility API",
+  "type": "object",
+  "required": [
+    "assessment_id",
+    "applicant"
+  ],
+  "properties": {
+    "assessment_id": {
+      "description": "The UUID of the assessment returned from the call to the assessment endpoint",
+      "$ref": "http://localhost:3000/schemas/assessment_request.json#definitions/uuid"
+    },
+    "applicant": {
+      "description": "An array of objects describing the applicant",
+      "type": "object",
+      "required": [
+        "date_of_birth",
+        "involvement_type",
+        "has_partner_opponent",
+        "receives_qualifying_benefit"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "date_of_birth": {
+          "description": "Date of the original submission of this assessment",
+          "$ref": "http://localhost:3000/schemas/assessment_request.json#definitions/date"
+        },
+        "involvement_type": {
+          "description": "The Legal Aid Applicant's involvment in the case e.g. defendant, applicant.",
+          "type": "string",
+          "enum": [
+            "applicant", 
+            "defendant"
+          ]
+        },
+        "has_partner_opponent": {
+          "description": "Does the applicant have a partner opponent",
+          "type": "boolean"
+        },
+        "receives_qualifying_benefit": {
+          "description": "Does the applicant receive qualifying benefit",
+          "type": "boolean"
+        }
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/spec/models/applicant_spec.rb
+++ b/spec/models/applicant_spec.rb
@@ -1,5 +1,0 @@
-require 'rails_helper'
-
-RSpec.describe Applicant, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
-end

--- a/spec/models/applicant_spec.rb
+++ b/spec/models/applicant_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Applicant, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/requests/applicants_spec.rb
+++ b/spec/requests/applicants_spec.rb
@@ -1,0 +1,45 @@
+require 'rails_helper'
+
+RSpec.describe ApplicantsController, type: :request do
+  describe 'POST applicants' do
+    let(:assessment) { create :assessment }
+    let(:params) do
+      {
+        dummy_payload: true,
+        assessment_id: '123'
+      }
+    end
+
+    context 'valid payload' do
+      before do
+        expect(ApplicantCreationService).to receive(:new).with(params.to_json).and_return(applicant_create_service)
+        post assessment_applicants_path(assessment.id), params: params.to_json
+      end
+      let(:applicant_create_service) { double ApplicantCreationService, success?: true, assessment: assessment }
+
+      it 'returns success' do
+        expect(response.status).to eq 200
+      end
+
+      it 'returns expected response' do
+        expect(response.body).to eq({ status: :ok, assessment_id: assessment.id }.to_json)
+      end
+    end
+
+    context 'invalid payload' do
+      before do
+        expect(ApplicantCreationService).to receive(:new).with(params.to_json).and_return(applicant_create_service)
+        post assessment_applicants_path(assessment.id), params: params.to_json
+      end
+      let(:applicant_create_service) { double ApplicantCreationService, success?: false, errors: ['xxx'] }
+
+      it 'returns unprocessable entity' do
+        expect(response.status).to eq 422
+      end
+
+      it 'returns expected response' do
+        expect(response.body).to eq({ status: :error, errors: ['xxx'] }.to_json)
+      end
+    end
+  end
+end

--- a/spec/requests/applicants_spec.rb
+++ b/spec/requests/applicants_spec.rb
@@ -3,42 +3,47 @@ require 'rails_helper'
 RSpec.describe ApplicantsController, type: :request do
   describe 'POST applicants' do
     let(:assessment) { create :assessment }
+    let(:applicant) { 'applicant' }
     let(:params) do
       {
         dummy_payload: true,
         assessment_id: '123'
-      }
+      }.to_json
     end
 
     context 'valid payload' do
       before do
-        expect(ApplicantCreationService).to receive(:new).with(params.to_json).and_return(applicant_create_service)
-        post assessment_applicants_path(assessment.id), params: params.to_json
+        service = double ApplicantCreationService, success?: true, applicant: applicant
+        expect(ApplicantCreationService).to receive(:call).with(params).and_return(service)
+        post assessment_applicant_path(assessment.id), params: params
       end
-      let(:applicant_create_service) { double ApplicantCreationService, success?: true, assessment: assessment }
 
       it 'returns success' do
-        expect(response.status).to eq 200
+        expect(response).to have_http_status(:success)
       end
 
       it 'returns expected response' do
-        expect(response.body).to eq({ status: :ok, assessment_id: assessment.id }.to_json)
+        expect(json[:success]).to eq(true)
+        expect(json[:errors]).to be_empty
+        expect(json[:objects]).to eq(applicant)
       end
     end
 
     context 'invalid payload' do
       before do
-        expect(ApplicantCreationService).to receive(:new).with(params.to_json).and_return(applicant_create_service)
-        post assessment_applicants_path(assessment.id), params: params.to_json
-      end
-      let(:applicant_create_service) { double ApplicantCreationService, success?: false, errors: ['xxx'] }
-
-      it 'returns unprocessable entity' do
-        expect(response.status).to eq 422
+        service = double ApplicantCreationService, success?: false, errors: ['xxx']
+        expect(ApplicantCreationService).to receive(:call).with(params).and_return(service)
+        post assessment_applicant_path(assessment.id), params: params
       end
 
-      it 'returns expected response' do
-        expect(response.body).to eq({ status: :error, errors: ['xxx'] }.to_json)
+      it 'returns http unprocessable entity' do
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+
+      it 'returns error payload' do
+        expect(json[:success]).to eq(false)
+        expect(json[:objects]).to eq(nil)
+        expect(json[:errors]).to match_array(['xxx'])
       end
     end
   end

--- a/spec/services/applicant_creation_service_spec.rb
+++ b/spec/services/applicant_creation_service_spec.rb
@@ -1,0 +1,125 @@
+require 'rails_helper'
+
+RSpec.describe ApplicantCreationService do
+  describe 'POST applicant' do
+    let(:assessment) { create :assessment }
+    let(:service) { described_class.new(request_payload) }
+
+    before do
+      # stub requests to get schemas
+      stub_request(:get, 'http://localhost:3000/schemas/assessment_request.json')
+        .with(
+          headers: {
+            'Accept' => '*/*',
+            'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+            'User-Agent' => 'Ruby'
+          }
+        )
+        .to_return(status: 200, body: full_schema, headers: {})
+    end
+
+    context 'valid payload' do
+      let(:valid_payload) do
+        {
+          assessment_id: assessment.id,
+          applicant: {
+            date_of_birth: '2010-04-04',
+            involvement_type: 'applicant',
+            has_partner_opponent: true,
+            receives_qualifying_benefit: true
+          }
+        }.to_json
+      end
+
+      let(:request_payload) { valid_payload }
+
+      describe '#success?' do
+        it 'returns true' do
+          expect(service.success?).to be true
+        end
+
+        it 'creates an applicant' do
+          expect { service.success? }.to change { Applicant.count }.by 1
+        end
+      end
+
+      describe '#assessment' do
+        it 'returns the assessment record' do
+          expect(service.assessment).to eq assessment
+        end
+      end
+    end
+
+    context 'payload fails JSON Schema' do
+      let(:invalid_payload) do
+        {
+          assessment_id: assessment.id,
+          extra_property: 'this should not be here',
+          applicant: {
+            date_of_birth: '2010x-04-04',
+            involvement_type: 'applicant',
+            receives_qualifying_benefit: false,
+            reason: 'extra property'
+          }
+        }.to_json
+      end
+
+      let(:request_payload) { invalid_payload }
+
+      describe '#success?' do
+        it 'returns false' do
+          expect(service.success?).to be false
+        end
+
+        it 'returns errors' do
+          service.success?
+          expect(service.errors.size).to eq 4
+          expect(service.errors[0]).to match %r{The property '#/applicant' did not contain a required property of 'has_partner_opponent'}
+          expect(service.errors[1]).to match %r{The property '#/applicant' contains additional properties \[\"reason\"\]}
+          expect(service.errors[2]).to match %r{The property '#/applicant/date_of_birth' value \"2010x-04-04\" did not match the regex }
+          expect(service.errors[3]).to match %r{The property '#/' contains additional properties \[\"extra_property\"\] }
+        end
+
+        it 'does not create an applicant' do
+          expect { service.success? }.not_to change { Applicant.count }
+        end
+      end
+    end
+
+    context 'ActiveRecord validation fails' do
+      let(:invalid_payload) do
+        {
+          assessment_id: assessment.id,
+          applicant: {
+            date_of_birth: Date.tomorrow.to_date,
+            involvement_type: 'applicant',
+            has_partner_opponent: false,
+            receives_qualifying_benefit: false
+          }
+        }.to_json
+      end
+
+      let(:request_payload) { invalid_payload }
+
+      describe '#success?' do
+        it 'returns false' do
+          expect(service.success?).to be false
+        end
+
+        it 'returns errors' do
+          service.success?
+          expect(service.errors.size).to eq 1
+          expect(service.errors[0]).to eq 'Date of birth cannot be in future'
+        end
+
+        it 'does not create an applicant' do
+          expect { service.success? }.not_to change { Applicant.count }
+        end
+      end
+    end
+
+    def full_schema
+      File.read(Rails.root.join('public/schemas/assessment_request.json'))
+    end
+  end
+end


### PR DESCRIPTION
AP728 Create Applicant for Means Calculation Service

[Create Applicant - Means Calculation Service](https://dsdmoj.atlassian.net/secure/RapidBoard.jspa?rapidView=233&modal=detail&selectedIssue=AP-728)

Created:  

- Applicants model that belongs_to the Assessment model and each assessment has one applicant.
- ApplicantCreationService that validates the applicant params passed in and if successful creates an applicant and returns self.
- ApplicantsController to call the ApplicationCreationService and render a  json success or error response depending on the result.
- Applicant JSON schema
- Tests

## Checklist

Before you ask people to review this PR:

- [X] Tests and rubocop should be passing: `bundle exec rake`
- [X] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [X] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [X] The PR description should say what you changed and why, with a link to the JIRA story.
- [X] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [X] You should have checked that the commit messages say why the change was made.