### PR TITLE
AP-729 refactor of the dependents creation service

### DIFF
--- a/app/controllers/assessments_controller.rb
+++ b/app/controllers/assessments_controller.rb
@@ -12,15 +12,7 @@ class AssessmentsController < ApplicationController
   def success_response
     {
       status: :ok,
-      assessment_id: assessment.id,
-      links: [
-        {
-          # TODO: applicant's url
-          # href: "https://check-for-legal-aid-eligibility/assessment/#{assessment.id}/applicant",
-          rel: 'applicant',
-          type: 'POST'
-        }
-      ]
+      assessment_id: assessment.id
     }
   end
 

--- a/app/controllers/dependents_controller.rb
+++ b/app/controllers/dependents_controller.rb
@@ -28,6 +28,6 @@ class DependentsController < ApplicationController
   end
 
   def dependent_creation_service
-    @dependent_creation_service ||= DependentCreationService.new(request.raw_post)
+    @dependent_creation_service ||= DependentsCreationService.new(request.raw_post)
   end
 end

--- a/app/controllers/dependents_controller.rb
+++ b/app/controllers/dependents_controller.rb
@@ -1,6 +1,33 @@
 class DependentsController < ApplicationController
   def create
-    service = DependentCreationService.new(request.raw_post)
-    render json: service.response_payload, status: service.http_status
+    if dependent_creation_service.success?
+      render json: success_response
+    else
+      render json: error_response, status: 422
+    end
+  end
+
+  private
+
+  def success_response
+    {
+      status: :ok,
+      assessment_id: assessment.id
+    }
+  end
+
+  def error_response
+    {
+      status: :error,
+      errors: dependent_creation_service.errors
+    }
+  end
+
+  def assessment
+    dependent_creation_service.assessment
+  end
+
+  def dependent_creation_service
+    @dependent_creation_service ||= DependentCreationService.new(request.raw_post)
   end
 end

--- a/app/services/dependent_creation_service.rb
+++ b/app/services/dependent_creation_service.rb
@@ -1,80 +1,56 @@
 class DependentCreationService
-  include Rails.application.routes.url_helpers
-
   SCHEMA_PATH = Rails.root.join('public/schemas/dependent.json').to_s
 
-  attr_reader :http_status
-
-  def initialize(payload)
-    @payload = JSON.parse(payload, symbolize_names: true)
-    @raw_payload = payload
+  def initialize(raw_post)
+    @raw_post =  raw_post
+    @payload = JSON.parse(@raw_post, symbolize_names: true)
+    @errors = []
   end
 
-  def result_payload
-    if create_dependents
-      @http_status = 200
-      success_response
-    else
-      @http_status = 422
-      error_response
-    end
+  def success?
+    errors.empty?
+  end
+
+  def assessment
+    @assessment ||= Assessment.find(@payload[:assessment_id])
+  end
+
+  def errors
+    validator.valid? ? model_errors : validator.errors
   end
 
   private
 
-  def json_payload_valid?
-    validator = JsonSchemaValidator.new(@raw_payload, SCHEMA_PATH)
-    if validator.invalid?
-      @errors = validator.errors
-      return false
-    end
-    true
+  def validator
+    @validator ||= JsonSchemaValidator.new(@raw_post, SCHEMA_PATH)
+  end
+
+  def model_errors
+    @model_errors ||= create_dependents
   end
 
   def create_dependents
-    return false unless json_payload_valid?
+    errors = []
+    ActiveRecord::Base.transaction do
+      @payload[:dependents].each do |dependent_params|
+        income_params = dependent_params.delete(:income)
+        dependent = assessment.dependents.new(dependent_params)
+        income_params&.each do |ip|
+          dependent.dependent_income_receipts.new(ip)
+        end
+        next if dependent.save
 
-    @assessment = Assessment.find(@payload[:assessment_id])
-    @payload[:dependents].each do |dependent_params|
-      income_params = dependent_params.delete(:income)
-      dependent = @assessment.dependents.new(dependent_params)
-      income_params&.each do |ip|
-        dependent.dependent_income_receipts.new(ip)
+        errors << collect_errors(dependent)
       end
-      next if dependent.save
-
-      collect_errors(dependent)
-      return false
     end
-    true
+    errors.flatten
   end
 
   def collect_errors(dependent)
-    @errors = dependent.errors.full_messages
-    dependent.dependent_income_receipts.each do |dir|
-      @errors += dir.errors.full_messages
-    end
+    dependent.errors.full_messages + income_receipt_errors(dependent)
   end
 
-  def success_response
-    {
-      status: :ok,
-      assessment_id: @assessment.id,
-      links: [
-        {
-          href: assessment_properties_path(@assessment),
-          rel: 'capital',
-          type: 'POST'
-        }
-      ]
-    }.to_json
-  end
-
-  def error_response
-    {
-      status: :error,
-      assessment_id: @payload[:assessment_id],
-      errors: @errors
-    }.to_json
+  def income_receipt_errors(dependent)
+    dependent.dependent_income_receipts.map { |ir| ir.errors.full_messages }
   end
 end

--- a/app/services/json_schema_validator.rb
+++ b/app/services/json_schema_validator.rb
@@ -11,8 +11,4 @@ class JsonSchemaValidator
   def valid?
     errors.empty?
   end
-
-  def invalid?
-    errors.any?
-  end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -75,3 +75,19 @@ require Rails.root.join('spec/fixtures/assessment_response_fixture')
 def open_structify(data)
   JSON.parse(data.to_json, object_class: DatedStruct)
 end
+
+def stub_call_to_get_json_schema
+  stub_request(:get, 'http://localhost:3000/schemas/assessment_request.json')
+    .with(
+      headers: {
+        'Accept' => '*/*',
+        'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+        'User-Agent' => 'Ruby'
+      }
+    )
+    .to_return(status: 200, body: full_schema, headers: {})
+end
+
+def full_schema
+  File.read(Rails.root.join('public/schemas/assessment_request.json'))
+end

--- a/spec/requests/assessments_spec.rb
+++ b/spec/requests/assessments_spec.rb
@@ -12,18 +12,7 @@ RSpec.describe AssessmentsController, type: :request do
 
     subject { post assessments_path, params: params.to_json }
 
-    before do
-      # stub requests to get schemas
-      stub_request(:get, 'http://localhost:3000/schemas/assessment_request.json')
-        .with(
-          headers: {
-            'Accept' => '*/*',
-            'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
-            'User-Agent' => 'Ruby'
-          }
-        )
-        .to_return(status: 200, body: full_schema, headers: {})
-    end
+    before { stub_call_to_get_json_schema }
 
     before { subject }
 
@@ -47,9 +36,5 @@ RSpec.describe AssessmentsController, type: :request do
         expect(json['errors']).not_to be_empty
       end
     end
-  end
-
-  def full_schema
-    File.read(Rails.root.join('public/schemas/assessment_request.json'))
   end
 end

--- a/spec/requests/dependents_spec.rb
+++ b/spec/requests/dependents_spec.rb
@@ -6,25 +6,39 @@ RSpec.describe DependentsController, type: :request do
     let(:request_payload) { { json_key: :json_value }.to_json }
     let(:response_payload) { { result: :ok }.to_json }
 
-    context 'valid payload' do
-      it 'returns http success' do
-        service = double DependentCreationService, response_payload: response_payload, http_status: 200
-        expect(DependentCreationService).to receive(:new).with(request_payload).and_return(service)
+    before { stub_call_to_get_json_schema }
 
+    context 'valid payload' do
+      before do
+        service = double DependentCreationService, success?: true, assessment: assessment
+        expect(DependentCreationService).to receive(:new).with(request_payload).and_return(service)
         post assessment_dependents_path(assessment), params: request_payload
+      end
+
+      let(:service) { double DependentCreationService, success?: true, assessment: assessment }
+
+      it 'returns http success' do
         expect(response).to have_http_status(:success)
-        expect(response.body).to eq response_payload
+      end
+
+      it 'generates a valid response' do
+        expect(response.body).to eq({ status: :ok, assessment_id: assessment.id }.to_json)
       end
     end
 
     context 'invalid payload' do
-      it 'returns http unprocessable entity' do
-        service = double DependentCreationService, response_payload: response_payload, http_status: 422
+      before do
+        service = double DependentCreationService, success?: false, errors: %w[error_1 error_2]
         expect(DependentCreationService).to receive(:new).with(request_payload).and_return(service)
-
         post assessment_dependents_path(assessment), params: request_payload
+      end
+
+      it 'returns http unprocessable entity' do
         expect(response).to have_http_status(:unprocessable_entity)
-        expect(response.body).to eq response_payload
+      end
+
+      it 'returns error payload' do
+        expect(response.body).to eq({ status: :error, errors: %w[error_1 error_2] }.to_json)
       end
     end
   end

--- a/spec/requests/dependents_spec.rb
+++ b/spec/requests/dependents_spec.rb
@@ -10,12 +10,12 @@ RSpec.describe DependentsController, type: :request do
 
     context 'valid payload' do
       before do
-        service = double DependentCreationService, success?: true, assessment: assessment
-        expect(DependentCreationService).to receive(:new).with(request_payload).and_return(service)
+        service = double DependentsCreationService, success?: true, assessment: assessment
+        expect(DependentsCreationService).to receive(:new).with(request_payload).and_return(service)
         post assessment_dependents_path(assessment), params: request_payload
       end
 
-      let(:service) { double DependentCreationService, success?: true, assessment: assessment }
+      let(:service) { double DependentsCreationService, success?: true, assessment: assessment }
 
       it 'returns http success' do
         expect(response).to have_http_status(:success)
@@ -28,8 +28,8 @@ RSpec.describe DependentsController, type: :request do
 
     context 'invalid payload' do
       before do
-        service = double DependentCreationService, success?: false, errors: %w[error_1 error_2]
-        expect(DependentCreationService).to receive(:new).with(request_payload).and_return(service)
+        service = double DependentsCreationService, success?: false, errors: %w[error_1 error_2]
+        expect(DependentsCreationService).to receive(:new).with(request_payload).and_return(service)
         post assessment_dependents_path(assessment), params: request_payload
       end
 

--- a/spec/services/assessment_creation_service_spec.rb
+++ b/spec/services/assessment_creation_service_spec.rb
@@ -5,18 +5,7 @@ RSpec.describe AssessmentCreationService do
 
   subject { described_class.new(remote_ip, raw_post) }
 
-  before do
-    # stub requests to get schemas
-    stub_request(:get, 'http://localhost:3000/schemas/assessment_request.json')
-      .with(
-        headers: {
-          'Accept' => '*/*',
-          'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
-          'User-Agent' => 'Ruby'
-        }
-      )
-      .to_return(status: 200, body: full_schema, headers: {})
-  end
+  before { stub_call_to_get_json_schema }
 
   context 'invalid json' do
     let(:raw_post) do
@@ -88,9 +77,5 @@ RSpec.describe AssessmentCreationService do
     it 'returns the created assessment' do
       expect(subject.assessment.id).to eq Assessment.last.id
     end
-  end
-
-  def full_schema
-    File.read(Rails.root.join('public/schemas/assessment_request.json'))
   end
 end

--- a/spec/services/dependents_creation_service_spec.rb
+++ b/spec/services/dependents_creation_service_spec.rb
@@ -5,130 +5,118 @@ RSpec.describe DependentCreationService do
   let(:assessment) { create :assessment }
   let(:service) { described_class.new(request_payload) }
 
-  before do
-    # stub request to get schema
-    stub_request(:get, 'http://localhost:3000/schemas/assessment_request.json')
-      .with(
-        headers: {
-          'Accept' => '*/*',
-          'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
-          'User-Agent' => 'Ruby'
-        }
-      )
-      .to_return(status: 200, body: full_schema, headers: {})
-  end
+  before { stub_call_to_get_json_schema }
 
   context 'valid payload without income' do
     let(:request_payload) { valid_payload_without_income }
+    describe '#success?' do
+      it 'returns true' do
+        expect(service.success?).to be true
+      end
 
-    it 'returns status code 200' do
-      service.result_payload
-      expect(service.http_status).to eq 200
-    end
+      it 'creates two dependent records for this assessment' do
+        expect {
+          service.success?
+        }.to change { Dependent.count }.by(2)
 
-    it 'returns expected success payload' do
-      expect(service.result_payload).to eq expected_result_payload
-    end
+        dependent = assessment.dependents.order(:date_of_birth).first
+        expect(dependent.date_of_birth).to eq 12.years.ago.to_date
+        expect(dependent.in_full_time_education).to be false
 
-    it 'creates two dependent records for this assessment' do
-      expect {
-        service.result_payload
-      }.to change { Dependent.count }.by(2)
-
-      dependent = assessment.dependents.order(:date_of_birth).first
-      expect(dependent.date_of_birth).to eq 12.years.ago.to_date
-      expect(dependent.in_full_time_education).to be false
-
-      dependent = assessment.dependents.order(:date_of_birth).last
-      expect(dependent.date_of_birth).to eq 6.years.ago.to_date
-      expect(dependent.in_full_time_education).to be true
+        dependent = assessment.dependents.order(:date_of_birth).last
+        expect(dependent.date_of_birth).to eq 6.years.ago.to_date
+        expect(dependent.in_full_time_education).to be true
+      end
     end
   end
 
   context 'valid payload with income' do
     let(:request_payload) { valid_payload_with_income }
+    describe '#success?' do
+      it 'creates one dependent' do
+        expect {
+          service.success?
+        }.to change { Dependent.count }.by(1)
+      end
 
-    it 'creates one dependent' do
-      expect {
-        service.result_payload
-      }.to change { Dependent.count }.by(1)
-    end
+      it 'creates three income records' do
+        expect {
+          service.success?
+        }.to change { DependentIncomeReceipt.count }.by(3)
 
-    it 'creates three income records' do
-      expect {
-        service.result_payload
-      }.to change { DependentIncomeReceipt.count }.by(3)
+        dirs = assessment.dependents.first.dependent_income_receipts.order(:date_of_payment)
+        expect(dirs.first.date_of_payment).to eq 60.days.ago.to_date
+        expect(dirs.first.amount).to eq 66.66
 
-      dirs = assessment.dependents.first.dependent_income_receipts.order(:date_of_payment)
-      expect(dirs.first.date_of_payment).to eq 60.days.ago.to_date
-      expect(dirs.first.amount).to eq 66.66
+        expect(dirs[1].date_of_payment).to eq 40.days.ago.to_date
+        expect(dirs[1].amount).to eq 44.44
 
-      expect(dirs[1].date_of_payment).to eq 40.days.ago.to_date
-      expect(dirs[1].amount).to eq 44.44
-
-      expect(dirs.last.date_of_payment).to eq 20.days.ago.to_date
-      expect(dirs.last.amount).to eq 22.22
+        expect(dirs.last.date_of_payment).to eq 20.days.ago.to_date
+        expect(dirs.last.amount).to eq 22.22
+      end
     end
   end
 
   context 'payload fails JSON schema' do
     let(:request_payload) { invalid_payload }
-
-    it 'returns https status 422' do
-      service.result_payload
-      expect(service.http_status).to eq 422
+    describe '#success?' do
+      it 'returns false' do
+        expect(service.success?).to be false
+      end
     end
 
-    it 'returns an error payload' do
-      result = JSON.parse(service.result_payload, symbolize_names: true)
-      expect(result[:status]).to eq 'error'
-      expect(result[:errors].size).to eq 4
-      expect(result[:errors][0]).to match %r{The property '#/' contains additional properties \[\"extra_property\"\] }
-      expect(result[:errors][1]).to match %r{The property '#/dependents/0' did not contain a required property of 'in_full_time_education'}
-      expect(result[:errors][2]).to match %r{The property '#/dependents/0' contains additional properties \[\"extra_dependent_property\"\]}
-      expect(result[:errors][3]).to match %r{The property '#/dependents/1/income/0' contains additional properties \[\"reason\"\]}
+    describe 'errors' do
+      it 'returns array of errors' do
+        service.success?
+        expect(service.errors.size).to eq 4
+        expect(service.errors[0]).to match %r{The property '#/' contains additional properties \[\"extra_property\"\] }
+        expect(service.errors[1]).to match %r{The property '#/dependents/0' did not contain a required property of 'in_full_time_education'}
+        expect(service.errors[2]).to match %r{The property '#/dependents/0' contains additional properties \[\"extra_dependent_property\"\]}
+        expect(service.errors[3]).to match %r{The property '#/dependents/1/income/0' contains additional properties \[\"reason\"\]}
+      end
     end
 
     it 'does not create a Dependent record' do
       expect {
-        service.result_payload
+        service.success?
       }.not_to change { Dependent.count }
     end
 
     it 'does not create any DependentIncomeReceipt records' do
       expect {
-        service.result_payload
+        service.success?
       }.not_to change { DependentIncomeReceipt.count }
     end
   end
 
   context 'payload fails ActiveRecord validations' do
     let(:request_payload) { payload_with_future_dates }
+    describe '#success?' do
+      it 'returns false' do
+        expect(service.success?).to be false
+      end
 
-    it 'returns https status 422' do
-      service.result_payload
-      expect(service.http_status).to eq 422
+      it 'does not create a Dependent record' do
+        expect {
+          service.success?
+        }.not_to change { Dependent.count }
+      end
+
+      it 'does not create any DependentIncomeReceipt records' do
+        expect {
+          service.success?
+        }.not_to change { DependentIncomeReceipt.count }
+      end
     end
 
-    it 'returns an error payload' do
-      result = JSON.parse(service.result_payload, symbolize_names: true)
-      expect(result[:status]).to eq 'error'
-      expect(result[:errors].size).to eq 3
-      expect(result[:errors][0]).to eq 'Dependent income receipts is invalid'
-      expect(result[:errors][1]).to eq 'Date of birth cannot be in future'
-      expect(result[:errors][2]).to eq 'Date of payment cannot be in the future'
-    end
-
-    it 'does not create a Dependent record' do
-      expect {
-        service.result_payload
-      }.not_to change { Dependent.count }
-    end
-
-    it 'does not create any DependentIncomeReceipt records' do
-      expect {
-        service.result_payload
-      }.not_to change { DependentIncomeReceipt.count }
+    describe 'errors' do
+      it 'returns an error payload' do
+        service.success?
+        expect(service.errors.size).to eq 3
+        expect(service.errors[0]).to eq 'Dependent income receipts is invalid'
+        expect(service.errors[1]).to eq 'Date of birth cannot be in future'
+        expect(service.errors[2]).to eq 'Date of payment cannot be in the future'
+      end
     end
   end
 
@@ -236,9 +224,5 @@ RSpec.describe DependentCreationService do
         }
       ]
     }.to_json
-  end
-
-  def full_schema
-    File.read(Rails.root.join('public/schemas/assessment_request.json'))
   end
 end


### PR DESCRIPTION
## Refactor of the DependentsController and DependentCreationService

[Link to story](https://dsdmoj.atlassian.net/browse/AP-729)

Refactored the above classes so as to use the same pattern as Julien used for Assessments creation:
- moved the generation of the response and status code from service to controller
- removed links from response
- made stubbing the response from reading the schema into a rspec helper method

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
