### PR TITLE
Change spelling from dependent to dependant

### DIFF
--- a/app/controllers/dependants_controller.rb
+++ b/app/controllers/dependants_controller.rb
@@ -1,9 +1,9 @@
-class DependentsController < ApplicationController
+class DependantsController < ApplicationController
   def create
     if creation_service_result.success?
       render json: {
         success: true,
-        objects: creation_service_result.dependents,
+        objects: creation_service_result.dependants,
         errors: []
       }
     else
@@ -18,6 +18,6 @@ class DependentsController < ApplicationController
   private
 
   def creation_service_result
-    @creation_service_result ||= DependentsCreationService.call(request.raw_post)
+    @creation_service_result ||= DependantsCreationService.call(request.raw_post)
   end
 end

--- a/app/models/assessment.rb
+++ b/app/models/assessment.rb
@@ -7,7 +7,7 @@ class Assessment < ApplicationRecord
 
   has_many :bank_accounts
   has_many :benefit_receipts
-  has_many :dependents
+  has_many :dependants
   has_many :non_liquid_assets
   has_many :outgoings
   has_many :properties

--- a/app/models/dependant.rb
+++ b/app/models/dependant.rb
@@ -1,7 +1,7 @@
-class Dependent < ApplicationRecord
+class Dependant < ApplicationRecord
   belongs_to :assessment
-  has_many :dependent_income_receipts
-  accepts_nested_attributes_for :dependent_income_receipts
+  has_many :dependant_income_receipts
+  accepts_nested_attributes_for :dependant_income_receipts
 
   validate :date_of_birth_in_past
 

--- a/app/models/dependant_income_receipt.rb
+++ b/app/models/dependant_income_receipt.rb
@@ -1,5 +1,5 @@
-class DependentIncomeReceipt < ApplicationRecord
-  belongs_to :dependent
+class DependantIncomeReceipt < ApplicationRecord
+  belongs_to :dependant
 
   validate :date_of_payment_cannot_be_in_future
 

--- a/app/services/dependants_creation_service.rb
+++ b/app/services/dependants_creation_service.rb
@@ -1,7 +1,7 @@
-class DependentsCreationService < BaseCreationService
-  SCHEMA_PATH = Rails.root.join('public/schemas/dependent.json').to_s
+class DependantsCreationService < BaseCreationService
+  SCHEMA_PATH = Rails.root.join('public/schemas/dependant.json').to_s
 
-  attr_accessor :raw_post, :dependents
+  attr_accessor :raw_post, :dependants
 
   def initialize(raw_post)
     @raw_post = raw_post
@@ -16,7 +16,7 @@ class DependentsCreationService < BaseCreationService
 
   def validate_and_create
     validate_json
-    create_dependents
+    create_dependants
   rescue CreationError => e
     self.errors = e.errors
   end
@@ -29,8 +29,8 @@ class DependentsCreationService < BaseCreationService
     @json_validator ||= JsonSchemaValidator.new(@raw_post, SCHEMA_PATH)
   end
 
-  def create_dependents
-    self.dependents = assessment.dependents.create!(dependent_params)
+  def create_dependants
+    self.dependants = assessment.dependants.create!(dependant_params)
   rescue ActiveRecord::RecordInvalid => e
     raise CreationError, e.record.errors.full_messages
   end
@@ -43,10 +43,10 @@ class DependentsCreationService < BaseCreationService
     @payload ||= JSON.parse(@raw_post, symbolize_names: true)
   end
 
-  def dependent_params
-    payload[:dependents].map do |dependent|
-      dependent[:dependent_income_receipts_attributes] = dependent.delete(:income) if dependent[:income]
-      dependent
+  def dependant_params
+    payload[:dependants].map do |dependant|
+      dependant[:dependant_income_receipts_attributes] = dependant.delete(:income) if dependant[:income]
+      dependant
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@ Rails.application.routes.draw do
   resources :assessments, only: [:create] do
     resource :applicant, only: [:create]
     resources :capitals, only: [:create]
-    resources :dependents, only: [:create]
+    resources :dependants, only: [:create]
     resource :income, only: [:create]
     resources :outgoings, only: [:create]
     resources :properties, only: [:create]

--- a/db/migrate/20190710105635_change_dependants_spelling.rb
+++ b/db/migrate/20190710105635_change_dependants_spelling.rb
@@ -1,0 +1,8 @@
+class ChangeDependantsSpelling < ActiveRecord::Migration[5.2]
+  def change
+    rename_table :dependents, :dependants
+
+    rename_table :dependent_income_receipts, :dependant_income_receipts
+    rename_column :dependant_income_receipts, :dependent_id, :dependant_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_06_24_151225) do
+ActiveRecord::Schema.define(version: 2019_07_10_105635) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -56,15 +56,15 @@ ActiveRecord::Schema.define(version: 2019_06_24_151225) do
     t.index ["assessment_id"], name: "index_benefit_receipts_on_assessment_id"
   end
 
-  create_table "dependent_income_receipts", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.uuid "dependent_id"
+  create_table "dependant_income_receipts", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "dependant_id"
     t.date "date_of_payment"
     t.decimal "amount"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  create_table "dependents", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "dependants", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "assessment_id"
     t.date "date_of_birth"
     t.boolean "in_full_time_education"

--- a/public/schemas/dependant.json
+++ b/public/schemas/dependant.json
@@ -1,10 +1,10 @@
 {
-  "id": "http://localhost:3000/schemas/dependent.json",
+  "id": "http://localhost:3000/schemas/dependant.json",
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "title": "Legal Aid Check Financial Eligibility create dependent payload schema",
-  "description": "This schema defines the payload required to create one or more dependents and specify any income they may have  for the Legal Aid Check Financial Eligibility API",
+  "title": "Legal Aid Check Financial Eligibility create dependant payload schema",
+  "description": "This schema defines the payload required to create one or more dependants and specify any income they may have  for the Legal Aid Check Financial Eligibility API",
   "definitions": {
-    "dependent": {
+    "dependant": {
       "required": [
         "date_of_birth",
         "in_full_time_education"
@@ -12,24 +12,24 @@
       "additionalProperties": false,
       "properties": {
         "date_of_birth": {
-          "description": "The date of birth of the dependent",
+          "description": "The date of birth of the dependant",
           "$ref": "http://localhost:3000/schemas/assessment_request.json#definitions/date"
         },
         "in_full_time_education": {
-          "description": "Whether or not the dependent is in full time education",
+          "description": "Whether or not the dependant is in full time education",
           "type":  "boolean"
         },
         "income": {
-          "description": "An array of objects describing the dependent's income receipts during the calculation period",
+          "description": "An array of objects describing the dependant's income receipts during the calculation period",
           "type": "array",
           "items":{
-            "$ref": "#/definitions/dependent_income_receipt"
+            "$ref": "#/definitions/dependant_income_receipt"
           }
         }
       }
     },
-    "dependent_income_receipt": {
-      "description": "An object describing one income receipt by a dependent",
+    "dependant_income_receipt": {
+      "description": "An object describing one income receipt by a dependant",
       "type": "object",
       "required": [
         "date_of_payment",
@@ -37,7 +37,7 @@
       ],
       "properties": {
         "date_of_payment": {
-          "description": "The date the dependent received this income",
+          "description": "The date the dependant received this income",
           "$ref": "http://localhost:3000/schemas/assessment_request.json#definitions/date"
         },
         "amount": {
@@ -51,7 +51,7 @@
   "type": "object",
   "required":[
     "assessment_id",
-    "dependents"
+    "dependants"
   ],
   "additionalProperties": false,
   "properties": {
@@ -59,11 +59,11 @@
       "description": "The UUID of the assessment returned from the call to the assessment endpoint",
       "$ref": "http://localhost:3000/schemas/assessment_request.json#definitions/uuid"
     },
-    "dependents": {
-      "description": "An array of objects describing the applicant's dependents",
+    "dependants": {
+      "description": "An array of objects describing the applicant's dependants",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/dependent"
+        "$ref": "#/definitions/dependant"
       }
     }
   }

--- a/public/schemas/vehicles.json
+++ b/public/schemas/vehicles.json
@@ -1,7 +1,7 @@
 {
   "id": "http://localhost:3000/schemas/vehicles.json",
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "title": "Legal Aid Check Financial Eligibility create dependent payload schema",
+  "title": "Legal Aid Check Financial Eligibility create dependant payload schema",
   "description": "This schema defines the payload required to create one or more define vehicles owned by the applicant for the Legal Aid Check Financial Eligibility API",
   "definitions": {
     "vehicle": {

--- a/spec/factories/dependant_factory.rb
+++ b/spec/factories/dependant_factory.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
-  factory :dependent do
+  factory :dependant do
     date_of_birth { Faker::Date.birthday }
     in_full_time_education { [true, false].sample }
     assessment

--- a/spec/fixtures/assessment_request.json
+++ b/spec/fixtures/assessment_request.json
@@ -9,7 +9,7 @@
     "involvement_type": "applicant",
     "has_partner_opponent": false,
     "receives_qualifying_benefit": false,
-    "dependents": [
+    "dependants": [
       {
         "date_of_birth": "1995-02-02",
         "in_full_time_education": false,

--- a/spec/fixtures/assessment_response_fixture.rb
+++ b/spec/fixtures/assessment_response_fixture.rb
@@ -89,6 +89,6 @@ class AssessmentResponseFixture < BaseAssessmentFixture
   end
 end
 # include outgoings total
-# allowances  -> dependents, adult dependents, over 65, et
+# allowances  -> dependants, adult dependants, over 65, et
 
 # return any aggregate values and any allowances, and calculated sums that we have used.

--- a/spec/models/dependant_income_receipt_spec.rb
+++ b/spec/models/dependant_income_receipt_spec.rb
@@ -1,5 +1,5 @@
 require 'rails_helper'
 
-RSpec.describe DependentIncomeReceipt, type: :model do
+RSpec.describe DependantIncomeReceipt, type: :model do
   pending "add some examples to (or delete) #{__FILE__}"
 end

--- a/spec/models/dependant_spec.rb
+++ b/spec/models/dependant_spec.rb
@@ -1,5 +1,5 @@
 require 'rails_helper'
 
-RSpec.describe Dependent, type: :model do
+RSpec.describe Dependant, type: :model do
   pending "add some examples to (or delete) #{__FILE__}"
 end

--- a/spec/requests/dependants_spec.rb
+++ b/spec/requests/dependants_spec.rb
@@ -1,19 +1,19 @@
 require 'rails_helper'
 
-RSpec.describe DependentsController, type: :request do
-  describe 'POST dependents' do
+RSpec.describe DependantsController, type: :request do
+  describe 'POST dependants' do
     let(:assessment) { create :assessment }
-    let(:dependents) { create_list :dependent, 2, assessment: assessment }
+    let(:dependants) { create_list :dependant, 2, assessment: assessment }
     let(:request_payload) { { foo: :bar }.to_json }
 
-    subject { post assessment_dependents_path(assessment), params: request_payload }
+    subject { post assessment_dependants_path(assessment), params: request_payload }
 
     before { stub_call_to_json_schema }
 
     context 'valid payload' do
       before do
-        service = double DependentsCreationService, success?: true, dependents: dependents
-        expect(DependentsCreationService).to receive(:call).with(request_payload).and_return(service)
+        service = double DependantsCreationService, success?: true, dependants: dependants
+        expect(DependantsCreationService).to receive(:call).with(request_payload).and_return(service)
         subject
       end
 
@@ -25,14 +25,14 @@ RSpec.describe DependentsController, type: :request do
         expect(parsed_response[:success]).to eq(true)
         expect(parsed_response[:errors]).to be_empty
         expect(parsed_response[:objects]).not_to be_empty
-        expect(parsed_response[:objects].first[:id]).to eq(dependents.first.id)
+        expect(parsed_response[:objects].first[:id]).to eq(dependants.first.id)
       end
     end
 
     context 'invalid payload' do
       before do
-        service = double DependentsCreationService, success?: false, errors: %w[error_1 error_2]
-        expect(DependentsCreationService).to receive(:call).with(request_payload).and_return(service)
+        service = double DependantsCreationService, success?: false, errors: %w[error_1 error_2]
+        expect(DependantsCreationService).to receive(:call).with(request_payload).and_return(service)
         subject
       end
 

--- a/spec/services/dependants_creation_service_spec.rb
+++ b/spec/services/dependants_creation_service_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe DependentsCreationService do
+RSpec.describe DependantsCreationService do
   include Rails.application.routes.url_helpers
   let(:assessment) { create :assessment }
 
@@ -11,16 +11,16 @@ RSpec.describe DependentsCreationService do
   context 'valid payload without income' do
     let(:request_payload) { valid_payload_without_income }
 
-    it 'creates two dependent records for this assessment' do
-      expect { subject }.to change { Dependent.count }.by(2)
+    it 'creates two dependant records for this assessment' do
+      expect { subject }.to change { Dependant.count }.by(2)
 
-      dependent = assessment.dependents.order(:date_of_birth).first
-      expect(dependent.date_of_birth).to eq 12.years.ago.to_date
-      expect(dependent.in_full_time_education).to be false
+      dependant = assessment.dependants.order(:date_of_birth).first
+      expect(dependant.date_of_birth).to eq 12.years.ago.to_date
+      expect(dependant.in_full_time_education).to be false
 
-      dependent = assessment.dependents.order(:date_of_birth).last
-      expect(dependent.date_of_birth).to eq 6.years.ago.to_date
-      expect(dependent.in_full_time_education).to be true
+      dependant = assessment.dependants.order(:date_of_birth).last
+      expect(dependant.date_of_birth).to eq 6.years.ago.to_date
+      expect(dependant.in_full_time_education).to be true
     end
 
     describe '#success?' do
@@ -29,11 +29,11 @@ RSpec.describe DependentsCreationService do
       end
     end
 
-    describe '#dependents' do
-      it 'returns the created dependents' do
-        expect(subject.dependents.count).to eq(2)
-        expect(subject.dependents.first).to be_a(Dependent)
-        expect(subject.dependents.first.assessment.id).to eq(assessment.id)
+    describe '#dependants' do
+      it 'returns the created dependants' do
+        expect(subject.dependants.count).to eq(2)
+        expect(subject.dependants.first).to be_a(Dependant)
+        expect(subject.dependants.first.assessment.id).to eq(assessment.id)
       end
     end
   end
@@ -41,14 +41,14 @@ RSpec.describe DependentsCreationService do
   context 'valid payload with income' do
     let(:request_payload) { valid_payload_with_income }
     describe '#success?' do
-      it 'creates one dependent' do
-        expect { subject }.to change { Dependent.count }.by(1)
+      it 'creates one dependant' do
+        expect { subject }.to change { Dependant.count }.by(1)
       end
 
       it 'creates three income records' do
-        expect { subject }.to change { DependentIncomeReceipt.count }.by(3)
+        expect { subject }.to change { DependantIncomeReceipt.count }.by(3)
 
-        dirs = assessment.dependents.first.dependent_income_receipts.order(:date_of_payment)
+        dirs = assessment.dependants.first.dependant_income_receipts.order(:date_of_payment)
         expect(dirs.first.date_of_payment).to eq 60.days.ago.to_date
         expect(dirs.first.amount).to eq 66.66
 
@@ -72,19 +72,19 @@ RSpec.describe DependentsCreationService do
     it 'returns an error payload' do
       expect(subject.errors.size).to eq 6
       expect(subject.errors[0]).to match %r{The property '#/' contains additional properties \[\"extra_property\"\] }
-      expect(subject.errors[1]).to match %r{The property '#/dependents/0' did not contain a required property of 'in_full_time_education'}
-      expect(subject.errors[2]).to match %r{The property '#/dependents/0' contains additional properties \[\"extra_dependent_property\"\]}
-      expect(subject.errors[3]).to match %r{The property '#/dependents/0/date_of_birth' value \"not-a-valid-date\" did not match the regex}
-      expect(subject.errors[4]).to match %r{The property '#/dependents/1/income/0/date_of_payment' value \".+\" did not match the regex}
-      expect(subject.errors[5]).to match %r{The property '#/dependents/1/income/0' contains additional properties \[\"reason\"\]}
+      expect(subject.errors[1]).to match %r{The property '#/dependants/0' did not contain a required property of 'in_full_time_education'}
+      expect(subject.errors[2]).to match %r{The property '#/dependants/0' contains additional properties \[\"extra_dependant_property\"\]}
+      expect(subject.errors[3]).to match %r{The property '#/dependants/0/date_of_birth' value \"not-a-valid-date\" did not match the regex}
+      expect(subject.errors[4]).to match %r{The property '#/dependants/1/income/0/date_of_payment' value \".+\" did not match the regex}
+      expect(subject.errors[5]).to match %r{The property '#/dependants/1/income/0' contains additional properties \[\"reason\"\]}
     end
 
-    it 'does not create a Dependent record' do
-      expect { subject }.not_to change { Dependent.count }
+    it 'does not create a Dependant record' do
+      expect { subject }.not_to change { Dependant.count }
     end
 
-    it 'does not create any DependentIncomeReceipt records' do
-      expect { subject }.not_to change { DependentIncomeReceipt.count }
+    it 'does not create any DependantIncomeReceipt records' do
+      expect { subject }.not_to change { DependantIncomeReceipt.count }
     end
   end
 
@@ -95,19 +95,19 @@ RSpec.describe DependentsCreationService do
         expect(subject.success?).to be false
       end
 
-      it 'does not create a Dependent record' do
-        expect { subject }.not_to change { Dependent.count }
+      it 'does not create a Dependant record' do
+        expect { subject }.not_to change { Dependant.count }
       end
 
-      it 'does not create any DependentIncomeReceipt records' do
-        expect { subject }.not_to change { DependentIncomeReceipt.count }
+      it 'does not create any DependantIncomeReceipt records' do
+        expect { subject }.not_to change { DependantIncomeReceipt.count }
       end
     end
 
     describe 'errors' do
       it 'returns an error payload' do
         expect(subject.errors.size).to eq 2
-        expect(subject.errors).to include 'Dependent income receipts date of payment cannot be in the future'
+        expect(subject.errors).to include 'Dependant income receipts date of payment cannot be in the future'
         expect(subject.errors).to include 'Date of birth cannot be in future'
       end
     end
@@ -120,12 +120,12 @@ RSpec.describe DependentsCreationService do
         expect(subject.success?).to be false
       end
 
-      it 'does not create a Dependent record' do
-        expect { subject }.not_to change { Dependent.count }
+      it 'does not create a Dependant record' do
+        expect { subject }.not_to change { Dependant.count }
       end
 
-      it 'does not create any DependentIncomeReceipt records' do
-        expect { subject }.not_to change { DependentIncomeReceipt.count }
+      it 'does not create any DependantIncomeReceipt records' do
+        expect { subject }.not_to change { DependantIncomeReceipt.count }
       end
     end
 
@@ -140,7 +140,7 @@ RSpec.describe DependentsCreationService do
   let(:payload_with_invalid_id) do
     {
       assessment_id: '34e353e2-dedb-4314-a271-9ff579e19f45',
-      dependents: [
+      dependants: [
         {
           date_of_birth: 12.years.ago.to_date,
           in_full_time_education: false
@@ -157,9 +157,9 @@ RSpec.describe DependentsCreationService do
     {
       assessment_id: assessment.id,
       extra_property: 'this should not be here',
-      dependents: [
+      dependants: [
         {
-          extra_dependent_property: 'this should not be here',
+          extra_dependant_property: 'this should not be here',
           date_of_birth: 'not-a-valid-date'
         },
         {
@@ -178,7 +178,7 @@ RSpec.describe DependentsCreationService do
   let(:valid_payload_without_income) do
     {
       assessment_id: assessment.id,
-      dependents: [
+      dependants: [
         {
           date_of_birth: 12.years.ago.to_date,
           in_full_time_education: false
@@ -194,7 +194,7 @@ RSpec.describe DependentsCreationService do
   let(:valid_payload_with_income) do
     {
       assessment_id: assessment.id,
-      dependents: [
+      dependants: [
         {
           date_of_birth: 12.years.ago.to_date,
           in_full_time_education: false,
@@ -221,7 +221,7 @@ RSpec.describe DependentsCreationService do
   let(:payload_with_future_dates) do
     {
       assessment_id: assessment.id,
-      dependents: [
+      dependants: [
         {
           date_of_birth: 3.years.from_now.to_date,
           in_full_time_education: false,

--- a/spec/services/json_schema_validator_spec.rb
+++ b/spec/services/json_schema_validator_spec.rb
@@ -105,10 +105,10 @@ describe JsonSchemaValidator do
         end
       end
 
-      context 'dependents' do
+      context 'dependants' do
         context 'none specified' do
           before do
-            assessment_hash[:applicant].delete(:dependents)
+            assessment_hash[:applicant].delete(:dependants)
           end
         end
 


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-763)

CheckFinancialEligibility was using the spelling dependent rather than dependant. This changes all uses to the preferred spelling. It also updates the database with a migration.

I used find/replace with case sensitivity to swap the spellings, left everything in the db file untouched and created a new migration file to rename the relevant tables and fields. I then ran `bundle exec rspec` and everything passed.

I was doing this as I was going along in AP-768 but realised that the PR at the end would be enormous and difficult for a reviewer to see what had actually changed so I split this off into its own PR.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
