### PR TITLE
AP-783 Adds PaymentPeriodAnalyser to determine frequency of payment

### DIFF
--- a/app/services/payment_period_analyser.rb
+++ b/app/services/payment_period_analyser.rb
@@ -1,0 +1,102 @@
+# rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+class PaymentPeriodAnalyser
+  attr_reader :data
+
+  def initialize(data)
+    @data = data
+  end
+
+  def monthly?
+    return false if dates.size > 4
+    return false if days_between_dates.median < 28.5
+    return false if dates.size == 4 && date_slope < -1.6
+    return false if date_slope < -2
+    return false if days_between_dates.range > 9
+
+    true
+  end
+
+  def weekly?
+    return true if dates.size > 8
+    return false if around_28(days_between_dates.median) || around_28(days_between_dates.range)
+    return true if days_between_dates.median > 19 && days_between_dates.range > 19 && days.range > 10
+
+    false
+  end
+
+  def two_weekly?
+    return false if dates.size > 8
+    return true if around_14(days_between_dates.median) && days_between_dates.range < 6
+    return true if around_28(days_between_dates.median) && around_28(days_between_dates.range)
+    return true if around_7_or_14(days_between_dates.median) && around_14_or_21_or_28(days_between_dates.range)
+    return true if around_14_or_21(days_between_dates.median) && around_7_or_14(days_between_dates.range)
+
+    false
+  end
+
+  def four_weekly?
+    return false if monthly?
+    return false if dates.size > 5
+    return true if around_28(days_between_dates.median) && days_between_dates.range < 6
+    return true if days_between_dates.median > 30 && around_28(days_between_dates.range)
+
+    false
+  end
+
+  def around_28(number)
+    number.between?(26, 30)
+  end
+
+  def around_21(number)
+    number.between?(20, 22)
+  end
+
+  def around_14(number)
+    number.between?(12, 16)
+  end
+
+  def around_7(number)
+    number.between?(6, 8)
+  end
+
+  def around_14_or_21(number)
+    around_14(number) || around_21(number)
+  end
+
+  def around_7_or_14(number)
+    around_7(number) || around_14(number)
+  end
+
+  def around_14_or_21_or_28(number)
+    around_14(number) || around_21(number) || around_28(number)
+  end
+
+  # Weekly sequences tend to have day numbers that reduce through the sequence
+  # So the greater the negative slope the less likely the data is monthly.
+  def date_slope
+    data = dates.map(&:day).each_with_index.each_with_object({}) { |(n, i), h| h[i] = n }
+    size = dates.size
+
+    sum_x = 0
+    sum_y = 0
+    sum_xx = 0
+    sum_xy = 0
+
+    # calculate the sums
+    data.each do |x, y|
+      sum_xy += x * y
+      sum_xx += x * x
+      sum_x  += x
+      sum_y  += y
+    end
+
+    1.0 * ((size * sum_xy) - (sum_x * sum_y)) / ((size * sum_xx) - (sum_x * sum_x))
+  end
+
+  def time_series_calculator
+    @time_series_calculator ||= TimeSeriesCalculator.new(data)
+  end
+  delegate :average_days_between_dates, :deviation_between_dates, :days_between_dates, :dates, :days,
+           to: :time_series_calculator
+end
+# rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity

--- a/app/services/time_series_calculator.rb
+++ b/app/services/time_series_calculator.rb
@@ -32,8 +32,12 @@ class TimeSeriesCalculator
   def days_between_dates
     @days_between_dates ||= begin
       days = dates.each_cons(2).map { |a, b| ((a - b) / 1.day).abs.round(0) }
-      DescriptiveStatistics::Stats.new(days)
+      DescriptiveStatistics::Stats.new days
     end
+  end
+
+  def days
+    @days ||= DescriptiveStatistics::Stats.new(dates.map(&:day))
   end
 
   def dates

--- a/spec/services/payment_period_analyser_spec.rb
+++ b/spec/services/payment_period_analyser_spec.rb
@@ -1,0 +1,178 @@
+require 'rails_helper'
+
+RSpec.describe PaymentPeriodAnalyser do
+  let(:generator) { SalaryPatternGenerator }
+
+  let(:first_day_of_month) { generator.call period: :monthly_set_day, start_at: Time.now.beginning_of_month }
+  let(:first_day_of_month_weekend_offset) { generator.call period: :monthly_set_day, start_at: Time.now.beginning_of_month, day_offset: 2 }
+  let(:monthly_spanning_month_end) { from_sequence '31-Jan-2019', '1-Mar-2019', '31-Mar-2019' }
+  let(:monthly_with_early_next_month) { from_sequence '1-Jan-2019', '31-Jan-2019', '1-Mar-2019', '31-Mar-2019' }
+  let(:twenty_eigth_of_month) { generator.call period: :monthly_set_day, start_at: Time.parse('28-jun-2019') }
+  let(:twenty_eigth_of_month_weekend_offset) { generator.call period: :monthly_set_day, start_at: Time.parse('28-jul-2019'), day_offset: 2 }
+  let(:monthly_by_period) { generator.call period: :monthly }
+  let(:monthly_by_period_with_offset) { generator.call period: :monthly, day_offset: 2 }
+
+  let(:monthlies) do
+    {
+      first_day_of_month: first_day_of_month,
+      first_day_of_month_weekend_offset: first_day_of_month_weekend_offset,
+      monthly_spanning_month_end: monthly_spanning_month_end,
+      monthly_with_early_next_month: monthly_with_early_next_month,
+      twenty_eigth_of_month: twenty_eigth_of_month,
+      twenty_eigth_of_month_weekend_offset: twenty_eigth_of_month_weekend_offset,
+      monthly_by_period: monthly_by_period,
+      monthly_by_period_with_offset: monthly_by_period_with_offset
+    }
+  end
+
+  let(:every_monday) { generator.call period: :weekly, start_at: Time.now.beginning_of_week }
+  let(:midweek_with_variance) { generator.call period: :weekly, start_at: (Time.now.beginning_of_week + 2.days), day_offset: 2 }
+  let(:incomplete_weekly) { every_monday.to_a.sample(10).to_h }
+  let(:three_weeks) { [1, 4, 10].map { |n| every_monday.to_a[n] }.to_h }
+
+  let(:weeklies) do
+    {
+      every_monday: every_monday,
+      midweek_with_variance: midweek_with_variance,
+      incomplete_weekly: incomplete_weekly,
+      three_weeks: three_weeks
+    }
+  end
+
+  let(:every_other_monday) { generator.call period: :two_weekly, start_at: Time.now.beginning_of_week }
+  let(:midweek_fortnighly_with_variance) { generator.call period: :two_weekly, start_at: (Time.now.beginning_of_week + 2.days), day_offset: 2 }
+  let(:incomplete_fortnightly) { every_other_monday.to_a.sample(5).to_h }
+  let(:three_of_fortnightly) { [1, 2, 5].map { |n| every_other_monday.to_a[n] }.to_h }
+
+  let(:fortnightlies) do
+    {
+      every_other_monday: every_other_monday,
+      midweek_fortnighly_with_variance: midweek_fortnighly_with_variance,
+      incomplete_fortnightly: incomplete_fortnightly,
+      three_of_fortnightly: three_of_fortnightly
+    }
+  end
+
+  let(:every_fourth_monday) { generator.call period: :four_weekly, start_at: Time.now.beginning_of_week }
+  let(:midweek_four_weely_with_variance) { generator.call period: :four_weekly, start_at: (Time.now.beginning_of_week + 2.days), day_offset: 1 }
+  let(:incomplete_four_weekly) { every_fourth_monday.to_a.sample(3).to_h }
+  let(:four_weekly_near_month_end) { generator.call period: :four_weekly, start_at: (Time.now.end_of_month - 1.day) }
+
+  let(:four_weeklies) do
+    {
+      every_fourth_monday: every_fourth_monday,
+      midweek_four_weely_with_variance: midweek_four_weely_with_variance,
+      incomplete_four_weekly: incomplete_four_weekly,
+      four_weekly_near_month_end: four_weekly_near_month_end
+    }
+  end
+
+  let(:monthly_by_period_with_large_offset) { generator.call period: :monthly, day_offset: 4 }
+  let(:incomplete_four_weekly_with_variance) { midweek_four_weely_with_variance.to_a.sample(3).to_h }
+  let(:difficulties) do
+    {
+      monthly_by_period_with_large_offset: monthly_by_period_with_large_offset,
+      incomplete_four_weekly_with_variance: incomplete_four_weekly_with_variance
+    }
+  end
+
+  def message(name, analyser) # rubocop:disable Metrics/AbcSize
+    insight = {
+      days_between_dates: analyser.days_between_dates,
+      size: analyser.dates.size,
+      median: analyser.days_between_dates.median,
+      range: analyser.days_between_dates.range,
+      day_range: analyser.days.range,
+      slope: analyser.date_slope
+    }
+    dates = analyser.dates.map { |d| d.to_s(:short) }.join(', ')
+    [name, insight, dates].join("\n")
+  end
+
+  def from_sequence(*date_strings)
+    date_strings.each_with_object({}) { |d, h| h[Time.parse(d)] = 10 }
+  end
+
+  def expect_all(data_set, to_be: nil, with_method: nil)
+    data_set.each do |name, data|
+      analyser = described_class.new(data)
+      expect(analyser.__send__(with_method)).to be(to_be), message(name, analyser)
+    end
+  end
+
+  describe '.monthly?' do
+    it 'returns true for each monthly' do
+      expect_all(monthlies, to_be: true, with_method: :monthly?)
+    end
+
+    it 'returns false for each weekly' do
+      expect_all(weeklies, to_be: false, with_method: :monthly?)
+    end
+
+    it 'returns false for each fortnightly' do
+      expect_all(fortnightlies, to_be: false, with_method: :monthly?)
+    end
+
+    it 'returns false for each four weekly' do
+      expect_all(four_weeklies, to_be: false, with_method: :monthly?)
+    end
+  end
+
+  describe '.weekly?' do
+    it 'returns false for each monthly' do
+      expect_all(monthlies, to_be: false, with_method: :weekly?)
+    end
+
+    it 'returns true for each weekly' do
+      expect_all(weeklies, to_be: true, with_method: :weekly?)
+    end
+
+    it 'returns false for each fortnightly' do
+      expect_all(fortnightlies, to_be: false, with_method: :weekly?)
+    end
+
+    it 'returns false for each four weekly' do
+      expect_all(four_weeklies, to_be: false, with_method: :weekly?)
+    end
+
+    it 'returns false for difficulties' do
+      expect_all(difficulties, to_be: false, with_method: :weekly?)
+    end
+  end
+
+  describe '.two_weekly?' do
+    it 'returns false for each monthly' do
+      expect_all(monthlies, to_be: false, with_method: :two_weekly?)
+    end
+
+    it 'returns false for each weekly' do
+      expect_all(weeklies, to_be: false, with_method: :two_weekly?)
+    end
+
+    it 'returns true for each fortnightly' do
+      expect_all(fortnightlies, to_be: true, with_method: :two_weekly?)
+    end
+
+    it 'returns false for each four weekly' do
+      expect_all(four_weeklies, to_be: false, with_method: :two_weekly?)
+    end
+  end
+
+  describe '.four_weekly?' do
+    it 'returns false for each monthly' do
+      expect_all(monthlies, to_be: false, with_method: :four_weekly?)
+    end
+
+    it 'returns false for each weekly' do
+      expect_all(weeklies, to_be: false, with_method: :four_weekly?)
+    end
+
+    it 'returns false for each fortnightly' do
+      expect_all(fortnightlies, to_be: false, with_method: :four_weekly?)
+    end
+
+    it 'returns true for each four weekly' do
+      expect_all(four_weeklies, to_be: true, with_method: :four_weekly?)
+    end
+  end
+end


### PR DESCRIPTION
[Jira AP-783](https://dsdmoj.atlassian.net/browse/AP-783)

Generates sets of time series data of various patterns, and passes them to a new service `PaymentPeriodAnalyser` to determine if it can identify the correct period of payment.

The solution works, but struggles to distinguish between monthly and four-weekly series where there is a lot of variance (more than a couple of days) and the sequence of days is negatively sloped (that is, each day is earlier in the month). That is, _[13-May-19, 14-Jun-19, 15-Jul-19]_ is unlikely to be four weekly because each day is higher through the sequence (positively sloped). But _[16-May-19, 14-Jun-19, 12-Jul-19]_ could be either four weekly or monthly with a two day variance.