### PR TITLE
AP-817 Convert WorkflowManager to use DB

### DIFF
--- a/app/services/workflow_manager.rb
+++ b/app/services/workflow_manager.rb
@@ -1,6 +1,6 @@
 class WorkflowManager
-  def initialize(particulars, workflow)
-    @particulars = particulars
+  def initialize(assessment_id, workflow)
+    @assessment = Assessment.find assessment_id
     @workflow = workflow
     @workflow_terminated = false
   end
@@ -21,7 +21,7 @@ class WorkflowManager
 
   def process_service(step_config:)
     service_class = step_config[:klass]
-    result = service_class.new(@particulars).call
+    result = service_class.new(@assessment).call
     next_step = step_config["#{result}_step".to_sym]
     process_step(step_config: @workflow[next_step], step_name: next_step)
   end

--- a/spec/services/workflow_manager_spec.rb
+++ b/spec/services/workflow_manager_spec.rb
@@ -2,7 +2,8 @@ require 'rails_helper'
 require Rails.root.join 'spec/fixtures/test_workflow.rb'
 
 RSpec.describe WorkflowManager do
-  let(:manager) { described_class.new(particulars, workflow) }
+  let(:assessment) { create :assessment }
+  let(:manager) { described_class.new(assessment.id, workflow) }
   let(:particulars) { double 'particulars' }
   let(:workflow) { TestWorkflow.workflow }
 
@@ -23,6 +24,6 @@ RSpec.describe WorkflowManager do
   end
 
   def expect_service_result(klass, result)
-    expect(klass).to receive(:new).with(particulars).and_return(double(klass, call: result))
+    expect(klass).to receive(:new).with(assessment).and_return(double(klass, call: result))
   end
 end


### PR DESCRIPTION
## Convert WorkflowManager to use DB

[Link to story](https://dsdmoj.atlassian.net/browse/AP-817)

Changed workflow manager to:
 - accept `assessment_id` rather than JSON struct in initializer
 - Call all required services passing in the `Assessment` object rather than the JSON struct

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
