### PR TITLE
AP-641 identify frequency of payments

### DIFF
--- a/app/models/benefit_receipt.rb
+++ b/app/models/benefit_receipt.rb
@@ -6,6 +6,15 @@ class BenefitReceipt < ApplicationRecord
 
   validate :payment_date_cannot_be_in_future
 
+  scope :time_series, -> { pluck(:payment_date, :amount).to_h.transform_keys(&:to_time) }
+
+  scope :payment_pattern, -> do
+    return :no_data unless time_series.present?
+
+    analyser = PaymentPeriodAnalyser.new(time_series)
+    analyser.period_pattern
+  end
+
   def payment_date_cannot_be_in_future
     errors.add(:base, 'Benefit payment date cannot be in the future') if payment_date > Date.today
   end

--- a/app/models/benefit_receipt.rb
+++ b/app/models/benefit_receipt.rb
@@ -1,19 +1,13 @@
 class BenefitReceipt < ApplicationRecord
   extend EnumHash
+  extend PaymentPatternConcern
+  define_payment_pattern
+
   belongs_to :assessment
 
   enum benefit_name: enum_hash_for(:child_benefit, :jobseekers_allowance, :universal_credit)
 
   validate :payment_date_cannot_be_in_future
-
-  scope :time_series, -> { pluck(:payment_date, :amount).to_h.transform_keys(&:to_time) }
-
-  scope :payment_pattern, -> do
-    return :no_data unless time_series.present?
-
-    analyser = PaymentPeriodAnalyser.new(time_series)
-    analyser.period_pattern
-  end
 
   def payment_date_cannot_be_in_future
     errors.add(:base, 'Benefit payment date cannot be in the future') if payment_date > Date.today

--- a/app/models/concerns/payment_pattern_concern.rb
+++ b/app/models/concerns/payment_pattern_concern.rb
@@ -1,0 +1,11 @@
+module PaymentPatternConcern
+  def define_payment_pattern(date_field: :payment_date, currency_field: :amount)
+    scope :time_series, -> { pluck(date_field, currency_field).to_h.transform_keys(&:to_time) }
+
+    define_singleton_method(:payment_pattern) do
+      return :no_data unless time_series.present?
+
+      PaymentPeriodAnalyser.pattern_for time_series
+    end
+  end
+end

--- a/app/models/wage_slip.rb
+++ b/app/models/wage_slip.rb
@@ -1,4 +1,7 @@
 class WageSlip < ApplicationRecord
+  extend PaymentPatternConcern
+  define_payment_pattern currency_field: :gross_pay
+
   belongs_to :assessment
 
   alias_attribute :national_insurance_contribution, :nic

--- a/app/services/date_slope.rb
+++ b/app/services/date_slope.rb
@@ -1,4 +1,7 @@
 class DateSlope
+  MONTH_START_CUTOFF = 10 # Days lower than this are at start of month and suitable for bumping to previous month
+  BEST_MATCH_VARIANCE = 10 # If there is low variance in the range of dates, it is unlikely that they span month end
+
   def self.call(dates)
     new(dates).slope
   end
@@ -22,7 +25,7 @@ class DateSlope
   end
 
   def best_match_days
-    return days if days.range < 10
+    return days if days.range < BEST_MATCH_VARIANCE
 
     if days.standard_deviation <= normalized_days.standard_deviation
       days
@@ -38,7 +41,7 @@ class DateSlope
   def days_at_beginning_bump_to_previous_month
     dates.map do |date|
       day = date.day
-      if day > 10
+      if day > MONTH_START_CUTOFF
         day
       else
         previous_month_length = (date.beginning_of_month - 1.day).day

--- a/app/services/date_slope.rb
+++ b/app/services/date_slope.rb
@@ -60,7 +60,7 @@ class DateSlope
   end
 
   def sum_x
-    coordinates.sum(&:first)
+    @sum_x ||= coordinates.sum(&:first)
   end
 
   def sum_y

--- a/app/services/date_slope.rb
+++ b/app/services/date_slope.rb
@@ -1,0 +1,73 @@
+class DateSlope
+  def self.call(dates)
+    new(dates).slope
+  end
+
+  attr_reader :dates
+
+  def initialize(dates)
+    @dates = dates
+  end
+
+  def slope # rubocop:disable Metrics/AbcSize
+    1.0 * ((size * sum_xy) - (sum_x * sum_y)) / ((size * sum_xx) - (sum_x * sum_x))
+  end
+
+  def days
+    @days ||= DescriptiveStatistics::Stats.new(dates.map(&:day))
+  end
+
+  def normalized_days
+    @normalized_days ||= DescriptiveStatistics::Stats.new(days_at_beginning_bump_to_previous_month)
+  end
+
+  def best_match_days
+    return days if days.range < 10
+
+    if days.standard_deviation <= normalized_days.standard_deviation
+      days
+    else
+      normalized_days
+    end
+  end
+
+  # If day is in first part of month, bump it so it effectively looks like a day in an oversized previous month
+  # So 1st April looks like 32nd of March.
+  # This will convert ['2-May-2019', '30-May-2019', '29-Jun-2019', '28-Jul-2019'], so that it behaves as if it was
+  # ['32-Apr-2019', '30-May-2019', '29-Jun-2019', '28-Jul-2019']
+  def days_at_beginning_bump_to_previous_month
+    dates.map do |date|
+      day = date.day
+      if day > 10
+        day
+      else
+        previous_month_length = (date.beginning_of_month - 1.day).day
+        day + previous_month_length
+      end
+    end
+  end
+
+  def coordinates
+    @coordinates ||= best_match_days.each_with_index.each_with_object({}) { |(n, i), h| h[i] = n }
+  end
+
+  def sum_xy
+    coordinates.sum { |x, y| x * y }
+  end
+
+  def sum_xx
+    coordinates.sum { |x, _y| x * x }
+  end
+
+  def sum_x
+    coordinates.sum(&:first)
+  end
+
+  def sum_y
+    coordinates.sum(&:last)
+  end
+
+  def size
+    @size ||= dates.size
+  end
+end

--- a/app/services/payment_period_analyser.rb
+++ b/app/services/payment_period_analyser.rb
@@ -6,6 +6,15 @@ class PaymentPeriodAnalyser
     @data = data
   end
 
+  def period_pattern
+    return :monthly if monthly?
+    return :weekly if weekly?
+    return :two_weekly if two_weekly?
+    return :four_weekly if four_weekly?
+
+    :unknown
+  end
+
   def monthly?
     return false if dates.size > 4
     return false if days_between_dates.median < 28.5

--- a/app/services/payment_period_analyser.rb
+++ b/app/services/payment_period_analyser.rb
@@ -13,6 +13,10 @@ class PaymentPeriodAnalyser
   LARGE_VARIANCE = 10
   VERY_LARGE_VARIANCE = 19
 
+  def self.pattern_for(data)
+    new(data).period_pattern
+  end
+
   attr_reader :data
 
   def initialize(data)

--- a/app/services/payment_period_analyser.rb
+++ b/app/services/payment_period_analyser.rb
@@ -72,6 +72,8 @@ class PaymentPeriodAnalyser
     false
   end
 
+  # Factors of 7 have a particular significance when analysing weekly sequences of data. Which means patterns
+  # around the numbers 7, 14, 21, and 28 can be used to identify the likely sequence type.
   def around_28(number)
     number.between?(24, 30)
   end

--- a/app/services/payment_period_analyser.rb
+++ b/app/services/payment_period_analyser.rb
@@ -1,5 +1,18 @@
 # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
 class PaymentPeriodAnalyser
+  SIZE_THRESHOLD_WEEKLY = 8 # Threshold above which data size could only match a weekly pattern
+  SIZE_THRESHOLD_MONTHLY = 4 # Threshold above which data size cannot match a monthly pattern
+  SIZE_THRESHOLD_FOUR_WEEKLY = 5 # Threshold above which data size cannot match a four weekly pattern
+
+  MONTHLY_MEDIAN_LIMIT = 28.5 # Below this the median of the number of days between dates is too small for monthly pattern
+  MONTHLY_RANGE_LIMIT = 9 # Monthly data is unlikely to have a large range of days between dates. So above this not monthly pattern
+
+  MONTHLY_SLOPE_LIMIT = { upper: -1.6, lower: -2 }.freeze # Below these limits, slopes better match four weekly than monthly
+
+  SMALL_VARIANCE = 6
+  LARGE_VARIANCE = 10
+  VERY_LARGE_VARIANCE = 19
+
   attr_reader :data
 
   def initialize(data)
@@ -16,26 +29,29 @@ class PaymentPeriodAnalyser
   end
 
   def monthly?
-    return false if dates.size > 4
-    return false if days_between_dates.median < 28.5
-    return false if dates.size == 4 && date_slope < -1.6
-    return false if date_slope < -2
-    return false if days_between_dates.range > 9
+    return false if dates.size > SIZE_THRESHOLD_MONTHLY
+    return false if days_between_dates.median < MONTHLY_MEDIAN_LIMIT
+    # At size threshold, data is more likely to be four weekly so can move slope limit so easier to match to four weekly
+    return false if dates.size == SIZE_THRESHOLD_MONTHLY && date_slope < MONTHLY_SLOPE_LIMIT[:upper]
+    return false if date_slope < MONTHLY_SLOPE_LIMIT[:lower]
+    return false if days_between_dates.range > MONTHLY_RANGE_LIMIT
 
     true
   end
 
   def weekly?
-    return true if dates.size > 8
+    return true if dates.size > SIZE_THRESHOLD_WEEKLY
     return false if around_28(days_between_dates.median) || around_28(days_between_dates.range)
-    return true if days_between_dates.median > 19 && days_between_dates.range > 19 && days.range > 10
+    return true if days_between_dates.median > VERY_LARGE_VARIANCE &&
+                   days_between_dates.range > VERY_LARGE_VARIANCE &&
+                   days.range > LARGE_VARIANCE
 
     false
   end
 
   def two_weekly?
-    return false if dates.size > 8
-    return true if around_14(days_between_dates.median) && days_between_dates.range < 6
+    return false if dates.size > SIZE_THRESHOLD_WEEKLY
+    return true if around_14(days_between_dates.median) && days_between_dates.range < SMALL_VARIANCE
     return true if around_28(days_between_dates.median) && around_28(days_between_dates.range)
     return true if around_7_or_14(days_between_dates.median) && around_14_or_21_or_28(days_between_dates.range)
     return true if around_14_or_21(days_between_dates.median) && around_7_or_14(days_between_dates.range)
@@ -45,15 +61,15 @@ class PaymentPeriodAnalyser
 
   def four_weekly?
     return false if monthly?
-    return false if dates.size > 5
-    return true if around_28(days_between_dates.median) && days_between_dates.range < 6
-    return true if days_between_dates.median > 30 && around_28(days_between_dates.range)
+    return false if dates.size > SIZE_THRESHOLD_FOUR_WEEKLY
+    return true if around_28(days_between_dates.median) && days_between_dates.range < SMALL_VARIANCE
+    return true if days_between_dates.median > MONTHLY_MEDIAN_LIMIT && around_28(days_between_dates.range)
 
     false
   end
 
   def around_28(number)
-    number.between?(26, 30)
+    number.between?(24, 30)
   end
 
   def around_21(number)
@@ -76,30 +92,17 @@ class PaymentPeriodAnalyser
     around_7(number) || around_14(number)
   end
 
+  # :nocov:
+  # Some combinations of test data lead to this check being skipped
   def around_14_or_21_or_28(number)
     around_14(number) || around_21(number) || around_28(number)
   end
+  # :nocov:
 
-  # Weekly sequences tend to have day numbers that reduce through the sequence
+  # Four weekly sequences tend to have day numbers that reduce through the sequence
   # So the greater the negative slope the less likely the data is monthly.
   def date_slope
-    data = dates.map(&:day).each_with_index.each_with_object({}) { |(n, i), h| h[i] = n }
-    size = dates.size
-
-    sum_x = 0
-    sum_y = 0
-    sum_xx = 0
-    sum_xy = 0
-
-    # calculate the sums
-    data.each do |x, y|
-      sum_xy += x * y
-      sum_xx += x * x
-      sum_x  += x
-      sum_y  += y
-    end
-
-    1.0 * ((size * sum_xy) - (sum_x * sum_y)) / ((size * sum_xx) - (sum_x * sum_x))
+    @date_slope ||= DateSlope.call(dates)
   end
 
   def time_series_calculator

--- a/spec/models/benefit_receipt_spec.rb
+++ b/spec/models/benefit_receipt_spec.rb
@@ -1,0 +1,64 @@
+require 'rails_helper'
+
+RSpec.describe BenefitReceipt, type: :model do
+  let!(:dates) { [4, 8, 12, 16].map { |n| n.weeks.ago } }
+  let(:assessment) { create :assessment }
+  let!(:benefit_receipts) do
+    dates.map { |date| create :benefit_receipt, payment_date: date, assessment: assessment }
+  end
+  let(:time_series) do
+    benefit_receipts.each_with_object({}) { |b, h| h[b.payment_date.to_time] = b.amount }
+  end
+
+  describe 'time_series' do
+    it 'matches expected time series' do
+      expect(assessment.benefit_receipts.time_series).to eq(time_series)
+    end
+  end
+
+  describe 'payment_period' do
+    it 'matches date pattern' do
+      expect(assessment.benefit_receipts.payment_pattern).to eq(:four_weekly)
+    end
+
+    context 'with weekly dates' do
+      let!(:dates) { (1..14).map { |n| n.weeks.ago } }
+
+      it 'returns :weekly' do
+        expect(assessment.benefit_receipts.payment_pattern).to eq(:weekly)
+      end
+    end
+
+    context 'with two weekly dates' do
+      let!(:dates) { (1..14).step(2).map { |n| n.weeks.ago } }
+
+      it 'returns :two_weekly' do
+        expect(assessment.benefit_receipts.payment_pattern).to eq(:two_weekly)
+      end
+    end
+
+    context 'with monthly dates' do
+      let!(:dates) { (1..3).map { |n| n.months.ago } }
+
+      it 'returns :monthly' do
+        expect(assessment.benefit_receipts.payment_pattern).to eq(:monthly)
+      end
+    end
+
+    context 'with odd weekly dates' do
+      let!(:dates) { [2.months.ago, 15.days.ago] }
+
+      it 'returns :unknown' do
+        expect(assessment.benefit_receipts.payment_pattern).to eq(:unknown)
+      end
+    end
+
+    context 'with no benefit receipts' do
+      let!(:benefit_receipts) { nil }
+
+      it 'returns nil' do
+        expect(assessment.benefit_receipts.payment_pattern).to eq(:no_data)
+      end
+    end
+  end
+end

--- a/spec/models/wage_slip_spec.rb
+++ b/spec/models/wage_slip_spec.rb
@@ -1,32 +1,31 @@
 require 'rails_helper'
 
-RSpec.describe BenefitReceipt, type: :model do
+RSpec.describe WageSlip, type: :model do
   let!(:dates) { [4, 8, 12, 16].map { |n| n.weeks.ago } }
   let(:assessment) { create :assessment }
-  let!(:benefit_receipts) do
-    dates.map { |date| create :benefit_receipt, payment_date: date, assessment: assessment }
+  let!(:wage_slips) do
+    dates.map { |date| create :wage_slip, payment_date: date, assessment: assessment }
   end
-  let!(:other_benefit_receipt) { create :benefit_receipt }
   let(:time_series) do
-    benefit_receipts.each_with_object({}) { |b, h| h[b.payment_date.to_time] = b.amount }
+    wage_slips.each_with_object({}) { |w, h| h[w.payment_date.to_time] = w.gross_pay }
   end
 
   describe 'time_series' do
     it 'matches expected time series' do
-      expect(assessment.benefit_receipts.time_series).to eq(time_series)
+      expect(assessment.wage_slips.time_series).to eq(time_series)
     end
   end
 
   describe 'payment_period' do
     it 'matches date pattern' do
-      expect(assessment.benefit_receipts.payment_pattern).to eq(:four_weekly)
+      expect(assessment.wage_slips.payment_pattern).to eq(:four_weekly)
     end
 
     context 'with weekly dates' do
       let!(:dates) { (1..14).map { |n| n.weeks.ago } }
 
       it 'returns :weekly' do
-        expect(assessment.benefit_receipts.payment_pattern).to eq(:weekly)
+        expect(assessment.wage_slips.payment_pattern).to eq(:weekly)
       end
     end
 
@@ -34,7 +33,7 @@ RSpec.describe BenefitReceipt, type: :model do
       let!(:dates) { (1..14).step(2).map { |n| n.weeks.ago } }
 
       it 'returns :two_weekly' do
-        expect(assessment.benefit_receipts.payment_pattern).to eq(:two_weekly)
+        expect(assessment.wage_slips.payment_pattern).to eq(:two_weekly)
       end
     end
 
@@ -42,7 +41,7 @@ RSpec.describe BenefitReceipt, type: :model do
       let!(:dates) { (1..3).map { |n| n.months.ago } }
 
       it 'returns :monthly' do
-        expect(assessment.benefit_receipts.payment_pattern).to eq(:monthly)
+        expect(assessment.wage_slips.payment_pattern).to eq(:monthly)
       end
     end
 
@@ -50,15 +49,15 @@ RSpec.describe BenefitReceipt, type: :model do
       let!(:dates) { [2.months.ago, 15.days.ago] }
 
       it 'returns :unknown' do
-        expect(assessment.benefit_receipts.payment_pattern).to eq(:unknown)
+        expect(assessment.wage_slips.payment_pattern).to eq(:unknown)
       end
     end
 
     context 'with no benefit receipts' do
-      let!(:benefit_receipts) { nil }
+      let!(:wage_slips) { nil }
 
       it 'returns nil' do
-        expect(assessment.benefit_receipts.payment_pattern).to eq(:no_data)
+        expect(assessment.wage_slips.payment_pattern).to eq(:no_data)
       end
     end
   end

--- a/spec/services/date_slope_spec.rb
+++ b/spec/services/date_slope_spec.rb
@@ -1,0 +1,28 @@
+require 'rails_helper'
+
+RSpec.describe DateSlope do
+  let(:days) { ['23-May-19', '21-May-19', '19-May-19'] }
+  let(:dates) { days.map(&:to_time) }
+
+  subject { described_class.call(dates) }
+
+  describe '.call' do
+    it 'returns the slope' do
+      expect(subject).to eq(-2)
+    end
+
+    context 'with a positive slope' do
+      let(:days) { ['20-May-19', '21-May-19', '22-May-19'] }
+      it 'returns a positive slope' do
+        expect(subject).to eq(1)
+      end
+    end
+
+    context 'across month boundary' do
+      let(:days) { ['1-May-2019', '30-May-2019', '29-Jun-2019', '28-Jul-2019'] }
+      it 'adjusts for month end and returns a negative slope' do
+        expect(subject).to eq(-1)
+      end
+    end
+  end
+end

--- a/spec/services/payment_period_analyser_spec.rb
+++ b/spec/services/payment_period_analyser_spec.rb
@@ -57,13 +57,17 @@ RSpec.describe PaymentPeriodAnalyser do
   let(:midweek_four_weely_with_variance) { generator.call period: :four_weekly, start_at: (Time.now.beginning_of_week + 2.days), day_offset: 1 }
   let(:incomplete_four_weekly) { every_fourth_monday.to_a.sample(3).to_h }
   let(:four_weekly_near_month_end) { generator.call period: :four_weekly, start_at: (Time.now.end_of_month - 1.day) }
+  let(:four_weely_across_month_end) { from_sequence '1-May-2019', '30-May-2019', '25-Jun-2019', '24-Jul-2019' }
+  let(:incomplte_four_weekly_accross_month_end) { from_sequence '2-May-2019', '25-Jun-2019', '25-Jul-2019' }
 
   let(:four_weeklies) do
     {
       every_fourth_monday: every_fourth_monday,
       midweek_four_weely_with_variance: midweek_four_weely_with_variance,
       incomplete_four_weekly: incomplete_four_weekly,
-      four_weekly_near_month_end: four_weekly_near_month_end
+      four_weekly_near_month_end: four_weekly_near_month_end,
+      four_weely_across_month_end: four_weely_across_month_end,
+      incomplte_four_weekly_accross_month_end: incomplte_four_weekly_accross_month_end
     }
   end
 
@@ -100,7 +104,16 @@ RSpec.describe PaymentPeriodAnalyser do
     end
   end
 
-  describe '.monthly?' do
+  describe '#period_pattern' do
+    let(:time_series) { first_day_of_month }
+    subject { described_class.new(time_series).period_pattern }
+
+    it 'returns matching label' do
+      expect(subject).to eq(:monthly)
+    end
+  end
+
+  describe '#monthly?' do
     it 'returns true for each monthly' do
       expect_all(monthlies, to_be: true, with_method: :monthly?)
     end
@@ -118,7 +131,7 @@ RSpec.describe PaymentPeriodAnalyser do
     end
   end
 
-  describe '.weekly?' do
+  describe '#weekly?' do
     it 'returns false for each monthly' do
       expect_all(monthlies, to_be: false, with_method: :weekly?)
     end
@@ -140,7 +153,7 @@ RSpec.describe PaymentPeriodAnalyser do
     end
   end
 
-  describe '.two_weekly?' do
+  describe '#two_weekly?' do
     it 'returns false for each monthly' do
       expect_all(monthlies, to_be: false, with_method: :two_weekly?)
     end
@@ -158,7 +171,7 @@ RSpec.describe PaymentPeriodAnalyser do
     end
   end
 
-  describe '.four_weekly?' do
+  describe '#four_weekly?' do
     it 'returns false for each monthly' do
       expect_all(monthlies, to_be: false, with_method: :four_weekly?)
     end


### PR DESCRIPTION
[Jira AP-641](https://dsdmoj.atlassian.net/browse/AP-641)

This adds a `payment_pattern` class method to `BenefitReceipt` and `WageSlip`, together with a `time_series` scope option. With this in place, the payment patterns for an assessment can be determined via:

- `assessment.benefit_receipts.payment_pattern`
- `assessment.wage_slips.payment_pattern`

`payment_pattern` returns one of `:monthly`, `:weekly`, `:two_weekly`, `:four_weekly`, `:unknown` depending on the sequence of payment dates.

Also the slope calculation has been split out from `PaymentPeriodAnalyser` and a system added that allows better analysis of data sequences that straddle the month end. Also constants have been added to `PaymentPeriodAnalyser` to aid adjustment of the values at a later date. 