### PR TITLE
AP-785 Amend LiquidCapitalAssessment service

### DIFF
--- a/app/models/assessment.rb
+++ b/app/models/assessment.rb
@@ -13,4 +13,5 @@ class Assessment < ApplicationRecord
   has_many :properties
   has_many :vehicles
   has_many :wage_slips
+  has_one :result
 end

--- a/app/models/result.rb
+++ b/app/models/result.rb
@@ -1,0 +1,5 @@
+class Result < ActiveRecord::Base
+  after_initialize do
+    self.details = {} if details.nil?
+  end
+end

--- a/app/services/assessment_creation_service.rb
+++ b/app/services/assessment_creation_service.rb
@@ -27,6 +27,10 @@ class AssessmentCreationService < BaseCreationService
   private
 
   def new_assessment
-    @new_assessment ||= Assessment.create(assessment_hash)
+    if @new_assessment.nil?
+      @new_assessment = Assessment.create(assessment_hash)
+      @new_assessment.result = Result.new(state: 'pending')
+    end
+    @new_assessment
   end
 end

--- a/app/services/base_workflow_service.rb
+++ b/app/services/base_workflow_service.rb
@@ -8,4 +8,8 @@ class BaseWorkflowService
   def applicant
     @applicant ||= @assessment.applicant
   end
+
+  def bank_accounts
+    @bank_accounts ||= @assessment.bank_accounts
+  end
 end

--- a/app/services/workflow_service/liquid_capital_assessment.rb
+++ b/app/services/workflow_service/liquid_capital_assessment.rb
@@ -1,12 +1,8 @@
 module WorkflowService
-  class LiquidCapitalAssessment
-    def initialize(assessment)
-      @assessment = assessment
-    end
-
+  class LiquidCapitalAssessment < BaseWorkflowService
     def call
       total_liquid_capital = 0.0
-      @assessment.bank_accounts.each do |acct|
+      bank_accounts.each do |acct|
         total_liquid_capital += acct.lowest_balance if acct.lowest_balance.positive?
       end
       total_liquid_capital.round(2)

--- a/app/services/workflow_service/liquid_capital_assessment.rb
+++ b/app/services/workflow_service/liquid_capital_assessment.rb
@@ -1,7 +1,7 @@
 module WorkflowService
   class LiquidCapitalAssessment
-    def initialize(assessment_id)
-      @assessment = Assessment.find assessment_id
+    def initialize(assessment)
+      @assessment = assessment
     end
 
     def call

--- a/app/services/workflow_service/liquid_capital_assessment.rb
+++ b/app/services/workflow_service/liquid_capital_assessment.rb
@@ -1,12 +1,12 @@
 module WorkflowService
   class LiquidCapitalAssessment
-    def initialize(request)
-      @request = request
+    def initialize(assessment_id)
+      @assessment = Assessment.find assessment_id
     end
 
     def call
       total_liquid_capital = 0.0
-      @request.bank_accounts.each do |acct|
+      @assessment.bank_accounts.each do |acct|
         total_liquid_capital += acct.lowest_balance if acct.lowest_balance.positive?
       end
       total_liquid_capital.round(2)

--- a/db/migrate/20190729103203_create_results.rb
+++ b/db/migrate/20190729103203_create_results.rb
@@ -1,0 +1,10 @@
+class CreateResults < ActiveRecord::Migration[5.2]
+  def change
+    create_table :results do |t|
+      t.uuid :assessment_id
+      t.string :state
+      t.jsonb :details
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_07_10_105635) do
+ActiveRecord::Schema.define(version: 2019_07_29_103203) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -101,6 +101,14 @@ ActiveRecord::Schema.define(version: 2019_07_10_105635) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["assessment_id"], name: "index_properties_on_assessment_id"
+  end
+
+  create_table "results", force: :cascade do |t|
+    t.uuid "assessment_id"
+    t.string "state"
+    t.jsonb "details"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "statuses", force: :cascade do |t|

--- a/spec/services/assessment_creation_service_spec.rb
+++ b/spec/services/assessment_creation_service_spec.rb
@@ -23,6 +23,23 @@ RSpec.describe AssessmentCreationService do
       expect { subject.success? }.to change { Assessment.count }.by(1)
     end
 
+    it 'creates a Result record' do
+      expect { subject.success? }.to change { Result.count }.by(1)
+    end
+
+    context 'result record' do
+      before { subject.success? }
+      let(:result) { Result.first }
+
+      it 'creates a pending Result record' do
+        expect(result.state).to eq 'pending'
+      end
+
+      it 'creates an empty details hash' do
+        expect(result.details).to eq({})
+      end
+    end
+
     it 'has no errors' do
       expect(subject.errors).to be_empty
     end

--- a/spec/services/workflow_service/liquid_capital_assessment_spec.rb
+++ b/spec/services/workflow_service/liquid_capital_assessment_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 module WorkflowService
   RSpec.describe LiquidCapitalAssessment do
     let(:assessment) { create :assessment }
-    let(:service) { described_class.new(assessment.id) }
+    let(:service) { described_class.new(assessment) }
 
     context 'all positive supplied' do
       it 'adds them all together' do

--- a/spec/services/workflow_service/liquid_capital_assessment_spec.rb
+++ b/spec/services/workflow_service/liquid_capital_assessment_spec.rb
@@ -2,57 +2,58 @@ require 'rails_helper'
 
 module WorkflowService
   RSpec.describe LiquidCapitalAssessment do
-    let(:service) { described_class.new(liquid_capital_request) }
+    let(:assessment) { create :assessment }
+    let(:service) { described_class.new(assessment.id) }
 
     context 'all positive supplied' do
-      let(:liquid_capital_request) { open_structify(all_positive_bank_accounts) }
       it 'adds them all together' do
+        assessment.bank_accounts << all_positive_bank_accounts
         expect(service.call).to eq 136.87
       end
     end
 
     context 'mixture of positive and negative supplied' do
-      let(:liquid_capital_request) { open_structify(mixture_of_negative_and_positive_bank_accounts) }
       it 'ignores negative values' do
+        assessment.bank_accounts << mixture_of_negative_and_positive_bank_accounts
         expect(service.call).to eq 35.88
       end
     end
 
     context 'all negative supplied' do
-      let(:liquid_capital_request) { open_structify(all_negative_bank_accounts) }
       it 'ignores negative values' do
+        assessment.bank_accounts << all_negative_bank_accounts
+        expect(service.call).to eq 0.0
+      end
+    end
+
+    context 'no values supplied' do
+      it 'returns 0' do
         expect(service.call).to eq 0.0
       end
     end
 
     def all_positive_bank_accounts
-      {
-        bank_accounts: [
-          { account_name: 'Account 1', lowest_balance: 35.66 },
-          { account_name: 'Account 2', lowest_balance: 100.99 },
-          { account_name: 'Account 3', lowest_balance: 0.22 }
-        ]
-      }
+      [
+        BankAccount.new(assessment_id: assessment.id, name: 'Account 1', lowest_balance: 35.66),
+        BankAccount.new(assessment_id: assessment.id, name: 'Account 2', lowest_balance: 100.99),
+        BankAccount.new(assessment_id: assessment.id, name: 'Account 3', lowest_balance: 0.22)
+      ]
     end
 
     def mixture_of_negative_and_positive_bank_accounts
-      {
-        bank_accounts: [
-          { account_name: 'Account 1', lowest_balance: 35.66 },
-          { account_name: 'Account 2', lowest_balance: -100.99 },
-          { account_name: 'Account 3', lowest_balance: 0.22 }
-        ]
-      }
+      [
+        BankAccount.new(assessment_id: assessment.id, name: 'Account 1', lowest_balance: 35.66),
+        BankAccount.new(assessment_id: assessment.id, name: 'Account 2', lowest_balance: -100.99),
+        BankAccount.new(assessment_id: assessment.id, name: 'Account 3', lowest_balance: 0.22)
+      ]
     end
 
     def all_negative_bank_accounts
-      {
-        bank_accounts: [
-          { account_name: 'Account 1', lowest_balance: -35.66 },
-          { account_name: 'Account 2', lowest_balance: - 100.99 },
-          { account_name: 'Account 3', lowest_balance: -0.22 }
-        ]
-      }
+      [
+        BankAccount.new(assessment_id: assessment.id, name: 'Account 1', lowest_balance: -35.66),
+        BankAccount.new(assessment_id: assessment.id, name: 'Account 2', lowest_balance: -100.99),
+        BankAccount.new(assessment_id: assessment.id, name: 'Account 3', lowest_balance: -0.22)
+      ]
     end
   end
 end


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-785)

Refactor the `LiquidCapitalAssessment` service to use data from the database and not the JSON struct.

- Accept `assessment_id` rather than JSON struct in `initializer`
- Use the `Assessment` object to retrieve `BankAccount` data

This PR doesn't change the `DisposableCapitalAssessment` service which calls `LiquidCapitalAssessment`. That will be handled in a separate story (AP-784).

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
