### PR TITLE
AP-786 Amend NonLiquidCapitalAssessment service

### DIFF
--- a/app/models/dated_struct.rb
+++ b/app/models/dated_struct.rb
@@ -13,9 +13,12 @@ class DatedStruct < OpenStruct
     end
   end
 
+  # TODO: remove this method (or even the whole class) once all reference to it has been removed from other services
+  # :nocov:
   def []=(name, value)
     modifiable?[new_ostruct_member!(name)] = value_or_time(value)
   end
+  # :nocov:
 
   # OpenStruct will normally serialize to JSON with an intermediate key 'table'.
   # DatedStruct will only do it if created with option {serialize_as_open_struct: true}

--- a/app/services/base_workflow_service.rb
+++ b/app/services/base_workflow_service.rb
@@ -13,6 +13,10 @@ class BaseWorkflowService
     @bank_accounts ||= @assessment.bank_accounts
   end
 
+  def non_liquid_assets
+    @non_liquid_assets ||= @assessment.non_liquid_assets
+  end
+
   def result
     @result ||= @assessment.result
   end

--- a/app/services/workflow_service/non_liquid_capital_assessment.rb
+++ b/app/services/workflow_service/non_liquid_capital_assessment.rb
@@ -1,12 +1,8 @@
 module WorkflowService
-  class NonLiquidCapitalAssessment
-    def initialize(assessment_id)
-      @assessment = Assessment.find assessment_id
-    end
-
+  class NonLiquidCapitalAssessment < BaseWorkflowService
     def call
       total_value = 0.0
-      @assessment.non_liquid_assets.each do |item|
+      non_liquid_assets.each do |item|
         total_value += item.value
       end
       total_value.round(2)

--- a/app/services/workflow_service/non_liquid_capital_assessment.rb
+++ b/app/services/workflow_service/non_liquid_capital_assessment.rb
@@ -1,12 +1,12 @@
 module WorkflowService
   class NonLiquidCapitalAssessment
-    def initialize(request)
-      @request = request
+    def initialize(assessment_id)
+      @assessment = Assessment.find assessment_id
     end
 
     def call
       total_value = 0.0
-      @request&.each do |item|
+      @assessment.non_liquid_assets.each do |item|
         total_value += item.value
       end
       total_value.round(2)

--- a/spec/services/workflow_service/non_liquid_capital_assessment_spec.rb
+++ b/spec/services/workflow_service/non_liquid_capital_assessment_spec.rb
@@ -2,24 +2,17 @@ require 'rails_helper'
 
 module WorkflowService
   RSpec.describe NonLiquidCapitalAssessment do
-    let(:service) { described_class.new(non_liquid_capital_request) }
+    let(:assessment) { create :assessment }
+    let(:service) { described_class.new(assessment.id) }
 
     context 'all positive supplied' do
-      let(:non_liquid_capital_request) { open_structify(non_liquid_capital) }
       it 'adds them all together' do
+        assessment.non_liquid_assets << non_liquid_capital
         expect(service.call).to eq 179_664.44
       end
     end
 
-    context 'empty array supplied' do
-      let(:non_liquid_capital_request) { open_structify([]) }
-      it 'returns zero' do
-        expect(service.call).to eq 0.0
-      end
-    end
-
-    context 'nil supplied' do
-      let(:non_liquid_capital_request) { open_structify(nil) }
+    context 'no values supplied' do
       it 'returns zero' do
         expect(service.call).to eq 0.0
       end
@@ -27,18 +20,9 @@ module WorkflowService
 
     def non_liquid_capital
       [
-        {
-          item_description: 'trust_fund',
-          value: 100_000.0
-        },
-        {
-          item_description: 'Ming Vase',
-          value: 30_000
-        },
-        {
-          item_description: 'Portfolie of stocks and shares',
-          value: 49_664.44
-        }
+        NonLiquidAsset.new(assessment_id: assessment.id, description: 'trust_fund', value: 100_000.0),
+        NonLiquidAsset.new(assessment_id: assessment.id, description: 'Ming Vase', value: 30_000.0),
+        NonLiquidAsset.new(assessment_id: assessment.id, description: 'Portfolie of stocks and shares', value: 49_664.44)
       ]
     end
   end

--- a/spec/services/workflow_service/non_liquid_capital_assessment_spec.rb
+++ b/spec/services/workflow_service/non_liquid_capital_assessment_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 module WorkflowService
   RSpec.describe NonLiquidCapitalAssessment do
     let(:assessment) { create :assessment }
-    let(:service) { described_class.new(assessment.id) }
+    let(:service) { described_class.new(assessment) }
 
     context 'all positive supplied' do
       it 'adds them all together' do


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-785)

Refactor the `NonLiquidCapitalAssessment` service to use data from the database and not the JSON struct.

- Accept `assessment_id` rather than JSON struct in `initializer`
- Use the `Assessment` object to retrieve `non_liquid_assets` data

This PR doesn't change the DisposableCapitalAssessment service which calls NonLiquidCapitalAssessment. That will be handled in a separate story (AP-784).

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
