### PR TITLE
AP-788 Amend PropertyAssessment service

### DIFF
--- a/app/services/base_workflow_service.rb
+++ b/app/services/base_workflow_service.rb
@@ -20,4 +20,12 @@ class BaseWorkflowService
   def result
     @result ||= @assessment.result
   end
+
+  def main_home
+    @main_home ||= @assessment.properties.find_by(main_home: true)
+  end
+
+  def additional_properties
+    @additional_properties ||= @assessment.properties.where(main_home: false)
+  end
 end

--- a/spec/factories/property_factory.rb
+++ b/spec/factories/property_factory.rb
@@ -7,5 +7,21 @@ FactoryBot.define do
     percentage_owned { Faker::Number.decimal(1, 2).to_f }
     main_home { [true, false].sample }
     shared_with_housing_assoc { [true, false].sample }
+
+    trait :main_home do
+      main_home { true }
+    end
+
+    trait :additional_property do
+      main_home { false }
+    end
+
+    trait :shared_ownership do
+      shared_with_housing_assoc { true }
+    end
+
+    trait :not_shared_ownership do
+      shared_with_housing_assoc { false }
+    end
   end
 end


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-788)

This service was written to use values from the original large JSON payload. We have now converted the controllers to store values in database records, so refactor to use the database records and not the JSON struct.

* Accept `assessment` rather than JSON struct in `initializer`
* Use the `Assessment` object to retrieve `property` data
* Refactor tests 
* This PR doesn't change the `DisposableCapitalAssessment` service which calls `PropertyAssessment`. That will be handled in a separate story (AP-784).

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
