### PR TITLE
AP-787 Convert Pensioner Disregard service to use database

### DIFF
--- a/app/models/result.rb
+++ b/app/models/result.rb
@@ -1,4 +1,6 @@
 class Result < ActiveRecord::Base
+  belongs_to :assessment
+
   after_initialize do
     self.details = {} if details.nil?
   end

--- a/app/services/base_workflow_service.rb
+++ b/app/services/base_workflow_service.rb
@@ -12,4 +12,8 @@ class BaseWorkflowService
   def bank_accounts
     @bank_accounts ||= @assessment.bank_accounts
   end
+
+  def result
+    @result ||= @assessment.result
+  end
 end

--- a/app/services/workflow_service/pensioner_capital_disregard.rb
+++ b/app/services/workflow_service/pensioner_capital_disregard.rb
@@ -1,11 +1,5 @@
 module WorkflowService
-  class PensionerCapitalDisregard
-    def initialize(particulars)
-      @particulars = particulars
-      @submission_date = @particulars.request.meta_data.submission_date
-      @thresholds = Threshold.value_for(:pensioner_capital_disregard, at: @submission_date)
-    end
-
+  class PensionerCapitalDisregard < BaseWorkflowService
     def value
       return 0 unless pensioner?
 
@@ -14,6 +8,10 @@ module WorkflowService
       raise 'No disposable income specified for non-passported applicant' if disposable_income.nil?
 
       disregard_value(disposable_income)
+    end
+
+    def thresholds
+      @thresholds ||= Threshold.value_for(:pensioner_capital_disregard, at: @submission_date)
     end
 
     private
@@ -27,27 +25,29 @@ module WorkflowService
     end
 
     def minimum_pensioner_age
-      @thresholds[:minimum_age_in_years]
+      thresholds[:minimum_age_in_years]
     end
 
     def applicant_dob
-      @particulars.request.applicant.date_of_birth
+      applicant.date_of_birth
     end
 
     def passported?
-      WorkflowPredicate::DeterminePassported.new(@particulars).call
+      WorkflowPredicate::DeterminePassported.new(@assessment).call
     end
 
     def passported_value
-      @thresholds[:passported]
+      thresholds[:passported]
     end
 
     def disposable_income
-      @particulars.response.details.income.monthly_disposable_income
+      return nil if result.details['income'].nil?
+
+      result.details['income']['monthly_disposable_income']
     end
 
     def disregard_value(income)
-      income_vals = @thresholds[:monthly_income_values]
+      income_vals = thresholds[:monthly_income_values]
       threshold = income_vals.keys.select { |k| income >= k }.max
       income_vals[threshold]
     end

--- a/config/thresholds/8-Apr-2019.yml
+++ b/config/thresholds/8-Apr-2019.yml
@@ -10,6 +10,7 @@ disposable_income_upper: 50000
 capital_lower: 1
 capital_upper: 30000
 pensioner_capital_disregard:
+  minimum_age_in_years: 60
   passported: 100_000
   # capital to disregard if monthly disposable income (excluding income derived from capital) is below these figures
   monthly_income_values:

--- a/config/thresholds/8-Apr-2020.yml
+++ b/config/thresholds/8-Apr-2020.yml
@@ -8,6 +8,7 @@ disposable_income_upper: 20000
 capital_lower: 5
 capital_upper: 20000
 pensioner_capital_disregard:
+  minimum_age_in_years: 60
   passported: 100_000
   # capital to disregard if monthly disposable income (excluding income derived from capital) is below these figures
   monthly_income_values:

--- a/db/migrate/20190729100752_create_results.rb
+++ b/db/migrate/20190729100752_create_results.rb
@@ -1,0 +1,8 @@
+class CreateResults < ActiveRecord::Migration[5.2]
+  def change
+    create_table :results do |t|
+      t.uuid :assessment_id
+      t.jsonb :result_hash
+    end
+  end
+end

--- a/db/migrate/20190729100752_create_results.rb
+++ b/db/migrate/20190729100752_create_results.rb
@@ -1,8 +1,0 @@
-class CreateResults < ActiveRecord::Migration[5.2]
-  def change
-    create_table :results do |t|
-      t.uuid :assessment_id
-      t.jsonb :result_hash
-    end
-  end
-end

--- a/spec/factories/applicant_factory.rb
+++ b/spec/factories/applicant_factory.rb
@@ -9,5 +9,13 @@ FactoryBot.define do
     trait :with_qualifying_benfits do
       receives_qualifying_benefit { true }
     end
+
+    trait :under_pensionable_age do
+      date_of_birth { 59.years.ago.to_date }
+    end
+
+    trait :over_pensionable_age do
+      date_of_birth { 61.years.ago.to_date }
+    end
   end
 end

--- a/spec/factories/result_factory.rb
+++ b/spec/factories/result_factory.rb
@@ -1,0 +1,17 @@
+FactoryBot.define do
+  factory :result do
+    assessment
+
+    transient do
+      disposable_monthly_income { nil }
+    end
+
+    after(:create) do |result, evaluator|
+      if evaluator.disposable_monthly_income.present?
+        result.details['income'] = {} if result.details['income'].nil?
+        result.details['income']['monthly_disposable_income'] = evaluator.disposable_monthly_income
+      end
+      result.save!
+    end
+  end
+end

--- a/spec/services/date_slope_spec.rb
+++ b/spec/services/date_slope_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe DateSlope do
-  let(:days) { ['23-May-19', '21-May-19', '19-May-19'] }
+  let(:days) { %w[23-May-19 21-May-19 19-May-19] }
   let(:dates) { days.map(&:to_time) }
 
   subject { described_class.call(dates) }
@@ -12,14 +12,14 @@ RSpec.describe DateSlope do
     end
 
     context 'with a positive slope' do
-      let(:days) { ['20-May-19', '21-May-19', '22-May-19'] }
+      let(:days) { %w[20-May-19 21-May-19 22-May-19] }
       it 'returns a positive slope' do
         expect(subject).to eq(1)
       end
     end
 
     context 'across month boundary' do
-      let(:days) { ['1-May-2019', '30-May-2019', '29-Jun-2019', '28-Jul-2019'] }
+      let(:days) { %w[1-May-2019 30-May-2019 29-Jun-2019 28-Jul-2019] }
       it 'adjusts for month end and returns a negative slope' do
         expect(subject).to eq(-1)
       end

--- a/spec/services/workflow_service/pensioner_capital_disregard_spec.rb
+++ b/spec/services/workflow_service/pensioner_capital_disregard_spec.rb
@@ -2,16 +2,13 @@ require 'rails_helper'
 
 module WorkflowService
   RSpec.describe PensionerCapitalDisregard do
-    let(:service) { described_class.new(particulars) }
+    let(:service) { described_class.new(assessment) }
     let(:request_hash) { AssessmentRequestFixture.ruby_hash }
-    let(:assessment) { create :assessment, request_payload: request_hash.to_json }
-    let(:particulars) { AssessmentParticulars.new(assessment) }
+    let(:assessment) { create :assessment, applicant: applicant }
 
-    xdescribe '#value' do
+    describe '#value' do
       context 'not a pensioner' do
-        before do
-          particulars.request.applicant.date_of_birth = 59.years.ago.to_date
-        end
+        let(:applicant) { create :applicant, :under_pensionable_age }
         it 'returns zero' do
           expect(service.value).to eq 0.0
         end
@@ -19,65 +16,55 @@ module WorkflowService
 
       context 'a pensioner' do
         context 'passported' do
-          before do
-            particulars.request.applicant.receives_qualifying_benefit = true
-          end
+          let(:applicant) { create :applicant, :with_qualifying_benfits, :over_pensionable_age }
+          # before do
+          #   particulars.request.applicant.receives_qualifying_benefit = true
+          # end
           it 'returns the passported value' do
             expect(service.value).to eq 100_000.0
           end
         end
 
         context 'un-passported' do
-          before do
-            particulars.request.applicant.receives_qualifying_benefit = false
-          end
+          let(:applicant) { create :applicant, :over_pensionable_age }
 
           context 'monthly income above 315' do
-            before do
-              particulars.response.details.income.monthly_disposable_income = 315.01
-            end
+            let!(:result) { create :result, assessment: assessment, disposable_monthly_income: 315.01 }
             it 'returns zero' do
               expect(service.value).to eq 0
             end
           end
 
           context 'monthly income 315' do
-            before do
-              particulars.response.details.income.monthly_disposable_income = 315.0
-            end
+            let!(:result) { create :result, assessment: assessment, disposable_monthly_income: 315.0 }
             it 'returns 10_000' do
               expect(service.value).to eq 10_000
             end
           end
 
           context 'monthly_income 314.99' do
-            before do
-              particulars.response.details.income.monthly_disposable_income = 314.99
-            end
-            it 'returns 20_000' do
+            let!(:result) { create :result, assessment: assessment, disposable_monthly_income: 314.99 }
+            it 'returns 10_000' do
               expect(service.value).to eq 10_000
             end
           end
 
           context 'monthly_income 52' do
-            before do
-              particulars.response.details.income.monthly_disposable_income = 52
-            end
+            let!(:result) { create :result, assessment: assessment, disposable_monthly_income: 52 }
             it 'returns 80_000' do
               expect(service.value).to eq 80_000
             end
           end
 
           context 'monthly_income 0' do
+            let!(:result) { create :result, assessment: assessment, disposable_monthly_income: 0 }
             it 'returns 100_000' do
               expect(service.value).to eq 100_000
             end
           end
 
           context 'monthly income not set' do
-            before do
-              particulars.response.details.income.delete_field(:monthly_disposable_income)
-            end
+            let!(:result) { create :result, assessment: assessment }
             it 'raises' do
               expect {
                 service.value

--- a/spec/services/workflow_service/pensioner_capital_disregard_spec.rb
+++ b/spec/services/workflow_service/pensioner_capital_disregard_spec.rb
@@ -17,9 +17,6 @@ module WorkflowService
       context 'a pensioner' do
         context 'passported' do
           let(:applicant) { create :applicant, :with_qualifying_benfits, :over_pensionable_age }
-          # before do
-          #   particulars.request.applicant.receives_qualifying_benefit = true
-          # end
           it 'returns the passported value' do
             expect(service.value).to eq 100_000.0
           end


### PR DESCRIPTION
## Convert Pensioner Disregard service to use database

[Link to story](https://dsdmoj.atlassian.net/browse/AP-787)

Converted the service to use `Assessment` and `Applicant` database records and record result in `Result` database records, rather than the large JSON struct

## Checklist

Before you ask people to review this PR:

- [ ] Tests and rubocop should be passing: `bundle exec rake`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [ ] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [ ] The PR description should say what you changed and why, with a link to the JIRA story.
- [ ] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
