### PR TITLE
Ap 789 vehicle assessment service db

### DIFF
--- a/app/services/base_workflow_service.rb
+++ b/app/services/base_workflow_service.rb
@@ -28,4 +28,8 @@ class BaseWorkflowService
   def additional_properties
     @additional_properties ||= @assessment.properties.where(main_home: false)
   end
+
+  def vehicles
+    @vehicles ||= @assessment.vehicles
+  end
 end

--- a/app/services/workflow_service/vehicle_assessment.rb
+++ b/app/services/workflow_service/vehicle_assessment.rb
@@ -1,23 +1,21 @@
 module WorkflowService
-  class VehicleAssessment
-    def initialize(vehicles, submission_date)
-      @vehicles = vehicles
-      @submission_date = submission_date
-      @response = []
-    end
-
+  class VehicleAssessment < BaseWorkflowService
     def call
-      @vehicles.each { |v| assess(v) }
+      vehicles.each { |v| assess(v) }
       @response
     end
 
     private
 
+    def response
+      @response ||= []
+    end
+
     def assess(vehicle)
-      result = DatedStruct.new(AssessmentParticulars.initial_vehicle_details)
+      result = DatedStruct.new(vehicle.as_json)
       copy_request_details_to_result(vehicle, result)
       result.assessed_value = assessed_value(vehicle)
-      @response << result
+      response << result
     end
 
     def vehicle_disregard

--- a/spec/factories/assessment_factory.rb
+++ b/spec/factories/assessment_factory.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :assessment do
     sequence(:client_reference_id) { |n| format('CLIENT-REF-%04d', n) }
-    sequence(:remote_ip) { |n| "192.168.0.#{n}" }
+    remote_ip { Faker::Internet.ip_v4_address }
     submission_date { Date.today }
     matter_proceeding_type { 'domestic_abuse' }
   end

--- a/spec/services/workflow_service/vehicle_assessment_spec.rb
+++ b/spec/services/workflow_service/vehicle_assessment_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-module WorkflowService
+module WorkflowService # rubocop:disable Metrics/ModuleLength
   RSpec.describe VehicleAssessment do
     let(:assessment) { create :assessment }
     let(:service) { described_class.new(assessment) }
@@ -97,6 +97,47 @@ module WorkflowService
       end
 
       context 'multiple vehicles' do
+        context 'multiple vehicles included not in capital assessment' do
+          let(:vehicle_1) { create :vehicle, value: 9_500, loan_amount_outstanding: 0, date_of_purchase: 26.months.ago.to_date, in_regular_use: true }
+          let(:vehicle_2) { create :vehicle, value: 15_500, loan_amount_outstanding: 0, date_of_purchase: 46.months.ago.to_date, in_regular_use: true }
+          it 'is assessed at zero' do
+            assessment.vehicles << vehicle_1
+            assessment.vehicles << vehicle_2
+            result = service.call
+            expect(result.first).to have_matching_attributes(vehicle_1, common_attributes)
+            expect(result.first.assessed_value).to eq 0.0
+            expect(result[1]).to have_matching_attributes(vehicle_2, common_attributes)
+            expect(result[1].assessed_value).to eq 0.0
+          end
+        end
+
+        context 'multiple vehicles included in capital assessment' do
+          let(:vehicle_1) { create :vehicle, value: 23_700, loan_amount_outstanding: 2_250, date_of_purchase: 15.months.ago.to_date, in_regular_use: true }
+          let(:vehicle_2) { create :vehicle, value: 23_700, loan_amount_outstanding: 2_250, date_of_purchase: 26.months.ago.to_date, in_regular_use: false }
+          it 'is assessed at zero' do
+            assessment.vehicles << vehicle_1
+            assessment.vehicles << vehicle_2
+            result = service.call
+            expect(result.first).to have_matching_attributes(vehicle_1, common_attributes)
+            expect(result.first.assessed_value).to eq 2_160.0
+            expect(result[1]).to have_matching_attributes(vehicle_2, common_attributes)
+            expect(result[1].assessed_value).to eq 23_700.0
+          end
+        end
+
+        context 'mix of vehicles included/not included in capital assessment' do
+          let(:vehicle_1) { create :vehicle, value: 9_500, loan_amount_outstanding: 0, date_of_purchase: 26.months.ago.to_date, in_regular_use: true }
+          let(:vehicle_2) { create :vehicle, value: 23_700, loan_amount_outstanding: 2_250, date_of_purchase: 26.months.ago.to_date, in_regular_use: false }
+          it 'is assessed at zero' do
+            assessment.vehicles << vehicle_1
+            assessment.vehicles << vehicle_2
+            result = service.call
+            expect(result.first).to have_matching_attributes(vehicle_1, common_attributes)
+            expect(result.first.assessed_value).to eq 0.0
+            expect(result[1]).to have_matching_attributes(vehicle_2, common_attributes)
+            expect(result[1].assessed_value).to eq 23_700.0
+          end
+        end
       end
 
       def common_attributes


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-759)

Refactor the `VehicleAssessment` service to use data from the database and not the JSON struct.

* Accept an `Assessment` instance rather than JSON struct in `initializer`
* Use the `Assessment` object to retrieve `Vehicle` data
* Fix bug in `assessment_factory` by switching to `Faker` to generate IP addresses

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
