### PR TITLE
Fix failing capital spec

### DIFF
--- a/spec/factories/bank_account_factory.rb
+++ b/spec/factories/bank_account_factory.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :bank_account do
     assessment
-    name { Faker::Bank.name }
+    name { "#{Faker::Bank.name} #{Faker::Bank.unique.account_number}" }
     lowest_balance { Faker::Number.decimal(4, 2).to_f }
   end
 end

--- a/spec/services/capitals_creation_service_spec.rb
+++ b/spec/services/capitals_creation_service_spec.rb
@@ -18,7 +18,6 @@ RSpec.describe CapitalsCreationService do
   before { stub_call_to_json_schema }
 
   describe '.call' do
-    # TODO: This test fails randomly.  Needs to be rewritten to fix this
     it 'creates bank accounts for this assessment' do
       expect { subject }.to change { assessment.bank_accounts.count }.by(bank_accounts.count)
       bank_accounts.each do |bank_account|


### PR DESCRIPTION
## What
The `capitals_creation_service_spec` randomly fails. This is due to the use of `Faker::Bank.name` to create bank account names. There is only a small pool of bank names to select from so occasionally both accounts are created with the same name, leading to failures when `find_by!(name: bank_account[:name])` is executed.

I've fixed this by adding `Faker::Bank.account_number` to the name created by FactoryBot, which should hopefully result in unique names always being created.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
