### PR TITLE
Fix failing UAT and staging deploys

### DIFF
--- a/app/workflows/standard_workflow.rb
+++ b/app/workflows/standard_workflow.rb
@@ -13,7 +13,7 @@ WORKFLOW = {
     true_step: :compare_lower_capital_threshold_step
   },
   compare_lower_capital_threshold_step: {
-    klass: BelowLowerCapitalThresholdPredicate,
+    klass: WorkflowPredicate::BelowLowerCapitalThresholdPredicate,
     true_step: :end_step,
     false_step: :end_step
   },

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,4 +9,5 @@ Rails.application.routes.draw do
     resources :properties, only: [:create]
     resources :vehicles, only: :create
   end
+  resources :status, only: [:index]
 end

--- a/spec/requests/status_spec.rb
+++ b/spec/requests/status_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+
+RSpec.describe 'status requests' do
+  let(:response_json) { JSON.parse(response.body) }
+
+  describe 'GET /status' do
+    it 'is successful' do
+      get('/status')
+      expect(response).to be_successful
+      expect(response_json).to eq('alive' => true)
+    end
+  end
+end


### PR DESCRIPTION
K8s deployments to UAT and staging are failing due to

* missing module name. This causes `NameError: uninitialized constant BelowLowerCapitalThresholdPredicate` to be thrown when the server is started. Change `BelowLowerCapitalThresholdPredicate` to `WorkflowPredicate::BelowLowerCapitalThresholdPredicate` to fix this.

* no `status` route. K8s does a `GET` to `/status` to check whether the application is live. `status_controller` exists but has no route. This causes the deployment to fail. Add a route to `routes.rb` to remedy this.

I've tested in UAT and have successfully deployed there, so I assume this will also fix the problem for staging.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
