### PR TITLE
Remove wrong host for staging and prod deployment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -144,8 +144,7 @@ jobs:
                         --namespace=${KUBE_ENV_STAGING_NAMESPACE} \
                         --values ./deploy/helm/values-staging.yaml \
                         --set image.repository="$ECR_ENDPOINT/laa-apply-for-legal-aid/check-financial-eligibility-service" \
-                        --set image.tag="${CIRCLE_SHA1}" \
-                        --set ingress.hosts="{check-financial-eligibility-staging}"
+                        --set image.tag="${CIRCLE_SHA1}"
 
   deploy_production:
     <<: *deploy_container_config
@@ -170,8 +169,7 @@ jobs:
                         --namespace=${KUBE_ENV_PRODUCTION_NAMESPACE} \
                         --values ./deploy/helm/values-production.yaml \
                         --set image.repository="$ECR_ENDPOINT/laa-apply-for-legal-aid/check-financial-eligibility-service" \
-                        --set image.tag="${CIRCLE_SHA1}" \
-                        --set ingress.hosts="{check-financial-eligibility}"
+                        --set image.tag="${CIRCLE_SHA1}"
 
   clean_up_ecr:
     <<: *build_container_config


### PR DESCRIPTION

Remove erroneous hosts of staging and prod deployment.
We don't need to pass them to the `helm upgrade` because `ingress.hosts` is already set in the `values-*.yml` files
