### PR TITLE
AP-997 Remove upper capital threshold

### DIFF
--- a/app/models/capital_summary.rb
+++ b/app/models/capital_summary.rb
@@ -31,7 +31,6 @@ class CapitalSummary < ApplicationRecord
 
   def result
     return :eligible if assessed_capital <= lower_threshold
-    return :not_eligible if assessed_capital > upper_threshold
 
     :contribution_required
   end

--- a/spec/models/capital_summary_spec.rb
+++ b/spec/models/capital_summary_spec.rb
@@ -83,8 +83,8 @@ RSpec.describe CapitalSummary do
     context 'above upper threshold' do
       let(:capital_summary) { create :capital_summary, :above_upper_threshold }
 
-      it 'sets result to not eligible' do
-        expect(capital_summary).to be_not_eligible
+      it 'sets result to contribution_required' do
+        expect(capital_summary).to be_contribution_required
       end
     end
   end


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-997)

For cases where the applicant has an involvement type of `applicant` and the matter proceeding type is `domestic_abuse`, the upper capital threshold does not apply. All applicants above the lower threshold should have a result of `contribution_required`.

For MVP all cases are `applicant`/`domestic_abuse`, so to change this simply amend the `capital_summary` model to remove the upper threshold.

It can be reinstated when other involvement types/matter types are introduced to the service.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
