### PR TITLE
AP-998 Fix Property Calculation

### DIFF
--- a/app/models/property.rb
+++ b/app/models/property.rb
@@ -40,7 +40,7 @@ class Property < ApplicationRecord
   end
 
   def calculate_net_equity
-    self.net_equity = (net_value * shared_ownership_percentage).round(2)
+    self.net_equity = shared_with_housing_assoc ? (net_value - housing_association_share).round(2) : (net_value * shared_ownership_percentage).round(2)
   end
 
   def shared_ownership_percentage
@@ -56,6 +56,10 @@ class Property < ApplicationRecord
   end
 
   def calculate_assessed_equity
-    self.assessed_equity = net_equity - main_home_equity_disregard
+    self.assessed_equity = [net_equity - main_home_equity_disregard, 0].max
+  end
+
+  def housing_association_share
+    value * (1 - shared_ownership_percentage)
   end
 end

--- a/spec/services/workflow_service/property_assessment_spec.rb
+++ b/spec/services/workflow_service/property_assessment_spec.rb
@@ -109,9 +109,7 @@ module WorkflowService # rubocop:disable Metrics/ModuleLength
           end
         end
 
-        # TODO: There may be special rules for calculating assessed value for shares with housing associations
-        # leave this until it is clarified
-        xcontext '50% shared with housing association' do
+        context '50% shared with housing association' do
           let!(:main_home) do
             create :property,
                    :main_home,
@@ -121,15 +119,15 @@ module WorkflowService # rubocop:disable Metrics/ModuleLength
                    outstanding_mortgage: 70_000,
                    percentage_owned: 50.0
           end
-          it 'subtracts outstanding mortgage only from the share owned by applicant' do
+          it 'subtracts the housing association share as a %age of market value' do
             service.call
             main_home.reload
             expect(main_home.transaction_allowance).to eq 4_800.0 # 3% of 160,000
             expect(main_home.allowable_outstanding_mortgage).to eq 70_000.0
-            expect(main_home.net_value).to eq 415_726.77 # 466,993 - 14,009.79 - 37,256.45
-            expect(main_home.net_equity).to eq 277_123.46 # 66% of 415_726.77
+            expect(main_home.net_value).to eq 85_200.0 # 160,000 - 4,800 - 70,000
+            expect(main_home.net_equity).to eq 5_200.0 # 85,200.0 - (50% of 160,000)
             expect(main_home.main_home_equity_disregard).to eq 100_000.0
-            expect(main_home.assessed_equity).to eq 177_123.46
+            expect(main_home.assessed_equity).to eq 0
           end
         end
       end


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-998)

The capital calculation is incorrect for properties where ownership is shared with a housing association.

In these instances the housing association share is a percentage of the market value rather than a percentage of the net equity.

This PR amends the `calculate_net_equity` method on the `property` model so that the correct value is calculated dependent on whether a housing association owns a share of the property.

A (disabled) spec already existed for this scenario. It has been enabled and updated with correct values derived from the [guidance](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/1339654172/3.+Detailed+Means+Calculation+-+Capital+Assets?preview=/1339654172/1547763935/Property.pdf) in the Jira story. 

It also includes a small change to account for scenarios where the main dwelling equity disregard is greater than the equity, to limit `assessed_equity` to 0 instead of returning a negative value.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
