### PR TITLE
AP-1103 Calculate gross income threshold

### DIFF
--- a/app/controllers/assessments_controller.rb
+++ b/app/controllers/assessments_controller.rb
@@ -46,7 +46,8 @@ class AssessmentsController < ApplicationController
   end
 
   def show
-    assessment.summarise!
+    assessment.capital_summary.summarise!
+    assessment.gross_income_summary.summarise!
     assessment.determine_result!
 
     render json: ResultDecorator.new(assessment)

--- a/app/models/assessment.rb
+++ b/app/models/assessment.rb
@@ -20,5 +20,5 @@ class Assessment < ApplicationRecord
 
   enum matter_proceeding_type: enum_hash_for(:domestic_abuse)
 
-  delegate :capital_assessment_result, :summarise!, :determine_result!, to: :capital_summary
+  delegate :capital_assessment_result, :determine_result!, to: :capital_summary
 end

--- a/app/models/gross_income_summary.rb
+++ b/app/models/gross_income_summary.rb
@@ -2,4 +2,9 @@ class GrossIncomeSummary < ApplicationRecord
   belongs_to :assessment
 
   has_many :other_income_sources
+
+  def summarise!
+    data = WorkflowService::GrossIncomeCollator.call(assessment)
+    update!(data)
+  end
 end

--- a/app/services/base_workflow_service.rb
+++ b/app/services/base_workflow_service.rb
@@ -1,6 +1,7 @@
 class BaseWorkflowService
   delegate :applicant, :capital_summary, :submission_date, to: :assessment
   delegate :liquid_capital_items, :main_home, :additional_properties, :vehicles, to: :capital_summary
+  delegate :upper_threshold, to: :gross_income_summary
 
   attr_reader :assessment
 

--- a/app/services/workflow_service/gross_income_collator.rb
+++ b/app/services/workflow_service/gross_income_collator.rb
@@ -1,0 +1,39 @@
+module WorkflowService
+  class GrossIncomeCollator < BaseWorkflowService
+    def call
+      {
+        upper_threshold: upper_threshold
+      }
+    end
+
+    private
+
+    def upper_threshold
+      return infinite_threshold if assessment.matter_proceeding_type == 'domestic_abuse' && assessment.applicant.involvement_type == 'applicant'
+
+      Threshold.value_for(:gross_income_upper, at: assessment.submission_date) + dependant_increase
+    end
+
+    def infinite_threshold
+      @infinite_threshold ||= Threshold.value_for(:infinite_gross_income_upper, at: assessment.submission_date)
+    end
+
+    def dependant_increase_starts_after
+      @dependant_increase_starts_after ||= Threshold.value_for(:dependant_increase_starts_after, at: assessment.submission_date)
+    end
+
+    def dependant_step
+      @dependant_step ||= Threshold.value_for(:dependant_step, at: assessment.submission_date)
+    end
+
+    def number_of_child_dependants
+      assessment.dependants.where(relationship: 'child_relative').count
+    end
+
+    def dependant_increase
+      return 0 unless number_of_child_dependants > dependant_increase_starts_after
+
+      (number_of_child_dependants - dependant_increase_starts_after) * dependant_step
+    end
+  end
+end

--- a/config/thresholds/8-Apr-2018.yml
+++ b/config/thresholds/8-Apr-2018.yml
@@ -1,9 +1,8 @@
 ---
-gross_income_upper:
-  children:
-    one: 1
-    two: 3
-    many: 7
+gross_income_upper: 2657
+infinite_gross_income_upper: 999_999_999_999
+dependant_step: 222
+dependant_increase_starts_after: 4
 disposable_income_lower: 1000
 disposable_income_upper: 10000
 capital_lower: 3_000

--- a/config/thresholds/8-Apr-2019.yml
+++ b/config/thresholds/8-Apr-2019.yml
@@ -1,10 +1,8 @@
 ---
-gross_income_upper:
-  children:
-    one: 1
-    two: 3
-    three: 5
-    many: 7
+gross_income_upper: 2657
+infinite_gross_income_upper: 999_999_999_999
+dependant_step: 222
+dependant_increase_starts_after: 4
 disposable_income_lower: 100
 disposable_income_upper: 50000
 capital_lower: 3_000

--- a/config/thresholds/8-Apr-2020.yml
+++ b/config/thresholds/8-Apr-2020.yml
@@ -1,8 +1,8 @@
 ---
 gross_income_upper:
-  children:
-    one: 1
-    many: 7
+infinite_gross_income_upper: 999_999_999_999
+dependant_step:
+dependant_increase_starts_after:
 disposable_income_lower: 2000
 disposable_income_upper: 20000
 capital_lower: 3_000

--- a/db/migrate/20191206141200_add_upper_threshold_to_gross_income_summary.rb
+++ b/db/migrate/20191206141200_add_upper_threshold_to_gross_income_summary.rb
@@ -1,0 +1,5 @@
+class AddUpperThresholdToGrossIncomeSummary < ActiveRecord::Migration[6.0]
+  def change
+    add_column :gross_income_summaries, :upper_threshold, :decimal, default: 0.0, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_12_05_164153) do
+ActiveRecord::Schema.define(version: 2019_12_06_141200) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -119,6 +119,7 @@ ActiveRecord::Schema.define(version: 2019_12_05_164153) do
     t.uuid "assessment_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.decimal "upper_threshold", default: "0.0", null: false
     t.index ["assessment_id"], name: "index_gross_income_summaries_on_assessment_id"
   end
 

--- a/spec/factories/assessment_factory.rb
+++ b/spec/factories/assessment_factory.rb
@@ -13,9 +13,20 @@ FactoryBot.define do
       applicant { create :applicant, :over_pensionable_age }
     end
 
-    after(:create) do |assessment, _evaluator|
+    # use :with_child_dependants: 2 to create 2 children for the assessment
+    transient do
+      with_child_dependants { 0 }
+    end
+
+    after(:create) do |assessment, evaluator|
       create :capital_summary, assessment: assessment
       create :gross_income_summary, assessment: assessment
+
+      if evaluator.with_child_dependants > 0
+        evaluator.with_child_dependants.times do
+          create :dependant, :child_relative, assessment: assessment
+        end
+      end
     end
   end
 end

--- a/spec/factories/dependant_factory.rb
+++ b/spec/factories/dependant_factory.rb
@@ -6,5 +6,13 @@ FactoryBot.define do
     relationship { Dependant.relationships.values.sample }
     monthly_income { rand(1...10_000.0).round(2) }
     assets_value { rand(1...10_000.0).round(2) }
+
+    trait :child_relative do
+      relationship { :child_relative }
+    end
+
+    trait :adult_relative do
+      relationship { :adult_relative }
+    end
   end
 end

--- a/spec/models/gross_income_summary_spec.rb
+++ b/spec/models/gross_income_summary_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+RSpec.describe GrossIncomeSummary do
+  let(:assessment) { create :assessment }
+  let(:gross_income_summary) do
+    create :gross_income_summary, assessment: assessment
+  end
+
+  describe '#summarise!' do
+    let(:data) do
+      {
+        upper_threshold: Faker::Number.decimal
+      }
+    end
+
+    subject { gross_income_summary.summarise! }
+
+    before do
+      allow(WorkflowService::GrossIncomeCollator).to receive(:call).with(assessment).and_return(data)
+      subject
+      gross_income_summary.reload
+    end
+
+    it 'persists the data' do
+      data.each do |method, value|
+        expect(gross_income_summary.__send__(method).to_d).to eq(value.to_d)
+      end
+    end
+  end
+end

--- a/spec/requests/assessments_spec.rb
+++ b/spec/requests/assessments_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe AssessmentsController, type: :request do
     subject { get assessment_path(assessment) }
 
     before do
-      assessment.summarise!
+      assessment.capital_summary.summarise!
       assessment.determine_result!
       assessment.reload
       subject

--- a/spec/services/workflow_service/gross_income_collator_spec.rb
+++ b/spec/services/workflow_service/gross_income_collator_spec.rb
@@ -1,0 +1,69 @@
+require 'rails_helper'
+
+module WorkflowService
+  RSpec.describe GrossIncomeCollator do
+    let(:assessment) { create :assessment, :with_applicant }
+
+    describe '.call' do
+      subject { described_class.call assessment }
+
+      it 'always returns a hash' do
+        expect(subject).to be_a Hash
+      end
+
+      context 'upper income threshold' do
+        before { subject }
+
+        context 'threshold does not apply' do
+          it 'calculates the threshold correctly when there are no dependants' do
+            expect(subject[:upper_threshold]).to eq 999_999_999_999
+          end
+
+          context 'with child dependants' do
+            let(:assessment) { create :assessment, :with_applicant, with_child_dependants: 5 }
+            it 'calculates the threshold correctly when there are dependants' do
+              expect(subject[:upper_threshold]).to eq 999_999_999_999
+            end
+          end
+        end
+      end
+
+      context 'threshold applies' do
+        before { allow(assessment).to receive(:matter_proceeding_type).and_return 'not_domestic_abuse' }
+        context 'threshold applies, no child dependants' do
+          it 'calculates the threshold correctly' do
+            expect(subject[:upper_threshold]).to eq 2_657
+          end
+        end
+
+        context 'threshold applies, 2 child dependants' do
+          let(:assessment) { create :assessment, :with_applicant, with_child_dependants: 2 }
+          it 'calculates the threshold correctly' do
+            expect(subject[:upper_threshold]).to eq 2_657
+          end
+        end
+
+        context 'threshold applies, 5 child dependants' do
+          let(:assessment) { create :assessment, :with_applicant, with_child_dependants: 5 }
+          it 'calculates the threshold correctly' do
+            expect(subject[:upper_threshold]).to eq 2_879
+          end
+        end
+
+        context 'threshold applies, 8 child dependants' do
+          let(:assessment) { create :assessment, :with_applicant, with_child_dependants: 8 }
+          it 'calculates the threshold correctly' do
+            expect(subject[:upper_threshold]).to eq 3_545
+          end
+        end
+
+        context 'threshold applies, 10 child dependants' do
+          let(:assessment) { create :assessment, :with_applicant, with_child_dependants: 10 }
+          it 'calculates the threshold correctly' do
+            expect(subject[:upper_threshold]).to eq 3_989
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1103)

Added gross income upper threshold data and a mechanism for deriving the correct threshold.

* new database column on `gross_income_summary` to hold `upper_threshold`.
* new values in `config/thresholds` to hold threshold-related data: 
 - `gross_income_upper` - the basic threshold
 - `dependant_increase_starts_after` - the number of dependants above which the threshold is increased
 - `dependent_step` - the amount each additional dependant adds to the threshold
 - `infinite_gross_income_upper` - where the threshold is waived, an 'infinite' threshold applies. This is encoded as £999,999,999,999
* new `GrossIncomeCollator` class to calculate the correct threshold an persist it to the database

NOTE: values for the 2020 gross income threshold are not yet known. The `config/threshold` file has been left blank for these. The approach used in `GrossIncomeCollator` to calculate the threshold works for the 2018/2019 thresholds. If the structure of the 2020 threshold is significantly different, some rework will be necessary.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
