### PR TITLE
AP-1127 Calculate monthly value for OtherIncome

### DIFF
--- a/app/models/assessment.rb
+++ b/app/models/assessment.rb
@@ -16,6 +16,7 @@ class Assessment < ApplicationRecord
   has_many :vehicles, through: :capital_summary
   has_many :capital_items, through: :capital_summary
   has_many :wage_slips
+  has_many :assessment_errors
   has_one :result
 
   enum matter_proceeding_type: enum_hash_for(:domestic_abuse)

--- a/app/models/assessment_error.rb
+++ b/app/models/assessment_error.rb
@@ -1,0 +1,3 @@
+class AssessmentError < ApplicationRecord
+  belongs_to :assessment
+end

--- a/app/models/other_income_source.rb
+++ b/app/models/other_income_source.rb
@@ -3,4 +3,33 @@ class OtherIncomeSource < ApplicationRecord
   has_many :other_income_payments
 
   validates :gross_income_summary_id, :name, presence: true
+
+  delegate :assessment, to: :gross_income_summary
+
+  def calculate_monthly_income!
+    assessment.assessment_errors.create!(record_id: id, record_type: self.class, error_message: converter.error_message) if converter.error?
+
+    update!(monthly_income: converter.monthly_amount)
+    converter.monthly_amount
+  end
+
+  private
+
+  def dates_and_amounts
+    PaymentPeriodDataExtractor.call(collection: other_income_payments,
+                                    date_method: :payment_date,
+                                    amount_method: :amount)
+  end
+
+  def frequency
+    PaymentPeriodAnalyser.new(dates_and_amounts).period_pattern
+  end
+
+  def converter
+    @converter ||= UnearnedIncomeMonthlyConversionService.new(frequency, payment_amounts)
+  end
+
+  def payment_amounts
+    other_income_payments.map(&:amount)
+  end
 end

--- a/app/services/monthly_other_income_calculator.rb
+++ b/app/services/monthly_other_income_calculator.rb
@@ -1,0 +1,23 @@
+class MonthlyOtherIncomeCalculator
+  def self.call(assessment_id)
+    new(assessment_id).call
+  end
+
+  def initialize(assessment_id)
+    @assessment = Assessment.find assessment_id
+  end
+
+  def call
+    total_monthly_income = 0
+    gross_income_summary.other_income_sources.each do |source|
+      total_monthly_income += source.calculate_monthly_income!
+    end
+    gross_income_summary.update!(monthly_other_income: total_monthly_income)
+  end
+
+  private
+
+  def gross_income_summary
+    @gross_income_summary || @assessment.gross_income_summary
+  end
+end

--- a/app/services/payment_period_data_extractor.rb
+++ b/app/services/payment_period_data_extractor.rb
@@ -1,0 +1,18 @@
+# class for extracting data to pass into the PaymentPeriodAnalyser from a collection of records
+class PaymentPeriodDataExtractor
+  def self.call(collection:, date_method:, amount_method:)
+    new(collection, date_method, amount_method).call
+  end
+
+  def initialize(collection, date_method, amount_method)
+    @collection = collection
+    @date_method = date_method
+    @amount_method = amount_method
+  end
+
+  def call
+    @collection.map do |record|
+      [record.__send__(@date_method), record.__send__(@amount_method)]
+    end
+  end
+end

--- a/app/services/unearned_income_monthly_conversion_service.rb
+++ b/app/services/unearned_income_monthly_conversion_service.rb
@@ -1,0 +1,52 @@
+class UnearnedIncomeMonthlyConversionService
+  VALID_FREQUENCIES = %i[monthly four_weekly two_weekly weekly unknown].freeze
+
+  attr_reader :monthly_amount, :error_message
+
+  def initialize(frequency, payments)
+    @frequency = frequency
+    @payments = payments
+    @error = false
+    @error_message = nil
+    @monthly_amount = nil
+  end
+
+  def run
+    raise 'Unrecognized frequency' unless @frequency.in?(VALID_FREQUENCIES)
+
+    @monthly_amount = __send__("process_#{@frequency}")
+  end
+
+  def error?
+    run
+    @error
+  end
+
+  private
+
+  def process_monthly
+    payment_average.round(2)
+  end
+
+  def process_four_weekly
+    ((payment_average / 4) * 52 / 12).round(2)
+  end
+
+  def process_two_weekly
+    ((payment_average / 2) * 52 / 12).round(2)
+  end
+
+  def process_weekly
+    (payment_average * 52 / 12).round(2)
+  end
+
+  def process_unknown
+    @error = true
+    @error_message = :unknown_payment_frequency
+    nil
+  end
+
+  def payment_average
+    @payments.sum.to_f / @payments.size
+  end
+end

--- a/db/migrate/20191205155502_add_other_income_sources.rb
+++ b/db/migrate/20191205155502_add_other_income_sources.rb
@@ -3,6 +3,9 @@ class AddOtherIncomeSources < ActiveRecord::Migration[6.0]
     create_table :other_income_sources, id: :uuid do |t|
       t.belongs_to :gross_income_summary, foreign_key: true, null: false, type: :uuid
       t.string :name, null: false
+      t.decimal :monthly_income
+
+      t.boolean :assessment_error, default: false
 
       t.timestamps
     end

--- a/db/migrate/20191205164153_create_other_income_payments.rb
+++ b/db/migrate/20191205164153_create_other_income_payments.rb
@@ -4,6 +4,7 @@ class CreateOtherIncomePayments < ActiveRecord::Migration[6.0]
       t.belongs_to :other_income_source, foreign_key: true, null: false, type: :uuid
       t.date :payment_date, null: false
       t.decimal :amount, null: false
+      t.boolean :assessment_error, default: false
 
       t.timestamps
     end

--- a/db/migrate/20191209131409_add_monthly_oher_income_to_gross_income_summary.rb
+++ b/db/migrate/20191209131409_add_monthly_oher_income_to_gross_income_summary.rb
@@ -1,0 +1,6 @@
+class AddMonthlyOherIncomeToGrossIncomeSummary < ActiveRecord::Migration[6.0]
+  def change
+    add_column :gross_income_summaries, :monthly_other_income, :decimal
+    add_column :gross_income_summaries, :assessment_error, :boolean, default: false
+  end
+end

--- a/db/migrate/20191210100303_create_assessment_errors.rb
+++ b/db/migrate/20191210100303_create_assessment_errors.rb
@@ -1,0 +1,10 @@
+class CreateAssessmentErrors < ActiveRecord::Migration[6.0]
+  def change
+    create_table :assessment_errors do |t|
+      t.belongs_to :assessment, foreign_key: true, null: false, type: :uuid
+      t.uuid :record_id
+      t.string :record_type
+      t.string :error_message
+    end
+  end
+end

--- a/db/migrate/20191210102843_drop_wage_slips.rb
+++ b/db/migrate/20191210102843_drop_wage_slips.rb
@@ -1,0 +1,18 @@
+class DropWageSlips < ActiveRecord::Migration[6.0]
+  def up
+    drop_table :wage_slips
+  end
+
+  def down
+    create_table 'wage_slips', force: :cascade do |t|
+      t.uuid 'assessment_id', null: false
+      t.date 'payment_date'
+      t.decimal 'gross_pay'
+      t.decimal 'paye'
+      t.decimal 'nic'
+      t.datetime 'created_at', null: false
+      t.datetime 'updated_at', null: false
+      t.index ['assessment_id'], name: 'index_wage_slips_on_assessment_id'
+    end
+  end
+end

--- a/db/migrate/20191211161738_add_fields_to_other_payments.rb
+++ b/db/migrate/20191211161738_add_fields_to_other_payments.rb
@@ -1,0 +1,6 @@
+class AddFieldsToOtherPayments < ActiveRecord::Migration[6.0]
+  def change
+    add_column :other_income_sources, :monthly_income, :decimal
+    add_column :other_income_sources, :assessment_error, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_12_06_141200) do
+ActiveRecord::Schema.define(version: 2019_12_11_161738) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -25,6 +25,14 @@ ActiveRecord::Schema.define(version: 2019_12_06_141200) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["assessment_id"], name: "index_applicants_on_assessment_id"
+  end
+
+  create_table "assessment_errors", force: :cascade do |t|
+    t.uuid "assessment_id", null: false
+    t.uuid "record_id"
+    t.string "record_type"
+    t.string "error_message"
+    t.index ["assessment_id"], name: "index_assessment_errors_on_assessment_id"
   end
 
   create_table "assessments", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -120,6 +128,8 @@ ActiveRecord::Schema.define(version: 2019_12_06_141200) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.decimal "upper_threshold", default: "0.0", null: false
+    t.decimal "monthly_other_income"
+    t.boolean "assessment_error", default: false
     t.index ["assessment_id"], name: "index_gross_income_summaries_on_assessment_id"
   end
 
@@ -146,6 +156,8 @@ ActiveRecord::Schema.define(version: 2019_12_06_141200) do
     t.string "name", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.decimal "monthly_income"
+    t.boolean "assessment_error", default: false
     t.index ["gross_income_summary_id"], name: "index_other_income_sources_on_gross_income_summary_id"
   end
 
@@ -177,20 +189,20 @@ ActiveRecord::Schema.define(version: 2019_12_06_141200) do
     t.index ["capital_summary_id"], name: "index_properties_on_capital_summary_id"
   end
 
-  create_table "state_benefit_types", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.string "label"
-    t.text "description"
-    t.boolean "exclude_from_gross_income"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-  end
-
   create_table "results", force: :cascade do |t|
     t.uuid "assessment_id"
     t.string "state"
     t.jsonb "details"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+  end
+
+  create_table "state_benefit_types", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "label"
+    t.text "description"
+    t.boolean "exclude_from_gross_income"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "statuses", force: :cascade do |t|
@@ -221,18 +233,8 @@ ActiveRecord::Schema.define(version: 2019_12_06_141200) do
     t.index ["employment_id"], name: "index_wage_payments_on_employment_id"
   end
 
-  create_table "wage_slips", force: :cascade do |t|
-    t.uuid "assessment_id", null: false
-    t.date "payment_date"
-    t.decimal "gross_pay"
-    t.decimal "paye"
-    t.decimal "nic"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["assessment_id"], name: "index_wage_slips_on_assessment_id"
-  end
-
   add_foreign_key "applicants", "assessments"
+  add_foreign_key "assessment_errors", "assessments"
   add_foreign_key "benefit_in_kinds", "employments"
   add_foreign_key "benefit_receipts", "assessments"
   add_foreign_key "capital_items", "capital_summaries"
@@ -245,5 +247,4 @@ ActiveRecord::Schema.define(version: 2019_12_06_141200) do
   add_foreign_key "properties", "capital_summaries"
   add_foreign_key "vehicles", "capital_summaries"
   add_foreign_key "wage_payments", "employments"
-  add_foreign_key "wage_slips", "assessments"
 end

--- a/spec/factories/gross_income_summary_factory.rb
+++ b/spec/factories/gross_income_summary_factory.rb
@@ -1,5 +1,6 @@
 FactoryBot.define do
   factory :gross_income_summary do
     assessment
+    monthly_other_income { nil }
   end
 end

--- a/spec/factories/other_income_payment_factory.rb
+++ b/spec/factories/other_income_payment_factory.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :other_income_payment do
+    other_income_source
+    payment_date { Faker::Date.between(from: 3.months.ago, to: Date.today) }
+    amount { Faker::Number.decimal(l_digits: 3, r_digits: 2) }
+  end
+end

--- a/spec/factories/other_income_source_factory.rb
+++ b/spec/factories/other_income_source_factory.rb
@@ -1,0 +1,9 @@
+require Rails.root.join('spec/support/faker/other_income_source.rb')
+
+FactoryBot.define do
+  factory :other_income_source do
+    gross_income_summary
+    name { Faker::OtherIncomeSource.name }
+    monthly_income { nil }
+  end
+end

--- a/spec/models/other_income_source_spec.rb
+++ b/spec/models/other_income_source_spec.rb
@@ -1,0 +1,59 @@
+require 'rails_helper'
+
+RSpec.describe OtherIncomeSource, type: :model do
+  describe '#calculate_monthly_income' do
+    let(:source) { create :other_income_source }
+    let!(:payment1) { create :other_income_payment, other_income_source: source, payment_date: 3.months.ago.to_date, amount: 301.0 }
+    let!(:payment2) { create :other_income_payment, other_income_source: source, payment_date: 2.months.ago.to_date, amount: 302.0 }
+    let!(:payment3) { create :other_income_payment, other_income_source: source, payment_date: 1.months.ago.to_date, amount: 301.50 }
+    let(:analyser) { double PaymentPeriodAnalyser }
+
+    before do
+      expect(PaymentPeriodDataExtractor).to receive(:call)
+        .with(collection: source.other_income_payments,
+              date_method: :payment_date,
+              amount_method: :amount)
+      expect(PaymentPeriodAnalyser).to receive(:new).and_return(analyser)
+    end
+
+    subject { source.calculate_monthly_income! }
+
+    context 'valid payment frequency' do
+      before { expect(analyser).to receive(:period_pattern).and_return(:monthly) }
+
+      it 'updates the monthly_income field with the result' do
+        subject
+        expect(source.reload.monthly_income).to eq 301.5
+      end
+
+      it 'returns the result' do
+        expect(subject).to eq 301.5
+      end
+
+      it 'does not write an assessment_error_record' do
+        expect { subject }.not_to change { AssessmentError.count }
+      end
+    end
+
+    context 'unknown payment frequency' do
+      before { expect(analyser).to receive(:period_pattern).and_return(:unknown) }
+
+      it 'does not updates the monthly_income field' do
+        subject
+        expect(source.reload.monthly_income).to eq nil
+      end
+
+      it 'returns nil' do
+        expect(subject).to be_nil
+      end
+
+      it 'writes an assessment_error_record' do
+        expect { subject }.to change { AssessmentError.count }.by(1)
+        assessment_error = source.assessment.assessment_errors.first
+        expect(assessment_error.record_id).to eq source.id
+        expect(assessment_error.record_type).to eq source.class.to_s
+        expect(assessment_error.error_message).to eq 'unknown_payment_frequency'
+      end
+    end
+  end
+end

--- a/spec/services/payment_period_data_extractor_spec.rb
+++ b/spec/services/payment_period_data_extractor_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+RSpec.describe PaymentPeriodDataExtractor do
+  it 'returns an array of dates and amounts' do
+    payments = [
+      create(:other_income_payment, payment_date: 2.months.ago.to_date, amount: 501.77),
+      create(:other_income_payment, payment_date: 1.months.ago.to_date, amount: 502.66),
+      create(:other_income_payment, payment_date: Date.today, amount: 505.0)
+    ]
+    expected_results = [
+      [2.months.ago.to_date, 501.77],
+      [1.months.ago.to_date, 502.66],
+      [Date.today, 505.0]
+    ]
+    expect(described_class.call(collection: payments, date_method: :payment_date, amount_method: :amount)).to eq expected_results
+  end
+end

--- a/spec/services/unearned_income_monthly_conversion_service_spec.rb
+++ b/spec/services/unearned_income_monthly_conversion_service_spec.rb
@@ -1,0 +1,94 @@
+require 'rails_helper'
+
+RSpec.describe UnearnedIncomeMonthlyConversionService do
+  subject { described_class.new(frequency, payments) }
+
+  let(:payments) { [203.44, 205.00, 205.00] }
+
+  context 'monthly' do
+    let(:frequency) { :monthly }
+    describe 'error?' do
+      it 'returns false' do
+        expect(subject.error?).to be false
+      end
+    end
+
+    describe 'monthly_amount' do
+      it 'returns the average monthly amount' do
+        subject.error?
+        expect(subject.monthly_amount).to eq 204.48
+      end
+    end
+  end
+
+  context 'four_weekly' do
+    let(:frequency) { :four_weekly }
+    describe 'error?' do
+      it 'returns false' do
+        expect(subject.error?).to be false
+      end
+    end
+
+    describe 'monthly_amount' do
+      it 'returns the average for the calendar month' do
+        subject.error?
+        expect(subject.monthly_amount).to eq 221.52
+      end
+    end
+  end
+
+  context 'two_weekly' do
+    let(:frequency) { :two_weekly }
+    describe 'error?' do
+      it 'returns false' do
+        expect(subject.error?).to be false
+      end
+    end
+
+    describe 'monthly_amount' do
+      it 'returns the average for the calendar month' do
+        subject.error?
+        expect(subject.monthly_amount).to eq 443.04
+      end
+    end
+  end
+
+  context 'weekly' do
+    let(:frequency) { :weekly }
+    describe 'error?' do
+      it 'returns false' do
+        expect(subject.error?).to be false
+      end
+    end
+
+    describe 'monthly_amount' do
+      it 'returns the average for the calendar month' do
+        subject.error?
+        expect(subject.monthly_amount).to eq 886.08
+      end
+    end
+  end
+
+  context 'unknown' do
+    let(:frequency) { :unknown }
+    describe 'error?' do
+      it 'returns true' do
+        expect(subject.error?).to be true
+      end
+    end
+
+    describe 'error_message' do
+      it 'returns error message' do
+        subject.error?
+        expect(subject.error_message).to eq :unknown_payment_frequency
+      end
+    end
+
+    describe 'monthly_amount' do
+      it 'returns nil' do
+        subject.error?
+        expect(subject.monthly_amount).to be_nil
+      end
+    end
+  end
+end

--- a/spec/support/faker/other_income_source.rb
+++ b/spec/support/faker/other_income_source.rb
@@ -1,0 +1,19 @@
+module Faker
+  class OtherIncomeSource
+    INCOMES = [
+      'Help from family',
+      'Student grant/loan',
+      'Private pension',
+      'Trust fund',
+      'Rental income',
+      'Bank interest',
+      'Maintenance received',
+      'Investment income'
+    ].freeze
+    class << self
+      def name
+        INCOMES.sample
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Calculate monthly other income value

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1127)

This PR takes care of calcualating the monthly income for each `OtherIncomeSource`, storing it on the `OtherIncomeSource` model, and the total for all sources on the `GrossIncomeSummary` record.  If the monthly income can't be calculated for any reason, e.g. the`PaymentPeriodAnalyser` can't determine the frequency of payments, an `AssessmentError` record is written to provide details.

- Added `AssessmentError` model to record cases and reasons where an assessment can’t be automatically calculated
- Added `OtherIncomeSource` model belonging to `GrossIncomeSummary` to record the various sources of other income
- Added `OtherIncomePayment` model belonging to `OtherIncomeSource` to record payments from each source
- Added `MonthlyIncomeCalculator` service to iterate over each other income source and call the `#calculate_monthly_income` method on each, and update the  `monthly_other_income` attribute on `GrossIncomeSummary` with a sum of the monthly incomes
- Added `UnearnedIncomeMonthlyConversionService` to calculate the monthly income given a series of payments and a frequency
- Dropped obsolete wage_slips table and associated models

## Checklist

Before you ask people to review this PR:

- [ ] Tests and rubocop should be passing: `bundle exec rake`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [ ] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [ ] The PR description should say what you changed and why, with a link to the JIRA story.
- [ ] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
