### PR TITLE
Add 2020 gross income threshold values

### DIFF
--- a/config/thresholds/8-Apr-2020.yml
+++ b/config/thresholds/8-Apr-2020.yml
@@ -1,8 +1,8 @@
 ---
-gross_income_upper:
+gross_income_upper: 2657
 infinite_gross_income_upper: 999_999_999_999
-dependant_step:
-dependant_increase_starts_after:
+dependant_step: 222
+dependant_increase_starts_after: 4
 disposable_income_lower: 2000
 disposable_income_upper: 20000
 capital_lower: 3_000


### PR DESCRIPTION
## What

Copy the 2019 gross income threshold values to the 2020 config file. 

It's possible they will change, in which case a further PR will be needed, but it's probably better to have some values populated now - if we forget to add them before April 2020 failures will occur.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
