### PR TITLE
AP1157 DisposableIncomeSummary model and migration file

### DIFF
--- a/app/models/assessment.rb
+++ b/app/models/assessment.rb
@@ -8,6 +8,7 @@ class Assessment < ApplicationRecord
   has_one :applicant
   has_one :capital_summary
   has_one :gross_income_summary
+  has_one :disposable_income_summary
 
   has_many :dependants
   has_many :outgoings

--- a/app/models/disposable_income_summary.rb
+++ b/app/models/disposable_income_summary.rb
@@ -1,0 +1,6 @@
+class DisposableIncomeSummary < ApplicationRecord
+  extend EnumHash
+  belongs_to :assessment
+
+  enum housing_cost_type: enum_hash_for(:rent, :mortgage, :board_and_lodging)
+end

--- a/db/migrate/20191223132825_create_disposable_income_summaries.rb
+++ b/db/migrate/20191223132825_create_disposable_income_summaries.rb
@@ -1,0 +1,18 @@
+class CreateDisposableIncomeSummaries < ActiveRecord::Migration[6.0]
+  def change
+    create_table :disposable_income_summaries, id: :uuid do |t|
+      t.belongs_to :assessment, foreign_key: true, null: false, type: :uuid
+      t.decimal :monthly_childcare, default: 0.0, null: false
+      t.decimal :monthly_dependant_allowance, default: 0.0, null: false
+      t.decimal :monthly_maintenance, default: 0.0, null: false
+      t.decimal :monthly_housing_costs, default: 0.0, null: false
+      t.decimal :total_monthly_outgoings, default: 0.0, null: false
+      t.decimal :total_disposable_income, default: 0.0, null: false
+      t.decimal :lower_threshold, default: 0.0, null: false
+      t.decimal :upper_threshold, default: 0.0, null: false
+      t.string :assessment_result, default: 'pending', null: false
+      t.string :housing_cost_type, null: false
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_12_20_091038) do
+ActiveRecord::Schema.define(version: 2019_12_23_132825) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -85,6 +85,23 @@ ActiveRecord::Schema.define(version: 2019_12_20_091038) do
     t.string "relationship"
     t.decimal "monthly_income"
     t.decimal "assets_value"
+  end
+
+  create_table "disposable_income_summaries", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "assessment_id", null: false
+    t.decimal "monthly_childcare", default: "0.0", null: false
+    t.decimal "monthly_dependant_allowance", default: "0.0", null: false
+    t.decimal "monthly_maintenance", default: "0.0", null: false
+    t.decimal "monthly_housing_costs", default: "0.0", null: false
+    t.decimal "total_monthly_outgoings", default: "0.0", null: false
+    t.decimal "total_disposable_income", default: "0.0", null: false
+    t.decimal "lower_threshold", default: "0.0", null: false
+    t.decimal "upper_threshold", default: "0.0", null: false
+    t.string "assessment_result", default: "pending", null: false
+    t.string "housing_cost_type", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["assessment_id"], name: "index_disposable_income_summaries_on_assessment_id"
   end
 
   create_table "gross_income_summaries", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -195,6 +212,7 @@ ActiveRecord::Schema.define(version: 2019_12_20_091038) do
   add_foreign_key "assessment_errors", "assessments"
   add_foreign_key "capital_items", "capital_summaries"
   add_foreign_key "capital_summaries", "assessments"
+  add_foreign_key "disposable_income_summaries", "assessments"
   add_foreign_key "gross_income_summaries", "assessments"
   add_foreign_key "other_income_payments", "other_income_sources"
   add_foreign_key "other_income_sources", "gross_income_summaries"


### PR DESCRIPTION
Create DisposableIncomeSummary model and migration file

[Link to story](https://dsdmoj.atlassian.net/secure/RapidBoard.jspa?rapidView=233&modal=detail&selectedIssue=AP-1157)

- Create DisposableIncomeSummary model that belongs_to an :assessment
- Add enum housing_cost_type: enum_hash_for(:rent, :mortgage, :board_and_lodging) on the DisposableIncomeSummary model.
- Update the Assessment to have one DisposableIncomeSummary

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
