### PR TITLE
AP-1148 Outgoings Controller

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -15,4 +15,15 @@ Metrics/ClassLength:
 Metrics/MethodLength:
   Exclude:
     - 'db/migrate/*' # this should be moved back to .rubocop.yaml when the other exceptions are removed
-  ExcludedMethods: ['monthly_equivalent', 'call', 'property_hash', 'parse_row', 'other_income_params', 'state_benefit_params', 'read_and_check_results', 'capital_data', 'ruby_hash']
+  ExcludedMethods: [
+    'monthly_equivalent',
+    'call',
+    'property_hash',
+    'parse_row',
+    'other_income_params',
+    'state_benefit_params',
+    'read_and_check_results',
+    'capital_data',
+    'ruby_hash',
+    'outgoings_params'
+  ]

--- a/app/controllers/outgoings_controller.rb
+++ b/app/controllers/outgoings_controller.rb
@@ -1,0 +1,59 @@
+class OutgoingsController < ApplicationController
+  # api! works but the links in resulting docs are broken. See https://github.com/Apipie/apipie-rails/issues/559
+  api :POST, 'assessments/:assessment_id/outgoings', 'Create outgoings'
+  formats ['json']
+  param :assessment_id, :uuid, required: true
+
+  param :outgoings, Hash, required: true do
+    param :childcare, Array, desc: 'Collection of childcare payments made', required: true do
+      param :payment_date, Date, date_option: :today_or_older, required: true, desc: 'The date the childcare payment was made'
+      param :amount, :currency, required: true, desc: 'The monetary amount paid for the childcare'
+    end
+
+    param :maintenance, Array, desc: 'Collection of maintenance payments made', required: true do
+      param :payment_date, Date, date_option: :today_or_older, required: true, desc: 'The date the maintenance payment was made'
+      param :amount, :currency, required: true, desc: 'The monetary value of the maintenance payment'
+    end
+
+    param :housing_costs, Array, desc: 'Collection of housing cost payment', required: true do
+      param :payment_date, Date, date_option: :today_or_older, required: true, desc: 'The date the housing cost payment was made'
+      param :amount, :currency, required: true, desc: 'The monetary amount paid for the housing cost'
+      param :housing_cost_type, String, required: true, desc: 'Type of housing cost, one of: rent, mortgage, board_and_lodging'
+    end
+  end
+
+  returns code: :ok, desc: 'Successful response' do
+    property :outgoings, array_of: Outgoings::BaseOutgoing, desc: 'Array of created outgoing objects'
+    property :success, ['true'], desc: 'Success flag shows true'
+  end
+
+  returns code: :unprocessable_entity do
+    property :errors, array_of: String, desc: 'Description of why object invalid'
+    property :success, ['false'], desc: 'Success flag shows false'
+  end
+
+  def create
+    if outgoing_creation_service.success?
+      render json: {
+        outgoings: outgoing_creation_service.outgoings,
+        success: true,
+        errors: []
+      }
+    else
+      render_unprocessable(outgoing_creation_service.errors)
+    end
+  end
+
+  private
+
+  def outgoing_creation_service
+    @outgoing_creation_service ||= Creators::OutgoingsCreator.call(
+      outgoings: input[:outgoings],
+      assessment_id: params[:assessment_id]
+    )
+  end
+
+  def input
+    @input ||= JSON.parse(request.raw_post, symbolize_names: true)
+  end
+end

--- a/app/controllers/outgoings_controller.rb
+++ b/app/controllers/outgoings_controller.rb
@@ -5,17 +5,17 @@ class OutgoingsController < ApplicationController
   param :assessment_id, :uuid, required: true
 
   param :outgoings, Hash, required: true do
-    param :childcare, Array, desc: 'Collection of childcare payments made', required: true do
+    param :childcare, Array, desc: 'Collection of childcare payments made', required: false do
       param :payment_date, Date, date_option: :today_or_older, required: true, desc: 'The date the childcare payment was made'
       param :amount, :currency, required: true, desc: 'The monetary amount paid for the childcare'
     end
 
-    param :maintenance, Array, desc: 'Collection of maintenance payments made', required: true do
+    param :maintenance, Array, desc: 'Collection of maintenance payments made', required: false do
       param :payment_date, Date, date_option: :today_or_older, required: true, desc: 'The date the maintenance payment was made'
       param :amount, :currency, required: true, desc: 'The monetary value of the maintenance payment'
     end
 
-    param :housing_costs, Array, desc: 'Collection of housing cost payment', required: true do
+    param :housing_costs, Array, desc: 'Collection of housing cost payment', required: false do
       param :payment_date, Date, date_option: :today_or_older, required: true, desc: 'The date the housing cost payment was made'
       param :amount, :currency, required: true, desc: 'The monetary amount paid for the housing cost'
       param :housing_cost_type, String, required: true, desc: 'Type of housing cost, one of: rent, mortgage, board_and_lodging'

--- a/app/models/disposable_income_summary.rb
+++ b/app/models/disposable_income_summary.rb
@@ -1,9 +1,7 @@
 class DisposableIncomeSummary < ApplicationRecord
-  extend EnumHash
   belongs_to :assessment
-  has_many :childcare_outgoings
-  has_many :housing_cost_outgoings
-  has_many :maintenance_outgoings
-
-  enum housing_cost_type: enum_hash_for(:rent, :mortgage, :board_and_lodging)
+  has_many :outgoings, class_name: 'Outgoings::BaseOutgoing'
+  has_many :childcare_outgoings, class_name: 'Outgoings::Childcare'
+  has_many :housing_cost_outgoings, class_name: 'Outgoings::HousingCost'
+  has_many :maintenance_outgoings, class_name: 'Outgoings::Maintenance'
 end

--- a/app/models/outgoings/housing_cost.rb
+++ b/app/models/outgoings/housing_cost.rb
@@ -1,4 +1,7 @@
 module Outgoings
   class HousingCost < BaseOutgoing
+    extend EnumHash
+
+    enum housing_cost_type: enum_hash_for(:rent, :mortgage, :board_and_lodging)
   end
 end

--- a/app/services/creators/base_creator.rb
+++ b/app/services/creators/base_creator.rb
@@ -14,6 +14,10 @@ module Creators
       errors.empty?
     end
 
+    def assessment
+      @assessment ||= Assessment.find_by(id: @assessment_id) || (raise CreationError, ['No such assessment id'])
+    end
+
     class CreationError < StandardError
       attr_reader :errors
 

--- a/app/services/creators/capitals_creator.rb
+++ b/app/services/creators/capitals_creator.rb
@@ -42,9 +42,5 @@ module Creators
         capital_summary.non_liquid_capital_items.create!(description: attrs[:description], value: attrs[:value])
       end
     end
-
-    def assessment
-      @assessment ||= Assessment.find_by(id: assessment_id) || (raise CreationError, ['No such assessment id'])
-    end
   end
 end

--- a/app/services/creators/dependants_creator.rb
+++ b/app/services/creators/dependants_creator.rb
@@ -25,9 +25,5 @@ module Creators
     rescue ActiveRecord::RecordInvalid => e
       raise CreationError, e.record.errors.full_messages
     end
-
-    def assessment
-      @assessment ||= Assessment.find_by(id: assessment_id) || (raise CreationError, ['No such assessment id'])
-    end
   end
 end

--- a/app/services/creators/outgoings_creator.rb
+++ b/app/services/creators/outgoings_creator.rb
@@ -1,0 +1,43 @@
+module Creators
+  class OutgoingsCreator < BaseCreator
+    OUTGOING_KLASSES = {
+      childcare: Outgoings::Childcare,
+      housing_costs: Outgoings::HousingCost,
+      maintenance: Outgoings::Maintenance
+    }.freeze
+
+    def initialize(assessment_id:, outgoings:)
+      @assessment_id = assessment_id
+      @outgoings = outgoings
+    end
+
+    def call
+      ActiveRecord::Base.transaction do
+        @outgoings.keys.each { |key| create_outgoing_collection(key) }
+      end
+      self
+    end
+
+    def outgoings
+      disposable_income_summary.outgoings
+    end
+
+    private
+
+    def create_outgoing_collection(key)
+      payments = @outgoings[key]
+      klass = OUTGOING_KLASSES[key]
+      payments.each do |payment_params|
+        klass.create! payment_params.merge(disposable_income_summary: disposable_income_summary)
+      end
+    end
+
+    def disposable_income_summary
+      @disposable_income_summary ||= find_or_create_disposable_income_summary
+    end
+
+    def find_or_create_disposable_income_summary
+      assessment.disposable_income_summary || assessment.create_disposable_income_summary
+    end
+  end
+end

--- a/app/services/creators/properties_creator.rb
+++ b/app/services/creators/properties_creator.rb
@@ -43,13 +43,5 @@ module Creators
       attrs[:main_home] = main_home
       @properties << capital_summary.properties.create!(attrs)
     end
-
-    def assessment
-      @assessment ||= Assessment.find_by(id: assessment_id) || (raise CreationError, ['No such assessment id'])
-    end
-
-    # def capital_summary
-    #   assessment.capital_summary
-    # end
   end
 end

--- a/app/services/creators/state_benefits_creator.rb
+++ b/app/services/creators/state_benefits_creator.rb
@@ -43,9 +43,5 @@ module Creators
       end
       state_benefit
     end
-
-    def assessment
-      @assessment ||= Assessment.find_by(id: assessment_id) || (raise CreationError, ['No such assessment id'])
-    end
   end
 end

--- a/config/initializers/apipie.rb
+++ b/config/initializers/apipie.rb
@@ -8,6 +8,7 @@ Apipie.configure do |config|
   # where is your API defined?
   config.api_controllers_matcher = "#{Rails.root}/app/controllers/**/*.rb"
   config.translate = false
+  config.validate = true
   config.show_all_examples = true
   config.app_info = <<-END_OF_TEXT
     This API is used to determine financial eligibility for Legal Aid from the data passed in.

--- a/db/migrate/20191230112428_create_new_outgoings.rb
+++ b/db/migrate/20191230112428_create_new_outgoings.rb
@@ -5,6 +5,7 @@ class CreateNewOutgoings < ActiveRecord::Migration[6.0]
       t.string :type, null: false
       t.date :payment_date, null: false
       t.decimal :amount, null: false
+      t.string :housing_cost_type
 
       t.timestamps
     end

--- a/db/migrate/20191230141019_remove_housing_cost_type.rb
+++ b/db/migrate/20191230141019_remove_housing_cost_type.rb
@@ -1,0 +1,5 @@
+class RemoveHousingCostType < ActiveRecord::Migration[6.0]
+  def change
+    remove_column :disposable_income_summaries, :housing_cost_type, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_12_30_112428) do
+ActiveRecord::Schema.define(version: 2019_12_30_141019) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -98,7 +98,6 @@ ActiveRecord::Schema.define(version: 2019_12_30_112428) do
     t.decimal "lower_threshold", default: "0.0", null: false
     t.decimal "upper_threshold", default: "0.0", null: false
     t.string "assessment_result", default: "pending", null: false
-    t.string "housing_cost_type", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["assessment_id"], name: "index_disposable_income_summaries_on_assessment_id"
@@ -141,6 +140,7 @@ ActiveRecord::Schema.define(version: 2019_12_30_112428) do
     t.string "type", null: false
     t.date "payment_date", null: false
     t.decimal "amount", null: false
+    t.string "housing_cost_type"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["disposable_income_summary_id"], name: "index_outgoings_on_disposable_income_summary_id"

--- a/doc/apipie_examples.json
+++ b/doc/apipie_examples.json
@@ -2,14 +2,14 @@
   "applicants#create": [
     {
       "verb": "POST",
-      "path": "/assessments/ee52de52-49df-4600-a488-ae5369a20d61/applicant",
+      "path": "/assessments/33bdfdca-01d6-4804-b7d8-e749517920b1/applicant",
       "versions": [
         "1.0"
       ],
       "query": null,
       "request_data": {
         "applicant": {
-          "date_of_birth": "1999-12-13",
+          "date_of_birth": "1999-12-31",
           "involvement_type": "applicant",
           "has_partner_opponent": false,
           "receives_qualifying_benefit": true
@@ -18,14 +18,15 @@
       "response_data": {
         "objects": [
           {
-            "id": "2bb82191-8992-466f-8513-098c99b8902a",
-            "assessment_id": "ee52de52-49df-4600-a488-ae5369a20d61",
-            "date_of_birth": "1999-12-13",
+            "id": "8c0de3bb-4322-43a7-8ee1-67577872067e",
+            "assessment_id": "33bdfdca-01d6-4804-b7d8-e749517920b1",
+            "date_of_birth": "1999-12-31",
             "involvement_type": "applicant",
             "has_partner_opponent": false,
             "receives_qualifying_benefit": true,
-            "created_at": "2019-12-13T11:22:04.592Z",
-            "updated_at": "2019-12-13T11:22:04.592Z"
+            "created_at": "2019-12-31T10:34:46.826Z",
+            "updated_at": "2019-12-31T10:34:46.826Z",
+            "self_employed": false
           }
         ],
         "errors": [
@@ -39,14 +40,14 @@
     },
     {
       "verb": "POST",
-      "path": "/assessments/4391257c-50f1-4961-93c1-3eaea496f991/applicant",
+      "path": "/assessments/7da7c370-681b-4922-a1d0-147189d3210d/applicant",
       "versions": [
         "1.0"
       ],
       "query": null,
       "request_data": {
         "applicant": {
-          "date_of_birth": "1999-12-13",
+          "date_of_birth": "1999-12-31",
           "involvement_type": "applicant",
           "has_partner_opponent": false,
           "receives_qualifying_benefit": "yes"
@@ -80,15 +81,15 @@
         "success": true,
         "objects": [
           {
-            "id": "d4163abf-d209-4c3f-ad5e-adf50e5b46e3",
+            "id": "c3df4aac-2440-4ebf-8663-5630b1a8e693",
             "client_reference_id": "psr-123",
             "remote_ip": {
               "family": 2,
               "addr": 2130706433,
               "mask_addr": 4294967295
             },
-            "created_at": "2019-12-13T11:22:04.618Z",
-            "updated_at": "2019-12-13T11:22:04.618Z",
+            "created_at": "2019-12-31T10:34:46.859Z",
+            "updated_at": "2019-12-31T10:34:46.859Z",
             "submission_date": "2019-06-06",
             "matter_proceeding_type": "domestic_abuse",
             "assessment_result": "pending"
@@ -128,7 +129,7 @@
   "assessments#show": [
     {
       "verb": "GET",
-      "path": "/assessments/2ed140c3-15b6-4959-8222-ca881b80d176",
+      "path": "/assessments/ecf47869-0bfb-4b45-ac1e-b9ffd751e2d9",
       "versions": [
         "1.0"
       ],
@@ -137,61 +138,61 @@
       "response_data": {
         "assessment_result": "contribution_required",
         "applicant": {
-          "receives_qualifying_benefit": false,
+          "receives_qualifying_benefit": true,
           "age_at_submission": 58
         },
         "capital": {
-          "total_liquid": "9043.51",
-          "total_non_liquid": "1613.92",
+          "total_liquid": "8270.37",
+          "total_non_liquid": "7763.89",
           "pensioner_capital_disregard": "0.0",
-          "total_capital": "10970.64",
-          "capital_contribution": "7970.64",
+          "total_capital": "18432.59",
+          "capital_contribution": "15432.59",
           "liquid_capital_items": [
             {
-              "description": "Et nobis nam architecto.",
-              "value": "9043.51"
+              "description": "Sint nihil sit velit.",
+              "value": "8270.37"
             }
           ],
           "non_liquid_capital_items": [
             {
-              "description": "Consequatur et labore itaque.",
-              "value": "1613.92"
+              "description": "Optio velit ut et.",
+              "value": "7763.89"
             }
           ]
         },
         "property": {
           "total_mortgage_allowance": "100000.0",
-          "total_property": "313.21",
+          "total_property": "0.0",
           "main_home": {
-            "value": "2143.64",
-            "transaction_allowance": "64.31",
-            "allowable_outstanding_mortgage": "3861.12",
-            "shared_with_housing_assoc": true,
-            "percentage_owned": "7.82",
-            "net_equity": "-3757.8",
+            "value": "3773.53",
+            "transaction_allowance": "113.21",
+            "allowable_outstanding_mortgage": "1838.88",
+            "shared_with_housing_assoc": false,
+            "percentage_owned": "1.74",
+            "net_equity": "31.69",
             "main_home_equity_disregard": "100000.0",
             "assessed_equity": "0.0"
           },
           "additional_properties": [
             {
-              "value": "7224.37",
-              "transaction_allowance": "216.73",
-              "allowable_outstanding_mortgage": "3795.19",
-              "percentage_owned": "9.75",
-              "assessed_equity": "313.21"
+              "value": "3913.83",
+              "transaction_allowance": "117.41",
+              "allowable_outstanding_mortgage": "8094.31",
+              "percentage_owned": "2.49",
+              "assessed_equity": "0.0"
             }
           ]
         },
         "vehicles": {
-          "total_vehicle": "0.0",
+          "total_vehicle": "2398.33",
           "vehicles": [
             {
-              "in_regular_use": true,
-              "value": "7429.76",
-              "loan_amount_outstanding": "6724.16",
-              "date_of_purchase": "2018-12-08",
-              "included_in_assessment": false,
-              "assessed_value": "0.0"
+              "in_regular_use": false,
+              "included_in_assessment": true,
+              "value": "2398.33",
+              "assessed_value": "2398.33",
+              "date_of_purchase": "2018-11-04",
+              "loan_amount_outstanding": "1628.62"
             }
           ]
         }
@@ -204,7 +205,7 @@
   "capitals#create": [
     {
       "verb": "POST",
-      "path": "/assessments/25ac6524-a093-4840-b3f1-14bec444015e/capitals",
+      "path": "/assessments/37870fb2-ce46-4ef2-9833-7243431f17a3/capitals",
       "versions": [
         "1.0"
       ],
@@ -212,29 +213,29 @@
       "request_data": {
         "bank_accounts": [
           {
-            "description": "ABBOTSTONE AGRICULTURAL PROPERTY UNIT TRUST 47932812",
-            "value": 38538.77
+            "description": "PGMS (GLASGOW) LIMITED 50082982",
+            "value": 55124.06
           },
           {
-            "description": "ABC INTERNATIONAL BANK PLC 87914925",
-            "value": 47006.81
+            "description": "ABG SUNDAL COLLIER LIMITED 76223101",
+            "value": 55924.53
           }
         ],
         "non_liquid_capital": [
           {
-            "description": "R.J.Ewing Trust",
-            "value": 11768.72
+            "description": "Aramco shares",
+            "value": 28924.19
           },
           {
-            "description": "R.J.Ewing Trust",
-            "value": 29038.49
+            "description": "Van Gogh Sunflowers",
+            "value": 29109.64
           }
         ]
       },
       "response_data": {
         "objects": {
-          "id": "952e1e04-3b10-4d86-89a5-65beafcdafa5",
-          "assessment_id": "25ac6524-a093-4840-b3f1-14bec444015e",
+          "id": "3713b53c-7c27-4db7-8a3f-590d01da5c06",
+          "assessment_id": "37870fb2-ce46-4ef2-9833-7243431f17a3",
           "total_liquid": "0.0",
           "total_non_liquid": "0.0",
           "total_vehicle": "0.0",
@@ -247,8 +248,8 @@
           "lower_threshold": "0.0",
           "upper_threshold": "0.0",
           "capital_assessment_result": "pending",
-          "created_at": "2019-12-13T11:22:04.829Z",
-          "updated_at": "2019-12-13T11:22:04.829Z"
+          "created_at": "2019-12-31T10:34:47.133Z",
+          "updated_at": "2019-12-31T10:34:47.133Z"
         },
         "errors": [
 
@@ -261,7 +262,7 @@
     },
     {
       "verb": "POST",
-      "path": "/assessments/313c33f3-5683-48ac-8dd4-9347a34307cd/capitals",
+      "path": "/assessments/404b1257-0655-4aac-8e4a-6c8fd61d14c1/capitals",
       "versions": [
         "1.0"
       ],
@@ -269,22 +270,22 @@
       "request_data": {
         "bank_accounts": [
           {
-            "description": "ABN AMRO HOARE GOVETT CORPORATE FINANCE LTD. 52700825",
-            "value": 57097.77
+            "description": "THE ROYAL BANK OF SCOTLAND PLC (FORMER RBS NV) 76804157",
+            "value": 11984.62
           },
           {
-            "description": "ALKEN ASSET MANAGEMENT 19144563",
-            "value": 93882.49
+            "description": "ABINGWORTH MANAGEMENT LIMITED 64762588",
+            "value": 36211.42
           }
         ],
         "non_liquid_capital": [
           {
-            "description": "Ming Vase",
-            "value": 70031.76
+            "description": "R.J.Ewing Trust",
+            "value": 29855.27
           },
           {
             "description": "Van Gogh Sunflowers",
-            "value": 21515.11
+            "value": 38216.68
           }
         ]
       },
@@ -302,7 +303,7 @@
   "dependants#create": [
     {
       "verb": "POST",
-      "path": "/assessments/267efc63-2f12-4601-9299-d305bd277912/dependants",
+      "path": "/assessments/86c7f0f2-956c-4ee1-a5e6-35092ca9d80a/dependants",
       "versions": [
         "1.0"
       ],
@@ -310,44 +311,44 @@
       "request_data": {
         "dependants": [
           {
-            "date_of_birth": "1992-09-28",
+            "date_of_birth": "1989-10-19",
             "in_full_time_education": false,
-            "relationship": "child_relative",
-            "monthly_income": 9992.41,
-            "assets_value": 7630.61
+            "relationship": "adult_relative",
+            "monthly_income": 586.52,
+            "assets_value": 3707.99
           },
           {
-            "date_of_birth": "1972-07-07",
-            "in_full_time_education": false,
+            "date_of_birth": "1994-06-06",
+            "in_full_time_education": true,
             "relationship": "child_relative",
-            "monthly_income": 9173.28,
-            "assets_value": 8546.77
+            "monthly_income": 8549.4,
+            "assets_value": 4765.59
           }
         ]
       },
       "response_data": {
         "objects": [
           {
-            "id": "6731526d-3030-4c1f-92f0-521ce4166555",
-            "assessment_id": "267efc63-2f12-4601-9299-d305bd277912",
-            "date_of_birth": "1992-09-28",
+            "id": "b9db45fd-a065-4c3f-8c98-864baa3f38d3",
+            "assessment_id": "86c7f0f2-956c-4ee1-a5e6-35092ca9d80a",
+            "date_of_birth": "1989-10-19",
             "in_full_time_education": false,
-            "created_at": "2019-12-13T11:22:04.873Z",
-            "updated_at": "2019-12-13T11:22:04.873Z",
-            "relationship": "child_relative",
-            "monthly_income": "9992.41",
-            "assets_value": "7630.61"
+            "created_at": "2019-12-31T10:34:47.181Z",
+            "updated_at": "2019-12-31T10:34:47.181Z",
+            "relationship": "adult_relative",
+            "monthly_income": "586.52",
+            "assets_value": "3707.99"
           },
           {
-            "id": "4e2f35b5-818c-4420-9889-c8a47a71b95c",
-            "assessment_id": "267efc63-2f12-4601-9299-d305bd277912",
-            "date_of_birth": "1972-07-07",
-            "in_full_time_education": false,
-            "created_at": "2019-12-13T11:22:04.875Z",
-            "updated_at": "2019-12-13T11:22:04.875Z",
+            "id": "e605a80b-4fed-4d7e-b8d3-553d7d37313b",
+            "assessment_id": "86c7f0f2-956c-4ee1-a5e6-35092ca9d80a",
+            "date_of_birth": "1994-06-06",
+            "in_full_time_education": true,
+            "created_at": "2019-12-31T10:34:47.184Z",
+            "updated_at": "2019-12-31T10:34:47.184Z",
             "relationship": "child_relative",
-            "monthly_income": "9173.28",
-            "assets_value": "8546.77"
+            "monthly_income": "8549.4",
+            "assets_value": "4765.59"
           }
         ],
         "errors": [
@@ -361,7 +362,7 @@
     },
     {
       "verb": "POST",
-      "path": "/assessments/a35a25e7-2f64-4f18-a2d5-cda50eea65d9/dependants",
+      "path": "/assessments/074ad5a2-555f-493a-a795-f17694ed9087/dependants",
       "versions": [
         "1.0"
       ],
@@ -369,18 +370,18 @@
       "request_data": {
         "dependants": [
           {
-            "date_of_birth": "1961-06-16",
-            "in_full_time_education": null,
-            "relationship": "child_relative",
-            "monthly_income": 5266.35,
-            "assets_value": 4978.03
-          },
-          {
-            "date_of_birth": "1993-03-26",
+            "date_of_birth": "1999-03-30",
             "in_full_time_education": null,
             "relationship": "adult_relative",
-            "monthly_income": 6627.62,
-            "assets_value": 9225.07
+            "monthly_income": 578.77,
+            "assets_value": 8887.94
+          },
+          {
+            "date_of_birth": "1989-06-17",
+            "in_full_time_education": null,
+            "relationship": "adult_relative",
+            "monthly_income": 6066.22,
+            "assets_value": 6494.89
           }
         ]
       },
@@ -396,7 +397,7 @@
     },
     {
       "verb": "POST",
-      "path": "/assessments/533cc617-bce8-4084-89f6-528547ed47c4/dependants",
+      "path": "/assessments/01077575-5339-4437-9fbb-e3b6a1e536f6/dependants",
       "versions": [
         "1.0"
       ],
@@ -404,18 +405,18 @@
       "request_data": {
         "dependants": [
           {
-            "date_of_birth": "1965-09-19",
-            "in_full_time_education": false,
-            "relationship": "child_relative",
-            "monthly_income": 2794.99,
-            "assets_value": 9060.85
-          },
-          {
-            "date_of_birth": "1993-02-08",
+            "date_of_birth": "1972-01-08",
             "in_full_time_education": true,
             "relationship": "child_relative",
-            "monthly_income": 2119.47,
-            "assets_value": 9804.29
+            "monthly_income": 3975.16,
+            "assets_value": 3477.81
+          },
+          {
+            "date_of_birth": "1968-03-14",
+            "in_full_time_education": true,
+            "relationship": "child_relative",
+            "monthly_income": 8399.87,
+            "assets_value": 8499.61
           }
         ]
       },
@@ -667,7 +668,7 @@
   "other_incomes#create": [
     {
       "verb": "POST",
-      "path": "/assessments/e2f8ced8-0533-41c0-98fe-5cd975550616/other_incomes",
+      "path": "/assessments/b91607ee-e57f-4d62-b08a-dac0ac4a473d/other_incomes",
       "versions": [
         "1.0"
       ],
@@ -713,20 +714,20 @@
       "response_data": {
         "objects": [
           {
-            "id": "58e4a9a1-2639-4b54-b898-f6bd8e1fdab3",
-            "gross_income_summary_id": "6b380d0f-36c6-4152-9ecb-f2c2b1edcd28",
+            "id": "b156e6a0-8546-459d-aad2-ae0b7d6daff1",
+            "gross_income_summary_id": "b9a40ea6-5f17-435a-8fee-39d1bde5b1c1",
             "name": "Student grant",
-            "created_at": "2019-12-13T11:22:04.929Z",
-            "updated_at": "2019-12-13T11:22:04.929Z",
+            "created_at": "2019-12-31T10:34:47.232Z",
+            "updated_at": "2019-12-31T10:34:47.232Z",
             "monthly_income": null,
             "assessment_error": false
           },
           {
-            "id": "c29aeece-9849-4e4b-9bef-234d23155808",
-            "gross_income_summary_id": "6b380d0f-36c6-4152-9ecb-f2c2b1edcd28",
+            "id": "d4d29d8a-1594-4726-b2ff-7d083a1e505a",
+            "gross_income_summary_id": "b9a40ea6-5f17-435a-8fee-39d1bde5b1c1",
             "name": "Help from family",
-            "created_at": "2019-12-13T11:22:04.945Z",
-            "updated_at": "2019-12-13T11:22:04.945Z",
+            "created_at": "2019-12-31T10:34:47.254Z",
+            "updated_at": "2019-12-31T10:34:47.254Z",
             "monthly_income": null,
             "assessment_error": false
           }
@@ -744,47 +745,105 @@
   "outgoings#create": [
     {
       "verb": "POST",
-      "path": "/assessments/f1fe651c-6d26-4f40-b6f0-4feea6cc5678/outgoings",
+      "path": "/assessments/777ecf55-e3e6-462f-9bfc-e74efc31f843/outgoings",
       "versions": [
         "1.0"
       ],
       "query": null,
       "request_data": {
-        "outgoings": [
-          {
-            "outgoing_type": "maintenance",
-            "payment_date": "2019-11-22",
-            "amount": 355.77
-          },
-          {
-            "outgoing_type": "mortgage",
-            "payment_date": "2019-11-22",
-            "amount": 617.24
-          }
-        ]
+        "outgoings": {
+          "childcare": [
+            {
+              "payment_date": "2019-12-10",
+              "amount": 991.17
+            },
+            {
+              "payment_date": "2019-12-10",
+              "amount": 254.44
+            }
+          ],
+          "maintenance": [
+            {
+              "payment_date": "2019-12-10",
+              "amount": 332.79
+            },
+            {
+              "payment_date": "2019-12-10",
+              "amount": 823.18
+            }
+          ],
+          "housing_costs": [
+            {
+              "payment_date": "2019-12-10",
+              "amount": 680.13,
+              "housing_cost_type": "mortgage"
+            },
+            {
+              "payment_date": "2019-12-10",
+              "amount": 763.22,
+              "housing_cost_type": "mortgage"
+            }
+          ]
+        }
       },
       "response_data": {
-        "success": true,
         "outgoings": [
           {
-            "id": "d9ab2fc3-d4de-4174-a4d9-d33d30e9644d",
-            "outgoing_type": "maintenance",
-            "payment_date": "2019-11-22",
-            "amount": "355.77",
-            "assessment_id": "f1fe651c-6d26-4f40-b6f0-4feea6cc5678",
-            "created_at": "2019-12-13T11:22:04.972Z",
-            "updated_at": "2019-12-13T11:22:04.972Z"
+            "id": 793,
+            "disposable_income_summary_id": "f54a0a00-ee8a-4954-8ef6-29a89e7d3810",
+            "payment_date": "2019-12-10",
+            "amount": "991.17",
+            "housing_cost_type": null,
+            "created_at": "2019-12-31T10:34:47.324Z",
+            "updated_at": "2019-12-31T10:34:47.324Z"
           },
           {
-            "id": "08b94977-3f4e-4583-9932-a4b7da2b21e5",
-            "outgoing_type": "mortgage",
-            "payment_date": "2019-11-22",
-            "amount": "617.24",
-            "assessment_id": "f1fe651c-6d26-4f40-b6f0-4feea6cc5678",
-            "created_at": "2019-12-13T11:22:04.974Z",
-            "updated_at": "2019-12-13T11:22:04.974Z"
+            "id": 794,
+            "disposable_income_summary_id": "f54a0a00-ee8a-4954-8ef6-29a89e7d3810",
+            "payment_date": "2019-12-10",
+            "amount": "254.44",
+            "housing_cost_type": null,
+            "created_at": "2019-12-31T10:34:47.327Z",
+            "updated_at": "2019-12-31T10:34:47.327Z"
+          },
+          {
+            "id": 795,
+            "disposable_income_summary_id": "f54a0a00-ee8a-4954-8ef6-29a89e7d3810",
+            "payment_date": "2019-12-10",
+            "amount": "332.79",
+            "housing_cost_type": null,
+            "created_at": "2019-12-31T10:34:47.333Z",
+            "updated_at": "2019-12-31T10:34:47.333Z"
+          },
+          {
+            "id": 796,
+            "disposable_income_summary_id": "f54a0a00-ee8a-4954-8ef6-29a89e7d3810",
+            "payment_date": "2019-12-10",
+            "amount": "823.18",
+            "housing_cost_type": null,
+            "created_at": "2019-12-31T10:34:47.334Z",
+            "updated_at": "2019-12-31T10:34:47.334Z"
+          },
+          {
+            "id": 797,
+            "disposable_income_summary_id": "f54a0a00-ee8a-4954-8ef6-29a89e7d3810",
+            "payment_date": "2019-12-10",
+            "amount": "680.13",
+            "housing_cost_type": "mortgage",
+            "created_at": "2019-12-31T10:34:47.340Z",
+            "updated_at": "2019-12-31T10:34:47.340Z"
+          },
+          {
+            "id": 798,
+            "disposable_income_summary_id": "f54a0a00-ee8a-4954-8ef6-29a89e7d3810",
+            "payment_date": "2019-12-10",
+            "amount": "763.22",
+            "housing_cost_type": "mortgage",
+            "created_at": "2019-12-31T10:34:47.341Z",
+            "updated_at": "2019-12-31T10:34:47.341Z"
           }
         ],
+        "success": true,
         "errors": [
 
         ]
@@ -801,18 +860,40 @@
       ],
       "query": null,
       "request_data": {
-        "outgoings": [
-          {
-            "outgoing_type": "maintenance",
-            "payment_date": "2019-11-22",
-            "amount": 905.02
-          },
-          {
-            "outgoing_type": "mortgage",
-            "payment_date": "2019-11-22",
-            "amount": 744.92
-          }
-        ]
+        "outgoings": {
+          "childcare": [
+            {
+              "payment_date": "2019-12-10",
+              "amount": 356.67
+            },
+            {
+              "payment_date": "2019-12-10",
+              "amount": 862.08
+            }
+          ],
+          "maintenance": [
+            {
+              "payment_date": "2019-12-10",
+              "amount": 414.02
+            },
+            {
+              "payment_date": "2019-12-10",
+              "amount": 229.18
+            }
+          ],
+          "housing_costs": [
+            {
+              "payment_date": "2019-12-10",
+              "amount": 279.97,
+              "housing_cost_type": "rent"
+            },
+            {
+              "payment_date": "2019-12-10",
+              "amount": 428.03,
+              "housing_cost_type": "rent"
+            }
+          ]
+        }
       },
       "response_data": {
         "errors": [
@@ -828,7 +909,7 @@
   "properties#create": [
     {
       "verb": "POST",
-      "path": "/assessments/114f321d-a058-4319-bcc0-ff798ca89b29/properties",
+      "path": "/assessments/52954f39-63e2-43f0-b566-31172f00c8ca/properties",
       "versions": [
         "1.0"
       ],
@@ -860,15 +941,15 @@
       "response_data": {
         "objects": [
           {
-            "id": "8e2aabc9-04a9-40a3-aa02-e3adb0913b03",
+            "id": "3b8f2878-509e-4e89-a77a-0bfb0b0b27cc",
             "value": "500000.0",
             "outstanding_mortgage": "200.0",
             "percentage_owned": "15.0",
             "main_home": true,
             "shared_with_housing_assoc": true,
-            "created_at": "2019-12-13T11:22:04.993Z",
-            "updated_at": "2019-12-13T11:22:04.993Z",
-            "capital_summary_id": "e7729bcb-8940-4a20-a393-f68be1b82ba4",
+            "created_at": "2019-12-31T10:34:47.365Z",
+            "updated_at": "2019-12-31T10:34:47.365Z",
+            "capital_summary_id": "72f0c411-75bd-40ad-8f95-0cd198d570e0",
             "transaction_allowance": "0.0",
             "allowable_outstanding_mortgage": "0.0",
             "net_value": "0.0",
@@ -877,15 +958,15 @@
             "main_home_equity_disregard": "0.0"
           },
           {
-            "id": "468baf90-0172-4fd1-a7ac-b9c9d00763bf",
+            "id": "c8f86e60-ee21-45d1-86ea-0efa65da26db",
             "value": "1000.0",
             "outstanding_mortgage": "0.0",
             "percentage_owned": "99.0",
             "main_home": false,
             "shared_with_housing_assoc": false,
-            "created_at": "2019-12-13T11:22:04.995Z",
-            "updated_at": "2019-12-13T11:22:04.995Z",
-            "capital_summary_id": "e7729bcb-8940-4a20-a393-f68be1b82ba4",
+            "created_at": "2019-12-31T10:34:47.368Z",
+            "updated_at": "2019-12-31T10:34:47.368Z",
+            "capital_summary_id": "72f0c411-75bd-40ad-8f95-0cd198d570e0",
             "transaction_allowance": "0.0",
             "allowable_outstanding_mortgage": "0.0",
             "net_value": "0.0",
@@ -894,15 +975,15 @@
             "main_home_equity_disregard": "0.0"
           },
           {
-            "id": "760263eb-b22e-454d-8f55-3ad61e7c1f2c",
+            "id": "516393dd-0c48-4248-bd11-906538612b07",
             "value": "10000.0",
             "outstanding_mortgage": "40.0",
             "percentage_owned": "80.0",
             "main_home": false,
             "shared_with_housing_assoc": true,
-            "created_at": "2019-12-13T11:22:04.997Z",
-            "updated_at": "2019-12-13T11:22:04.997Z",
-            "capital_summary_id": "e7729bcb-8940-4a20-a393-f68be1b82ba4",
+            "created_at": "2019-12-31T10:34:47.370Z",
+            "updated_at": "2019-12-31T10:34:47.370Z",
+            "capital_summary_id": "72f0c411-75bd-40ad-8f95-0cd198d570e0",
             "transaction_allowance": "0.0",
             "allowable_outstanding_mortgage": "0.0",
             "net_value": "0.0",
@@ -922,7 +1003,7 @@
     },
     {
       "verb": "POST",
-      "path": "/assessments/0fdd31bc-7a1e-47de-8ed0-3dfbeb0f9b7c/properties",
+      "path": "/assessments/6ab19a14-79ec-446b-a74b-265133627d81/properties",
       "versions": [
         "1.0"
       ],
@@ -965,7 +1046,7 @@
   "state_benefits#create": [
     {
       "verb": "POST",
-      "path": "/assessments/a605c9c6-854b-4ecd-9d41-52bb7f9fd2fc/state_benefits",
+      "path": "/assessments/2f70f18f-a30a-4fa8-b606-76a700a2fe82/state_benefits",
       "versions": [
         "1.0"
       ],
@@ -1011,20 +1092,22 @@
       "response_data": {
         "objects": [
           {
-            "id": "09d56302-1dd5-4514-b987-2c3c17ae4ecf",
-            "gross_income_summary_id": "7499eec8-1a1f-4c0a-8f06-c3acf146c7a2",
-            "state_benefit_type_id": "2d643b5f-b0b2-4837-89fc-75d3df2fe9d2",
+            "id": "0f526186-b9b5-4139-ae65-703339a87188",
+            "gross_income_summary_id": "3565c614-0298-4bd6-a04e-9f25088bff3d",
+            "state_benefit_type_id": "aa396d83-76b7-494c-add0-2872d983ba0a",
             "name": null,
-            "created_at": "2019-12-13T11:22:05.042Z",
-            "updated_at": "2019-12-13T11:22:05.042Z"
+            "created_at": "2019-12-31T10:34:47.423Z",
+            "updated_at": "2019-12-31T10:34:47.423Z",
+            "monthly_value": "0.0"
           },
           {
-            "id": "8af5070c-33de-4ccd-b00d-e2b243a15dc2",
-            "gross_income_summary_id": "7499eec8-1a1f-4c0a-8f06-c3acf146c7a2",
-            "state_benefit_type_id": "f0a1fb54-1643-4dd1-a043-d7af8514214f",
+            "id": "e407fc88-cdc7-4900-bec4-96af4ea09c0a",
+            "gross_income_summary_id": "3565c614-0298-4bd6-a04e-9f25088bff3d",
+            "state_benefit_type_id": "d8cf0352-8e8d-43bf-b525-08f08f178283",
             "name": null,
-            "created_at": "2019-12-13T11:22:05.059Z",
-            "updated_at": "2019-12-13T11:22:05.059Z"
+            "created_at": "2019-12-31T10:34:47.445Z",
+            "updated_at": "2019-12-31T10:34:47.445Z",
+            "monthly_value": "0.0"
           }
         ],
         "errors": [
@@ -1038,7 +1121,7 @@
     },
     {
       "verb": "POST",
-      "path": "/assessments/45072ac1-475a-4f5f-b008-c0e8ce99189b/state_benefits",
+      "path": "/assessments/d86ac979-60ae-43e7-90e9-fb73723f1007/state_benefits",
       "versions": [
         "1.0"
       ],
@@ -1094,7 +1177,7 @@
   "vehicles#create": [
     {
       "verb": "POST",
-      "path": "/assessments/c4e7b7a1-3517-4e2e-ac2f-3780c2372f41/vehicles",
+      "path": "/assessments/4272bbfd-795c-4150-9f5c-3635cf67b6fa/vehicles",
       "versions": [
         "1.0"
       ],
@@ -1102,15 +1185,15 @@
       "request_data": {
         "vehicles": [
           {
-            "value": 9026.96,
-            "loan_amount_outstanding": 1147.93,
-            "date_of_purchase": "2017-01-21",
-            "in_regular_use": false
+            "value": 8884.65,
+            "loan_amount_outstanding": 6763.02,
+            "date_of_purchase": "2015-05-09",
+            "in_regular_use": true
           },
           {
-            "value": 6562.87,
-            "loan_amount_outstanding": 6581.15,
-            "date_of_purchase": "2017-09-15",
+            "value": 1583.11,
+            "loan_amount_outstanding": 5054.41,
+            "date_of_purchase": "2016-01-11",
             "in_regular_use": false
           }
         ]
@@ -1118,26 +1201,26 @@
       "response_data": {
         "vehicles": [
           {
-            "id": "0d74133a-a02d-49b1-b6ee-d5ec3dd45aba",
-            "value": "9026.96",
-            "loan_amount_outstanding": "1147.93",
-            "date_of_purchase": "2017-01-21",
-            "in_regular_use": false,
-            "created_at": "2019-12-13T11:22:05.092Z",
-            "updated_at": "2019-12-13T11:22:05.092Z",
-            "capital_summary_id": "42ca5ca1-c509-4eea-8635-56b5b5814fae",
+            "id": "f827a799-52bf-4c07-b0d9-69891c38f317",
+            "value": "8884.65",
+            "loan_amount_outstanding": "6763.02",
+            "date_of_purchase": "2015-05-09",
+            "in_regular_use": true,
+            "created_at": "2019-12-31T10:34:47.486Z",
+            "updated_at": "2019-12-31T10:34:47.486Z",
+            "capital_summary_id": "5e469bab-56b3-4170-b2bb-c0e4f7aba88c",
             "included_in_assessment": false,
             "assessed_value": "0.0"
           },
           {
-            "id": "228295b5-59a1-4168-affc-2abbb622f8a2",
-            "value": "6562.87",
-            "loan_amount_outstanding": "6581.15",
-            "date_of_purchase": "2017-09-15",
+            "id": "fa3a7463-a763-4809-936c-e6718f5cfecf",
+            "value": "1583.11",
+            "loan_amount_outstanding": "5054.41",
+            "date_of_purchase": "2016-01-11",
             "in_regular_use": false,
-            "created_at": "2019-12-13T11:22:05.093Z",
-            "updated_at": "2019-12-13T11:22:05.093Z",
-            "capital_summary_id": "42ca5ca1-c509-4eea-8635-56b5b5814fae",
+            "created_at": "2019-12-31T10:34:47.488Z",
+            "updated_at": "2019-12-31T10:34:47.488Z",
+            "capital_summary_id": "5e469bab-56b3-4170-b2bb-c0e4f7aba88c",
             "included_in_assessment": false,
             "assessed_value": "0.0"
           }
@@ -1161,15 +1244,15 @@
       "request_data": {
         "vehicles": [
           {
-            "value": 2369.45,
-            "loan_amount_outstanding": 6593.55,
-            "date_of_purchase": "2019-05-23",
-            "in_regular_use": true
+            "value": 2612.18,
+            "loan_amount_outstanding": 9761.76,
+            "date_of_purchase": "2018-10-11",
+            "in_regular_use": false
           },
           {
-            "value": 7844.04,
-            "loan_amount_outstanding": 2900.96,
-            "date_of_purchase": "2016-12-17",
+            "value": 8134.78,
+            "loan_amount_outstanding": 9840.74,
+            "date_of_purchase": "2016-06-15",
             "in_regular_use": false
           }
         ]

--- a/spec/requests/outgoings_spec.rb
+++ b/spec/requests/outgoings_spec.rb
@@ -1,0 +1,132 @@
+require 'rails_helper'
+
+RSpec.describe OutgoingsController, type: :request do
+  describe 'POST /assessments/:assessment_id/outgoings' do
+    let(:assessment) { create :assessment }
+    let(:disposable_income_summary) { assessment.disposable_income_summary }
+    let(:payment_date) { 3.weeks.ago.strftime('%Y-%m-%d') }
+    let(:housing_cost_type) { Outgoings::HousingCost.housing_cost_types.values.sample }
+    let(:headers) { { 'CONTENT_TYPE' => 'application/json' } }
+
+    let(:params) do
+      {
+        outgoings: outgoings_params
+      }
+    end
+
+    subject { post assessment_outgoings_path(assessment), params: params.to_json, headers: headers }
+
+    it 'returns http success', :show_in_doc do
+      subject
+      expect(response).to have_http_status(:success)
+    end
+
+    it 'creates outgoings' do
+      expect { subject }.to change { Outgoings::BaseOutgoing.count }.by(6)
+    end
+
+    it 'sets success flag to true' do
+      subject
+      expect(parsed_response[:success]).to be true
+    end
+
+    it 'returns blank errors' do
+      subject
+      expect(parsed_response[:errors]).to be_empty
+    end
+
+    context 'with an invalid id' do
+      let(:assessment) { 33 }
+
+      before { subject }
+
+      it 'returns unprocessable', :show_in_doc do
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+
+      it 'returns error information' do
+        expect(parsed_response[:errors].join).to match(/Invalid.*assessment_id/)
+      end
+
+      it 'sets success flag to false' do
+        expect(parsed_response[:success]).to be false
+      end
+    end
+
+    context 'with an invalid payment date' do
+      let(:payment_date) { 3.days.from_now.strftime('%Y-%m-%d') }
+
+      before { subject }
+
+      it 'returns unprocessable' do
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+
+      it 'returns error information' do
+        expect(parsed_response[:errors].join).to match(/Invalid.*payment_date/)
+      end
+
+      it 'sets success flag to false' do
+        expect(parsed_response[:success]).to be false
+      end
+    end
+
+    context 'with a failure to save' do
+      let(:service) { double 'success?' => false, errors: [:foo] }
+      before do
+        expect(Creators::OutgoingsCreator).to receive(:call).and_return(service)
+        subject
+      end
+
+      it 'returns unprocessable' do
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+
+      it 'returns error information' do
+        expect(parsed_response[:errors].join).to match(/foo/)
+      end
+
+      it 'sets success flag to false' do
+        expect(parsed_response[:success]).to be false
+      end
+    end
+
+    def outgoings_params
+      {
+        childcare: [
+          {
+            payment_date: payment_date,
+            amount: Faker::Number.decimal(l_digits: 3, r_digits: 2)
+          },
+          {
+            payment_date: payment_date,
+            amount: Faker::Number.decimal(l_digits: 3, r_digits: 2)
+          }
+        ],
+        maintenance: [
+          {
+            payment_date: payment_date,
+            amount: Faker::Number.decimal(l_digits: 3, r_digits: 2)
+          },
+          {
+            payment_date: payment_date,
+            amount: Faker::Number.decimal(l_digits: 3, r_digits: 2)
+          }
+        ],
+        housing_costs: [
+          {
+            payment_date: payment_date,
+            amount: Faker::Number.decimal(l_digits: 3, r_digits: 2),
+            housing_cost_type: housing_cost_type
+          },
+          {
+            payment_date: payment_date,
+            amount: Faker::Number.decimal(l_digits: 3, r_digits: 2),
+            housing_cost_type: housing_cost_type
+
+          }
+        ]
+      }
+    end
+  end
+end

--- a/spec/requests/outgoings_spec.rb
+++ b/spec/requests/outgoings_spec.rb
@@ -71,6 +71,20 @@ RSpec.describe OutgoingsController, type: :request do
       end
     end
 
+    context 'without housing costs or maintenance payments' do
+      let(:params) do
+        {
+          outgoings: outgoings_params.except(:housing_costs).except(:maintenance)
+        }
+      end
+      it 'create the childcare records but does not create any other records' do
+        expect { subject }.to change { Outgoings::BaseOutgoing.count }.by(2)
+        expect(disposable_income_summary.childcare_outgoings.count).to eq 2
+        expect(disposable_income_summary.housing_cost_outgoings.count).to eq 0
+        expect(disposable_income_summary.maintenance_outgoings.count).to eq 0
+      end
+    end
+
     context 'with a failure to save' do
       let(:service) { double 'success?' => false, errors: [:foo] }
       before do

--- a/spec/services/creators/outgoings_creator_spec.rb
+++ b/spec/services/creators/outgoings_creator_spec.rb
@@ -1,0 +1,72 @@
+require 'rails_helper'
+
+module Creators
+  RSpec.describe OutgoingsCreator do
+    describe '.call' do
+      let(:assessment) { create :assessment }
+      let(:outgoings) { outgoings_params }
+      let(:housing_cost_type_rent) { 'rent' }
+      let(:housing_cost_type_mortgage) { 'mortgage' }
+
+      subject { described_class.call(assessment_id: assessment.id, outgoings: outgoings) }
+      it 'creates a disposable_income_summary if one doesnt already exist' do
+        expect { subject }.to change { DisposableIncomeSummary.count }.by(1)
+      end
+
+      it 'does not create an additional disposable_income_summary if one exists already' do
+        assessment.create_disposable_income_summary
+        expect { subject }.not_to change { DisposableIncomeSummary.count }
+      end
+
+      it 'creates all the required outgoing records' do
+        expect { subject }.to change { Outgoings::BaseOutgoing.count }.by(6)
+
+        childcares = assessment.disposable_income_summary.childcare_outgoings.order(:payment_date)
+        expect(childcares.first.payment_date).to eq Date.parse('2019-11-09')
+        expect(childcares.first.amount.to_f).to eq 584.31
+        expect(childcares.last.payment_date).to eq Date.parse('2019-12-09')
+        expect(childcares.last.amount.to_f).to eq 266.95
+
+        maintenances = assessment.disposable_income_summary.maintenance_outgoings.order(:payment_date)
+        expect(maintenances.first.payment_date).to eq Date.parse('2019-11-06')
+        expect(maintenances.first.amount.to_f).to eq 506.78
+        expect(maintenances.last.payment_date).to eq Date.parse('2019-12-06')
+        expect(maintenances.last.amount.to_f).to eq 193.47
+
+        housings = assessment.disposable_income_summary.housing_cost_outgoings.order(:payment_date)
+        expect(housings.first.payment_date).to eq Date.parse('2019-11-01')
+        expect(housings.first.amount.to_f).to eq 810.38
+        expect(housings.first.housing_cost_type).to eq 'mortgage'
+        expect(housings.last.payment_date).to eq Date.parse('2019-12-01')
+        expect(housings.last.amount.to_f).to eq 299.38
+        expect(housings.last.housing_cost_type).to eq 'rent'
+      end
+
+      context 'error in params' do
+        let(:housing_cost_type_rent) { 'xxxx' }
+
+        it 'doesnt create any outgoing records if there is an error' do
+          expect { subject }.to raise_error ArgumentError, "'xxxx' is not a valid housing_cost_type"
+          expect(Outgoings::BaseOutgoing.count).to eq 0
+        end
+      end
+
+      def outgoings_params
+        {
+          childcare: [
+            { payment_date: '2019-12-09', amount: 266.95 },
+            { payment_date: '2019-11-09', amount: 584.31 }
+          ],
+          maintenance: [
+            { payment_date: '2019-12-06', amount: 193.47 },
+            { payment_date: '2019-11-06', amount: 506.78 }
+          ],
+          housing_costs: [
+            { payment_date: '2019-12-01', amount: 299.38, housing_cost_type: housing_cost_type_rent },
+            { payment_date: '2019-11-01', amount: 810.38, housing_cost_type: housing_cost_type_mortgage }
+          ]
+        }
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Rewrote Outgoings controller to handle the updated payload and database structure

The old `OutgoingsController` and `OutgoingsCreationService` were removed in the previous PR when the database was restructured in order to prevent failing tests.  This implements the new controllers and creation services to manage input int he new format and use the new database structure.

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1148)

- Added `Outgoings Controller`
- Added `OutgoingsCreationService`
- Moved the type of housing cost from `DisposableIncomeSummary` record to each individual `Outgoings::HousingCost` records
- Moved the `#assessment` method from individual creation services to `Creators::BaseCreator`

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
