### PR TITLE
AP1213 Use StateBenefitsCalculator to calculator total monthly state benefits

### DIFF
--- a/app/services/calculators/state_benefits_calculator.rb
+++ b/app/services/calculators/state_benefits_calculator.rb
@@ -1,9 +1,7 @@
-module Collators
-  class StateBenefitCollator < BaseWorkflowService
+module Calculators
+  class StateBenefitsCalculator < BaseWorkflowService
     def call
-      gross_income_summary.update!(
-        monthly_state_benefits: total_monthly_state_benefits
-      )
+      total_monthly_state_benefits
     end
 
     private

--- a/app/services/collators/gross_income_collator.rb
+++ b/app/services/collators/gross_income_collator.rb
@@ -45,21 +45,13 @@ module Collators
     end
 
     def monthly_state_benefits
-      @monthly_state_benefits ||= collect_state_benefits
+      @monthly_state_benefits ||= Calculators::StateBenefitsCalculator.call(assessment)
     end
 
     def collect_other_incomes
       total = 0.0
       gross_income_summary.other_income_sources.each do |source|
         total += source.calculate_monthly_income!
-      end
-      total
-    end
-
-    def collect_state_benefits
-      total = 0.0
-      gross_income_summary.state_benefits.each do |state_benefit|
-        total += state_benefit.calculate_monthly_amount!
       end
       total
     end

--- a/spec/requests/assessments_spec.rb
+++ b/spec/requests/assessments_spec.rb
@@ -288,7 +288,7 @@ RSpec.describe AssessmentsController, type: :request do
     create :other_income_payment, other_income_source: ois, payment_date: Date.parse('31/3/2019'), amount: 1415
     create :other_income_payment, other_income_source: ois, payment_date: Date.parse('30/4/2019'), amount: 1415
 
-    sbt = create :state_benefit_type, label: 'child_benefit', name: 'Child Benefit'
+    sbt = create :state_benefit_type, label: 'child_benefit', name: 'Child Benefit', exclude_from_gross_income: false
     sb = create :state_benefit, state_benefit_type: sbt, gross_income_summary: gis
     create :state_benefit_payment, state_benefit: sb, payment_date: Date.parse('1/2/2019'), amount: 200
     create :state_benefit_payment, state_benefit: sb, payment_date: Date.parse('1/3/2019'), amount: 200

--- a/spec/services/calculators/state_benefits_calculator_spec.rb
+++ b/spec/services/calculators/state_benefits_calculator_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
-module Collators
-  RSpec.describe StateBenefitCollator do
+module Calculators
+  RSpec.describe StateBenefitsCalculator do
     let(:assessment) { create :assessment, :with_gross_income_summary }
     let(:gross_income_summary) { assessment.gross_income_summary }
     subject { described_class.call(assessment) }
@@ -22,9 +22,8 @@ module Collators
                state_benefit_type: state_benefit_type_included
       end
       context 'weekly payments' do
-        it 'updates gross income summary' do
-          subject
-          expect(gross_income_summary.reload.monthly_state_benefits).to eq 216.67
+        it 'returns correct total monthly state benefits' do
+          expect(subject).to eq 216.67
         end
       end
 
@@ -36,9 +35,8 @@ module Collators
                  gross_income_summary: gross_income_summary,
                  state_benefit_type: another_state_benefit_type_included
         end
-        it 'updates gross income summary with the sum of both monthly and weekly benefits' do
-          subject
-          expect(gross_income_summary.reload.monthly_state_benefits).to eq(216.67 + 75)
+        it 'returns correct sum of both monthly and weekly benefits' do
+          expect(subject).to eq(216.67 + 75)
         end
       end
       context 'mixture of included and excluded benefits' do
@@ -49,9 +47,8 @@ module Collators
                  gross_income_summary: gross_income_summary,
                  state_benefit_type: state_benefit_type_excluded
         end
-        it 'updates gross income summary with the sum amounts of only included benefits' do
-          subject
-          expect(gross_income_summary.reload.monthly_state_benefits).to eq(216.67)
+        it 'returns correct sum amounts of only included benefits' do
+          expect(subject).to eq(216.67)
         end
       end
     end


### PR DESCRIPTION
Use StateBenefitsCalculator in GrossIncomeCollator

## What

[Link to story](https://dsdmoj.atlassian.net/secure/RapidBoard.jspa?rapidView=233&projectKey=AP&modal=detail&selectedIssue=AP-1213)

- Change StateBenefitCollator to a calculator (StateBenefitsCalculator)
- Return total_monthly_state_benefits from StateBenefitsCalculator
- Call and use return value of StateBenefitsCalculator in GrossIncomeCollator
- Update tests

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
