### PR TITLE
FIX: Make CircleCI auto-deploy to UAT

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -231,21 +231,21 @@ workflows:
         filters:
           branches:
             ignore:
-              - /dependabot.*/
+              - /dependabot\/bundler\/.*/
     - auto-deploy-uat:
         requires:
           - build_and_test
         filters:
           branches:
             only:
-              - /dependabot.*/
+              - /dependabot\/bundler\/.*/
     - deploy_uat:
         requires:
         - hold_uat
         filters:
           branches:
             ignore:
-              - /dependabot.*/
+              - /dependabot\/bundler\/.*/
     - hold_staging:
         type: approval
         requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -128,7 +128,7 @@ jobs:
         name: Helm deployment to UAT
         command: |
           IMG_REPO="$ECR_ENDPOINT/laa-apply-for-legal-aid/check-financial-eligibility-service"
-          RELEASE_NAME=$(echo $CIRCLE_BRANCH | sed 's:^\w*\/::' | tr -s ' _/[]()' '-' | cut -c1-30 | sed 's/-$//')
+          RELEASE_NAME=$(echo $CIRCLE_BRANCH | sed 's:^\w*\/::' | tr -s ' _/[]().' '-' | cut -c1-30 | sed 's/-$//')
           RELEASE_HOST="$RELEASE_NAME-check-financial-uat.apps.live-1.cloud-platform.service.justice.gov.uk"
 
           echo "Deploying CIRCLE_SHA1: $CIRCLE_SHA1 under release name: '$RELEASE_NAME'..."

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,7 +111,7 @@ jobs:
     - *setup_aws_cli
     - *push_to_ecr
 
-  deploy_uat:
+  deploy_uat: &deploy_uat
     <<: *deploy_container_config
     steps:
     - checkout
@@ -142,6 +142,9 @@ jobs:
                         --set image.repository="$IMG_REPO" \
                         --set image.tag="$CIRCLE_SHA1" \
                         --set ingress.hosts="{$RELEASE_HOST}"
+
+  auto-deploy-uat:
+    <<: *deploy_uat
 
   deploy_staging:
     <<: *deploy_container_config
@@ -225,6 +228,13 @@ workflows:
         type: approval
         requires:
         - build_and_test
+    - auto-deploy-uat:
+        requires:
+          - build_and_test
+        filters:
+          branches:
+            only:
+              - /dependabot.*/
     - deploy_uat:
         requires:
         - hold_uat

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -228,6 +228,10 @@ workflows:
         type: approval
         requires:
         - build_and_test
+        filters:
+          branches:
+            ignore:
+              - /dependabot.*/
     - auto-deploy-uat:
         requires:
           - build_and_test
@@ -238,6 +242,10 @@ workflows:
     - deploy_uat:
         requires:
         - hold_uat
+        filters:
+          branches:
+            ignore:
+              - /dependabot.*/
     - hold_staging:
         type: approval
         requires:


### PR DESCRIPTION
## What

Step 1:
This should make CircleCI auto-deploy PRs if the branch name starts with dependabot
It creates an auto-deploy-uat job and filters it to run for PR's starting with dependabot

Step 2:
Ignore the manual hold and deploy steps for dependabot prefixed branches

Step 3:
Use correct regex for dependabot PR's, they are always `dependabot/bundler/gem_name-version`

## Step one seems to have worked...
![image](https://user-images.githubusercontent.com/6757677/75265189-72e71f00-57e8-11ea-9916-ebfbe9ae7605.png)

##Step two working too
![image](https://user-images.githubusercontent.com/6757677/75265637-17696100-57e9-11ea-926c-cedfa4727b08.png)
##Step 3
![image](https://user-images.githubusercontent.com/6757677/75265982-9ced1100-57e9-11ea-98cd-d7712762747a.png)
This has correctly reverted to the manual jobs as my branch name does not match the true dependabot branch naming convention

## Checklist

Before you ask people to review this PR:

- [ ] Tests and rubocop should be passing: `bundle exec rake`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [ ] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [ ] The PR description should say what you changed and why, with a link to the JIRA story.
- [ ] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
