### PR TITLE
Circle-Update: Add filter to circleci/config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -232,6 +232,7 @@ workflows:
           branches:
             ignore:
               - /dependabot\/bundler\/.*/
+              - master
     - auto-deploy-uat:
         requires:
           - build_and_test
@@ -239,6 +240,7 @@ workflows:
           branches:
             only:
               - /dependabot\/bundler\/.*/
+              - master
     - deploy_uat:
         requires:
         - hold_uat
@@ -246,6 +248,7 @@ workflows:
           branches:
             ignore:
               - /dependabot\/bundler\/.*/
+              - master
     - hold_staging:
         type: approval
         requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -217,13 +217,25 @@ jobs:
       - run:
           name: Delete UAT release
           command: |
-            ./bin/delete_uat_release
+            ./bin/delete_uat_release.sh
 
 workflows:
   version: 2
   build_and_deploy:
     jobs:
     - build_and_test
+    - delete_uat:
+        filters:
+          branches:
+            only: master
+    - auto-deploy-uat:
+        requires:
+          - build_and_test
+        filters:
+          branches:
+            only:
+              - /dependabot\/bundler\/.*/
+              - master
     - hold_uat:
         type: approval
         requires:
@@ -231,14 +243,6 @@ workflows:
         filters:
           branches:
             ignore:
-              - /dependabot\/bundler\/.*/
-              - master
-    - auto-deploy-uat:
-        requires:
-          - build_and_test
-        filters:
-          branches:
-            only:
               - /dependabot\/bundler\/.*/
               - master
     - deploy_uat:

--- a/bin/delete_uat_release.sh
+++ b/bin/delete_uat_release.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+GIT_MESSAGE=$(git log --format=%B -n 1 $CIRCLE_SHA1)
+
+echo "git message is:"
+echo "$GIT_MESSAGE"
+
+if [[ $GIT_MESSAGE == "Merge pull request #"* ]]
+then
+  MERGED_BRANCH=$(echo $GIT_MESSAGE | sed -n "s/^.*from ministryofjustice\/\s*\(\S*\).*$/\1/p")
+  UAT_RELEASE="apply-$(echo $MERGED_BRANCH | sed 's:^\w*\/::' | tr -s ' _/[]().' '-' | cut -c1-30 | sed 's/-$//')"
+
+  echo "Attempting to delete UAT release $UAT_RELEASE"
+
+  UAT_RELEASES=$(helm list --tiller-namespace=${KUBE_ENV_UAT_NAMESPACE} --all)
+
+  echo "Current UAT releases:"
+  echo "$UAT_RELEASES"
+
+  if [[ $UAT_RELEASES == *"$UAT_RELEASE"* ]]
+  then
+    echo "Deleting UAT release $UAT_RELEASE"
+    helm delete $UAT_RELEASE --tiller-namespace=${KUBE_ENV_UAT_NAMESPACE} --purge
+  else
+    echo "UAT release $UAT_RELEASE was not found"
+  fi
+
+else
+  echo "This commit is not a merged pull request"
+fi


### PR DESCRIPTION
## What
These duplicate the working steps used in apply

It will ignore the hold_ and deploy_uat steps for merges to master,
while running the auto-deploy-uat step instead

I have also implemented the delete_UAT step.  It was defined in the config file, but never called and the bin script was missing.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
