### PR TITLE
FIX: Remove the apply prefix in the delete_uat script

### DIFF
--- a/bin/delete_uat_release.sh
+++ b/bin/delete_uat_release.sh
@@ -8,7 +8,7 @@ echo "$GIT_MESSAGE"
 if [[ $GIT_MESSAGE == "Merge pull request #"* ]]
 then
   MERGED_BRANCH=$(echo $GIT_MESSAGE | sed -n "s/^.*from ministryofjustice\/\s*\(\S*\).*$/\1/p")
-  UAT_RELEASE="apply-$(echo $MERGED_BRANCH | sed 's:^\w*\/::' | tr -s ' _/[]().' '-' | cut -c1-30 | sed 's/-$//')"
+  UAT_RELEASE="$(echo $MERGED_BRANCH | sed 's:^\w*\/::' | tr -s ' _/[]().' '-' | cut -c1-30 | sed 's/-$//')"
 
   echo "Attempting to delete UAT release $UAT_RELEASE"
 


### PR DESCRIPTION
## What
This was a copy/paste omission from the apply script

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
