### PR TITLE
FIX: Update manual test step

### DIFF
--- a/.github/workflows/manual-integration-tests.yml
+++ b/.github/workflows/manual-integration-tests.yml
@@ -3,19 +3,49 @@ name: manual-integration-tests
 on:
   repository_dispatch:
     types: manual-trigger
+  schedule:
+    - cron:  '0 10 * * *'
 
 jobs:
   build:
+
     runs-on: ubuntu-latest
 
+    services:
+      postgres:
+        image: postgres:10.11
+        ports: ["5432:5432"]
+        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Ruby 2.6
-      uses: actions/setup-ruby@v1
-      with:
-        ruby-version: 2.6.x
-    - name: Build and test with Rake
-      run: |
-        gem install bundler
-        bundle install --jobs 4 --retry 3
-        VERBOSE=true bundle exec rspec spec/integration/test_runner_spec.rb
+      - uses: actions/checkout@v2
+      - name: Set up Ruby 2.6
+        uses: actions/setup-ruby@v1
+        with:
+          ruby-version: 2.6.x
+      - uses: actions/cache@v1
+        with:
+          path: vendor/bundle
+          key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-gems-
+      - name: Bundle install
+        run: |
+          bundle config path vendor/bundle
+          bundle install --jobs 4 --retry 3
+      - name: Configure database
+        env:
+          PGHOST: localhost
+          PGUSER: postgres
+          RAILS_ENV: test
+        run: |
+          bin/rails db:create db:schema:load
+      - name: Run Tests
+        env:
+          PGHOST: localhost
+          PGUSER: postgres
+          RAILS_ENV: test
+          SKIP_COVERAGE: true
+          VERBOSE: true
+        run: |
+          bundle exec rspec spec/integration/test_runner_spec.rb

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,7 @@
 require 'simplecov'
 require 'vcr'
 
-SimpleCov.minimum_coverage 100
+SimpleCov.minimum_coverage 100 unless ENV['SKIP_COVERAGE']
 
 unless ENV['NOCOVERAGE']
   SimpleCov.start do


### PR DESCRIPTION
## What

* Add postgres and configure for the test runs
* Implement a skip_coverage env_var this allows us to run *some* tests without the coverage drop causing the test to "fail"
* configure caching of the bundler set, this speeds up the run 

Triggering the job is via an API call using curl/postman/etc
``` sh
curl -H "Accept: application/vnd.github.everest-preview+json" \
     -H "Authorization: token <YOUR PERSONAL ACCESS TOKEN>" \
     --request POST \
     --data '{"event_type": "manual-trigger"}' \
     https://api.github.com/repos/ministryofjustice/check-financial-eligibility/dispatches
```

## Next steps
- implement a google drive link (working on local branch, awaiting central access to google cloud platform for the access key) to pull down new xlsx version of google sheet source
- Configure a call back that monitors the job and returns the success/failure and values returned
- Set up a slack bot that can be triggered, call the job and return the status


## Checklist

Before you ask people to review this PR:

- [ ] Tests and rubocop should be passing: `bundle exec rake`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [ ] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [ ] The PR description should say what you changed and why, with a link to the JIRA story.
- [ ] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
