### PR TITLE
AP-1361 Payment Period bugfix

### DIFF
--- a/app/models/concerns/monthly_equivalent_calculator.rb
+++ b/app/models/concerns/monthly_equivalent_calculator.rb
@@ -39,8 +39,6 @@ module MonthlyEquivalentCalculator
   end
 
   def converter
-    raise "Unable to calculate payment frequency for #{self.class} with payment dates #{payment_dates.inspect}" if frequency == :unknown
-
     @converter ||= Calculators::MonthlyIncomeConverter.new(frequency, payment_amounts)
   end
 

--- a/app/services/utilities/payment_period_analyser.rb
+++ b/app/services/utilities/payment_period_analyser.rb
@@ -25,6 +25,7 @@ module Utilities
     end
 
     def period_pattern
+      return :unknown if dates.size < 2
       return :monthly if monthly?
       return :weekly if weekly?
       return :two_weekly if two_weekly?

--- a/spec/models/other_income_source_spec.rb
+++ b/spec/models/other_income_source_spec.rb
@@ -38,10 +38,12 @@ RSpec.describe OtherIncomeSource, type: :model do
     context 'unknown payment frequency' do
       before { expect(analyser).to receive(:period_pattern).and_return(:unknown) }
 
-      it 'raises an exception' do
-        expect {
-          subject
-        }.to raise_error RuntimeError, /Unable to calculate payment frequency for OtherIncomeSource with payment dates \[.*\]/
+      let!(:payment1) { create :other_income_payment, other_income_source: source, payment_date: 1.day.ago.to_date, amount: 301.0 }
+      let!(:payment2) { create :other_income_payment, other_income_source: source, payment_date: 5.days.ago.to_date, amount: 123.45 }
+      let!(:payment3) { create :other_income_payment, other_income_source: source, payment_date: 45.days.ago.to_date, amount: 87.10 }
+
+      it 'returns the average of the payments' do
+        expect(subject).to eq 170.52
       end
     end
   end

--- a/spec/services/utilities/payment_period_analyser_spec.rb
+++ b/spec/services/utilities/payment_period_analyser_spec.rb
@@ -210,6 +210,22 @@ module Utilities
           expect(described_class.new(dates).period_pattern).to eq :two_weekly
         end
       end
+
+      context 'irregular payments' do
+        context 'just one payment' do
+          let(:string_dates) { ['2019-05-15'] }
+          it 'returns two-weekly' do
+            expect(described_class.new(dates).period_pattern).to eq :unknown
+          end
+        end
+
+        context 'two payments 10 days apart' do
+          let(:string_dates) { '2019-05-15, 2019-05-25'.split(', ') }
+          it 'returns two-weekly' do
+            expect(described_class.new(dates).period_pattern).to eq :unknown
+          end
+        end
+      end
     end
 
     describe '#period_pattern' do


### PR DESCRIPTION
## Fix bug that was causing the service to crash when given unorthodox payment periods

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1361)

There were in fact two bugs:
 - The `PaymentPeriodAnalyser` was not set up to handle arrays of dates comprising just one instance in the array
- Although the `MonthlyIncomeConverter` had been modified to just return the average monthly payment for unknown period types, the `MonthlyEquivalentCalculator` was raising an exception if the period type was unknown before calling it.

## Checklist

Before you ask people to review this PR:

- [ ] Tests and rubocop should be passing: `bundle exec rake`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [ ] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [ ] The PR description should say what you changed and why, with a link to the JIRA story.
- [ ] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
