### PR TITLE
Fix bug preventing noisy output of integration tests

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -28,6 +28,10 @@ Metrics/ParameterLists:
   Exclude:
     - 'spec/**/*'
 
+
+Layout/SpaceAroundMethodCallOperator:
+  Enabled: true
+
 Layout/LineLength:
   Max: 180
 
@@ -78,3 +82,7 @@ Style/HashTransformKeys:
 
 Style/HashTransformValues:
   Enabled: true
+
+Style/ExponentialNotation:
+  Enabled: true
+

--- a/lib/integration_helpers/expected_result.rb
+++ b/lib/integration_helpers/expected_result.rb
@@ -40,7 +40,8 @@ class ExpectedResult
     capital_contribution
   ].freeze
 
-  def initialize(expected_result_hash)
+  def initialize(worksheet_name, expected_result_hash)
+    @worksheet_name = worksheet_name
     @expected_result = expected_result_hash
     @actual_result = nil
   end
@@ -84,7 +85,7 @@ class ExpectedResult
   # :nocov:
   def display_differences_header
     header_pattern = '%40s  %-22s %-22s'
-    puts format(header_pattern, '', 'Expected', 'Actual')
+    puts format(header_pattern, @worksheet_name, 'Expected', 'Actual')
     puts format(header_pattern, '', '=========', '=========')
   end
   # :nocov:

--- a/lib/tasks/integration.rake
+++ b/lib/tasks/integration.rake
@@ -1,10 +1,10 @@
 desc 'Run integration tests in verbose mode, pass [silent] to run quiet, [noisy] to run extra noisy or nothing for normal noisiness'
 task :integration, [:silent] => :environment do |_task, args|
   integration_test_file = Rails.root.join('spec/integration/test_runner_spec.rb')
-  if args.silent == 'noisy'
-    verbosity = 'noisy'
-  else
-    verbosity = args.silent.blank?
-  end
+  verbosity = if args.silent == 'noisy'
+                'noisy'
+              else
+                args.silent.blank?
+              end
   system "VERBOSE=#{verbosity} bundle exec rspec #{integration_test_file}"
 end

--- a/lib/tasks/integration.rake
+++ b/lib/tasks/integration.rake
@@ -1,6 +1,10 @@
-desc 'Run integration tests in verbose mode, pass [silent] to run quiet'
+desc 'Run integration tests in verbose mode, pass [silent] to run quiet, [noisy] to run extra noisy or nothing for normal noisiness'
 task :integration, [:silent] => :environment do |_task, args|
   integration_test_file = Rails.root.join('spec/integration/test_runner_spec.rb')
-  silent = args.silent.blank?
-  system "VERBOSE=#{silent} bundle exec rspec #{integration_test_file}"
+  if args.silent == 'noisy'
+    verbosity = 'noisy'
+  else
+    verbosity = args.silent.blank?
+  end
+  system "VERBOSE=#{verbosity} bundle exec rspec #{integration_test_file}"
 end

--- a/spec/integration/test_runner_spec.rb
+++ b/spec/integration/test_runner_spec.rb
@@ -90,15 +90,15 @@ RSpec.describe 'IntegrationTests::TestRunner', type: :request do
         end
         get assessment_path(assessment_id), headers: headers
         expected_results = ExpectedResultsExtractor.new(spreadsheet, worksheet_name).run
-        results[worksheet_name] = compare_results(parsed_response, expected_results)
+        results[worksheet_name] = compare_results(worksheet_name, parsed_response, expected_results)
       end
       expect(results).to show_all_integration_tests_passed
     end
 
-    def compare_results(actual_results_hash, expected_results_hash)
+    def compare_results(worksheet_name, actual_results_hash, expected_results_hash)
       actual_result = ActualResult.new(actual_results_hash)
       noisy_pp actual_result, 'ASSESSMENT RESULT'
-      expected_result = ExpectedResult.new(expected_results_hash)
+      expected_result = ExpectedResult.new(worksheet_name, expected_results_hash)
       expected_result == actual_result
     end
 


### PR DESCRIPTION
## Fix bug preventing noisy output of integration tests

Integration tests can either be run in three modes:
- silent (used in Circle CI testing - just pass if all tests pass, otherwise fail)
- verbose (normal, with results printed for each tests)
- noisy (prints payloads sent and received for each step, as well as detailed results)

The verbose mode is default.
Silent mode is enabled by adding [silent] to the rake task, e.g. 
     `rake integration[silent]`

Noisy mode should be enabled by adding noisy to the rake task
    `rake integration[noisy]`

There was a bug preventing this from happening.  This PR fixes it.

Also, now prints the name of the worksheet against the results.
## Checklist

Before you ask people to review this PR:

- [ ] Tests and rubocop should be passing: `bundle exec rake`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [ ] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [ ] The PR description should say what you changed and why, with a link to the JIRA story.
- [ ] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
