### PR TITLE
Revert "Bump byebug from 11.1.2 to 11.1.3"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -70,7 +70,7 @@ GEM
     bootsnap (1.4.6)
       msgpack (~> 1.0)
     builder (3.2.4)
-    byebug (11.1.3)
+    byebug (11.1.2)
     case_transform (0.2)
       activesupport
     climate_control (0.2.0)


### PR DESCRIPTION
Reverts ministryofjustice/check-financial-eligibility#231

this byebug update appears to be breaking:

spec/services/utilities/payment_period_analyser_spec.rb:302 

This reverts the change for now until we can identify and fix the issue