### PR TITLE
AP-1401 adding Remarks to Assessment

### DIFF
--- a/app/models/assessment.rb
+++ b/app/models/assessment.rb
@@ -1,6 +1,8 @@
 class Assessment < ApplicationRecord
   extend EnumHash
 
+  serialize :remarks
+
   validates :remote_ip,
             :submission_date,
             :matter_proceeding_type, presence: true
@@ -22,5 +24,10 @@ class Assessment < ApplicationRecord
 
   def capital_assessment_result
     capital_summary.assessment_result
+  end
+
+  # Always instanitate a new Remarks object from a nil value
+  def remarks
+    attributes['remarks'] || Remarks.new
   end
 end

--- a/config/initializers/remarks.rb
+++ b/config/initializers/remarks.rb
@@ -1,0 +1,2 @@
+# We need to load this class before the ActiveRecord framework as it is serialized on the Assessment model
+Remarks

--- a/db/migrate/20200514131226_add_remarks_to_assessment.rb
+++ b/db/migrate/20200514131226_add_remarks_to_assessment.rb
@@ -1,0 +1,5 @@
+class AddRemarksToAssessment < ActiveRecord::Migration[6.0]
+  def change
+    add_column :assessments, :remarks, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_04_30_145529) do
+ActiveRecord::Schema.define(version: 2020_05_14_131226) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -44,6 +44,7 @@ ActiveRecord::Schema.define(version: 2020_04_30_145529) do
     t.date "submission_date", null: false
     t.string "matter_proceeding_type", null: false
     t.string "assessment_result", default: "pending", null: false
+    t.text "remarks"
     t.index ["client_reference_id"], name: "index_assessments_on_client_reference_id"
   end
 

--- a/spec/models/assessment_spec.rb
+++ b/spec/models/assessment_spec.rb
@@ -18,4 +18,29 @@ RSpec.describe Assessment, type: :model do
       expect(assessment.errors.full_messages).to include("Remote ip can't be blank")
     end
   end
+
+  describe '#remarks' do
+    context 'nil value in database' do
+      it 'instantiates a new empty Remarks object' do
+        assessment = create :assessment, remarks: nil
+        expect(assessment.remarks.class).to eq Remarks
+        expect(assessment.remarks.as_json).to eq Remarks.new.as_json
+      end
+    end
+
+    context 'saving and reloading' do
+      let(:remarks) do
+        r = Remarks.new
+        r.add(:other_income, :unknown_frequency, 'abc', 'def')
+        r.add(:other_income, :amount_variation, 'ghu', 'jkl')
+        r
+      end
+
+      let(:assessment) { create :assessment, remarks: remarks }
+
+      it 'reconstitutes into a remarks class with the same values' do
+        expect(assessment.remarks.as_json).to eq remarks.as_json
+      end
+    end
+  end
 end

--- a/spec/services/remarks_spec.rb
+++ b/spec/services/remarks_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe Remarks do
         end
       end
 
-      context 'addint a new type' do
+      context 'adding a new type' do
         it 'adds the new type' do
           remarks.add(:state_benefits, :amount_variation, 'def', 'ghi')
           expected_hash = {


### PR DESCRIPTION
## Add Remarks class to Assessment

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1401)

- added a column `remarks` to the `assessments` table to hold a serialized `Remarks` class
- Automatically instantiate a new `Remarks` class if the value of that column is nil
- Add an initializer for the `Remarks` class to ensure the class is loaded before the first Assessment

## Checklist

Before you ask people to review this PR:

- [ ] Tests and rubocop should be passing: `bundle exec rake`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [ ] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [ ] The PR description should say what you changed and why, with a link to the JIRA story.
- [ ] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
