### PR TITLE
AP1370 Set CircleCI Timezone to Europe/London

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,6 +28,7 @@ references:
         - RAILS_ENV=test
         - PGHOST=localhost
         - PGUSER=user
+        - TZ: "Europe/London"
     - image: postgres:10.5
       environment:
         - POSTGRES_USER=user


### PR DESCRIPTION
AP1370 Set CircleCI Timezone to Europe/London

[Link to story](https://dsdmoj.atlassian.net/secure/RapidBoard.jspa?rapidView=233&projectKey=AP&modal=detail&selectedIssue=AP-1370)

Set the timezone in CircleCi to use Europe/London. This accounts for any GMT to BST (vice versa) changes. As CircleCI was using UTC, which is the same as GMT in Ruby.

Why?

This together fixes the issue of calculating a threshold value that is on the day of the newly introduced values e.g. 06/04/2020 new threshold values were created and placed in a file. 

In the class Threshold under the ".value_for" method 'time < at' compares times. In CircleCI it was comparing BST at 00:00:00 +1 < CircleCI UTC/GMT of 00:00:00 +0, causing old thresholds to be used.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
