### PR TITLE
BugFix - Add old outgoing type names for earlier integration tests spreadsheet

### DIFF
--- a/app/services/remarks.rb
+++ b/app/services/remarks.rb
@@ -1,13 +1,20 @@
 class Remarks
   attr_reader :remarks_hash
 
+  # The types outgoings_childcare, outgoings_maintenance_out and outgoings_rent_or_mortgage are retained for compatibility with earlier versions of integration test spreadsheet
+  # TODO:
+  # Remove the above types when no longer required
+
   VALID_TYPES = %i[
     other_income_payment
     state_benefit_payment
     outgoings_child_care
+    outgoings_childcare
     outgoings_legal_aid
     outgoings_maintenance
+    outgoings_maintenance_out
     outgoings_housing_cost
+    outgoings_rent_or_mortgage
   ].freeze
   VALID_ISSUES = %i[unknown_frequency amount_variation].freeze
 

--- a/spec/integration/remarks_spec.rb
+++ b/spec/integration/remarks_spec.rb
@@ -181,7 +181,7 @@ RSpec.describe 'Full Assessment with remarks' do
           ]
         },
         {
-          name: 'maintenance_out', # irregular payment dates
+          name: %w[maintenance_out maintenance].sample, # irregular payment dates with old version type name maintenance
           payments: [
             {
               payment_date: '2019-11-03',


### PR DESCRIPTION
**BugFix** 

Add old outgoing type names for earlier integration tests spreadsheet

This fixes an error in sentry "_ArgumentError Invalid type: outgoings_childcare_" instead of outgoings_child_care  sent by the master uat branch in Apply

childcare, housing_costs and maintenance type names are retained for compatibility with earlier versions of integration test spreadsheet

Please see in the OutgoingsCreator class under OUTGOING_KLASSES

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
