### PR TITLE
AP1435 Capture all errors in the application controller

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,7 @@
 class ApplicationController < ActionController::API
-  rescue_from Apipie::ParamError do |e|
+  rescue_from StandardError do |e|
     render_unprocessable([e.message])
+    Raven.capture_exception(e)
   end
 
   def render_unprocessable(message)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,7 +1,10 @@
 class ApplicationController < ActionController::API
   rescue_from StandardError do |e|
-    render_unprocessable([e.message])
     Raven.capture_exception(e)
+    render json: { success: false, errors: ["#{e.class}: #{e.message}"] }, status: :unprocessable_entity
+  end
+  rescue_from Apipie::ParamError do |e|
+    render_unprocessable([e.message])
   end
 
   def render_unprocessable(message)

--- a/app/services/creators/applicant_creator.rb
+++ b/app/services/creators/applicant_creator.rb
@@ -17,7 +17,6 @@ module Creators
     def create
       create_applicant
     rescue CreationError => e
-      Raven.capture_exception(e)
       self.errors = e.errors
     end
 

--- a/app/services/creators/other_incomes_creator.rb
+++ b/app/services/creators/other_incomes_creator.rb
@@ -24,7 +24,6 @@ module Creators
         assessment
         create_other_income
       rescue CreationError => e
-        Raven.capture_exception(e)
         self.errors = e.errors
       end
     end

--- a/spec/requests/application_controller_spec.rb
+++ b/spec/requests/application_controller_spec.rb
@@ -1,0 +1,49 @@
+require 'rails_helper'
+
+RSpec.describe ApplicationController, type: :request do
+  class TestController < ::ApplicationController
+    def show
+      if params[:raise_error]
+        35 / 0
+      else
+        render_success
+      end
+    end
+  end
+
+  before do
+    Rails.application.routes.draw do
+      get '/my_test', to: 'test#show'
+    end
+  end
+  after do
+    Rails.application.reload_routes!
+  end
+
+  context 'no error raised' do
+    it 'returns json success response' do
+      expected_response = {
+        success: true,
+        errors: []
+      }.to_json
+      get '/my_test'
+      expect(parsed_response).to eq JSON.parse(expected_response, symbolize_names: true)
+    end
+  end
+
+  context 'raising an error' do
+    it 'returns standard error response' do
+      expected_response = {
+        success: false,
+        errors: ['ZeroDivisionError: divided by 0']
+      }.to_json
+      get '/my_test?raise_error=1'
+      expect(parsed_response).to eq JSON.parse(expected_response, symbolize_names: true)
+    end
+
+    it 'is captured by Raven' do
+      expect(Raven).to receive(:capture_exception).with(instance_of(ZeroDivisionError))
+      get '/my_test?raise_error=1'
+    end
+  end
+end

--- a/spec/services/creators/applicant_creator_spec.rb
+++ b/spec/services/creators/applicant_creator_spec.rb
@@ -65,11 +65,6 @@ module Creators
               end
             end
 
-            it 'captures error' do
-              expect(Raven).to receive(:capture_exception).with(message_contains('Date of birth cannot be in future'))
-              subject
-            end
-
             it 'does not create an applicant' do
               expect { subject }.not_to change { Applicant.count }
             end
@@ -80,11 +75,6 @@ module Creators
 
             it 'returns an error' do
               expect(subject.errors).to eq ['No such assessment id']
-            end
-
-            it 'captures error' do
-              expect(Raven).to receive(:capture_exception).with(message_contains('No such assessment id'))
-              subject
             end
           end
 
@@ -110,11 +100,6 @@ module Creators
             describe '#errors' do
               it 'returns error' do
                 expect(subject.errors[0]).to eq 'There is already an applicant for this assesssment'
-              end
-
-              it 'captures error' do
-                expect(Raven).to receive(:capture_exception).with(message_contains('There is already an applicant for this assesssment'))
-                subject
               end
             end
           end

--- a/spec/services/creators/other_incomes_creator_spec.rb
+++ b/spec/services/creators/other_incomes_creator_spec.rb
@@ -65,11 +65,6 @@ module Creators
             }
           }
         end
-
-        it 'captures an error' do
-          expect(Raven).to receive(:capture_exception).with(message_contains('No such assessment id'))
-          subject
-        end
       end
 
       def expected_dates


### PR DESCRIPTION
AP1435 Capture all errors in the application controller

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1435)

Capture all errors in the application controller, reducing the risk of returning a 500 internal server to users of this service.

- Add a `rescue_from StandardError` in the application controller to catch any uncaught errors at the highest level. 

- Add request test for the application controller

- Update creator tests to no longer call Raven.capture_exception as it will be called via the application controller.


----------
I tried and failed to standardise error capturing:

I tried standardising errors using the method stated in this blog [Error Handling in Rails — The Modular Way](https://medium.com/rails-ember-beyond/error-handling-in-rails-the-modular-way-9afcddd2fe1b) but it's a little overcomplicated for this application. Perhaps one day useful. 🤞
The creator service objects all have a success or error method, which uses any errors raised within it to define its success and failure. Leaving service objects to catch their own errors makes it more modular and less entangled, I believe. Feel free to comment otherwise.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
