### PR TITLE
AP-1441 Add client id to integration tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,18 +37,18 @@ PRIVATE_KEY_ID
 PRIVATE_KEY
 CLIENT_EMAIL
 CLIENT_ID
-``` 
+```
 A copy of the `.env` file including the current values can be found in the `Shared-LAA` section of LastPass
 
 ## Integration tests
-Several use cases and their expected results can be found in the google spreadsheet https://docs.google.com/spreadsheets/d/16X7ORqVRpC0BMxgsXn8_NR9ul4MNPWUbYqmpeoBstIo .
+Several use cases and their expected results can be found in the google spreadsheet https://docs.google.com/spreadsheets/d/1tgZUPtamZnpI-dibN8Q78miqZSfEYBnwBhaXFyFZ8no.
 
 Once the master Google spreadsheet is edited, the next time the unit test (`spec/integration/test_runner_spec.rb`) is started it will export the file to (`tmp/integration_test_data.xlsx`) and it will over-write any existing copy in the same location.
 
 This ensures that the service returns the expected results for the use cases of the spreadsheet.
 
-To run just the integration tests and see detailed output, run: 
-   
+To run just the integration tests and see detailed output, run:
+
    ```VERBOSE=true bundle exec rspec spec/integration/test_runner_spec.rb```
 
 or more simply:

--- a/lib/integration_helpers/deeply_nested_payload_generator.rb
+++ b/lib/integration_helpers/deeply_nested_payload_generator.rb
@@ -28,8 +28,6 @@ class DeeplyNestedPayloadGenerator
     }
   }.freeze
 
-  FAKE_CLIENT_ID = SecureRandom.uuid.freeze
-
   def initialize(rows, payload_type)
     @rows = rows
     @payload_type = payload_type
@@ -48,7 +46,7 @@ class DeeplyNestedPayloadGenerator
 
       store_amount(row) if amount?(row)
 
-      client_id?(row) ? store_client_id(row) : create_client_id(row)
+      store_client_id(row) if client_id?(row)
     end
     store_payment_source
     { top_level_name => @payload }
@@ -152,10 +150,5 @@ class DeeplyNestedPayloadGenerator
   def store_client_id(row)
     _object, _source, _attr, value = row
     @payment_hash[client_id_method] = value
-  end
-
-  # TODO: Remove #create_client_id method when integration tests spreadsheet passess in client_id with payments
-  def create_client_id(_row)
-    @payment_hash[client_id_method] = FAKE_CLIENT_ID
   end
 end

--- a/spec/integration_helpers/deeply_nested_payload_generator_spec.rb
+++ b/spec/integration_helpers/deeply_nested_payload_generator_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 require Rails.root.join 'lib/integration_helpers/deeply_nested_payload_generator.rb'
 
 RSpec.describe DeeplyNestedPayloadGenerator do
-  let(:client_id) { DeeplyNestedPayloadGenerator::FAKE_CLIENT_ID }
+  let(:client_id) { 'fake_client_id' }
 
   describe '#run' do
     let(:type) { :other_incomes }
@@ -18,6 +18,7 @@ RSpec.describe DeeplyNestedPayloadGenerator do
     [
       %w[other_incomes friends_or_family],
       [nil, nil, 'date', Date.parse('2020-02-07')],
+      [nil, nil, 'client_id', client_id],
       [nil, nil, 'amount', 250.0],
       [nil, nil, 'date', Date.parse('2020-02-08')],
       [nil, nil, 'client_id', client_id],
@@ -32,9 +33,6 @@ RSpec.describe DeeplyNestedPayloadGenerator do
     { other_incomes: [
       { source: 'friends_or_family',
         payments: [
-          {
-            client_id: client_id
-          },
           {
             date: Date.parse('2020-02-07'),
             client_id: client_id,


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1441)

The integration test spreadsheet has been updated so that all transactions in the Other Incomes, Outgoings and State Benefits categories now include a `client_id`.

As a result, the `create_client_id` method in `DeeplyNestedPayloadGenerator` is no longer necessary. This commit removes it and adjusts the logic so that the `client_id` from the spreadsheet is used.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
