### PR TITLE
AP-1606 Add remark generator for residual balances

### DIFF
--- a/app/services/remark_generators/orchestrator.rb
+++ b/app/services/remark_generators/orchestrator.rb
@@ -21,6 +21,7 @@ module RemarkGenerators
 
       check_amount_variations
       check_frequencies
+      check_residual_balances
     end
 
     private
@@ -41,6 +42,10 @@ module RemarkGenerators
       outgoings.group_by(&:type).each do |_type, collection|
         FrequencyChecker.call(@assessment, collection)
       end
+    end
+
+    def check_residual_balances
+      ResidualBalanceChecker.call(@assessment)
     end
 
     def state_benefits

--- a/app/services/remark_generators/residual_balance_checker.rb
+++ b/app/services/remark_generators/residual_balance_checker.rb
@@ -1,0 +1,35 @@
+module RemarkGenerators
+  class ResidualBalanceChecker
+    def self.call(assessment)
+      new(assessment).call
+    end
+
+    def initialize(assessment)
+      @assessment = assessment
+    end
+
+    def call
+      populate_remarks if residual_balance?
+    end
+
+    private
+
+    def residual_balance?
+      current_accounts = assessment.capital_items.where(description: 'Current accounts')
+      highest_current_account_balance = current_accounts.map(&:value).max || 0
+      capital_exceeds_lower_threshold? && highest_current_account_balance.positive?
+    end
+
+    def capital_exceeds_lower_threshold?
+      assessment.capital_summary.assessed_capital > assessment.capital_summary.lower_threshold
+    end
+
+    def populate_remarks
+      my_remarks = assessment.remarks
+      my_remarks.add(:current_account_balance, :residual_balance, [])
+      assessment.update!(remarks: my_remarks)
+    end
+
+    attr_reader :assessment
+  end
+end

--- a/app/services/remarks.rb
+++ b/app/services/remarks.rb
@@ -15,8 +15,9 @@ class Remarks
     outgoings_maintenance_out
     outgoings_housing_cost
     outgoings_rent_or_mortgage
+    current_account_balance
   ].freeze
-  VALID_ISSUES = %i[unknown_frequency amount_variation].freeze
+  VALID_ISSUES = %i[unknown_frequency amount_variation residual_balance].freeze
 
   def initialize
     @remarks_hash = {}

--- a/spec/services/remark_generators/orchestrator_spec.rb
+++ b/spec/services/remark_generators/orchestrator_spec.rb
@@ -24,6 +24,7 @@ module RemarkGenerators
       expect(AmountVariationChecker).to receive(:call).with(assessment, maintenance_outgoings)
       expect(AmountVariationChecker).to receive(:call).with(assessment, housing_outgoings)
       expect(AmountVariationChecker).to receive(:call).with(assessment, legal_aid_outgoings)
+      expect(ResidualBalanceChecker).to receive(:call).with(assessment)
 
       described_class.call(assessment)
     end

--- a/spec/services/remark_generators/residual_balance_checker_spec.rb
+++ b/spec/services/remark_generators/residual_balance_checker_spec.rb
@@ -1,0 +1,77 @@
+require 'rails_helper'
+
+module RemarkGenerators
+  RSpec.describe ResidualBalanceChecker do
+    let(:assessment) { create :assessment, capital_summary: capital_summary }
+    let(:capital_summary) { create :capital_summary, lower_threshold: 3000, assessed_capital: 4000 }
+
+    context 'when a residual balance exists and assessed capital is above the lower threshold' do
+      let!(:current_account) { create :liquid_capital_item, description: 'Current accounts', value: 100, capital_summary: capital_summary }
+
+      it 'adds the remark when a residual balance exists' do
+        expect_any_instance_of(Remarks).to receive(:add).with(:current_account_balance, :residual_balance, [])
+        described_class.call(assessment)
+      end
+
+      it 'stores the changed the remarks class on the assessment' do
+        original_remarks = assessment.remarks.as_json
+        described_class.call(assessment)
+        expect(assessment.reload.remarks.as_json).not_to eq original_remarks
+      end
+    end
+
+    context 'when there is no residual balance' do
+      let!(:current_account) { create :liquid_capital_item, description: 'Current accounts', value: 0, capital_summary: capital_summary }
+
+      it 'does not update the remarks class' do
+        original_remarks = assessment.remarks.as_json
+        described_class.call(assessment)
+        expect(assessment.reload.remarks.as_json).to eq original_remarks
+      end
+    end
+
+    context 'when capital assessment is below the lower threshold' do
+      let(:capital_summary) { create :capital_summary, lower_threshold: 3000, assessed_capital: 1000 }
+
+      it 'does not update the remarks class' do
+        original_remarks = assessment.remarks.as_json
+        described_class.call(assessment)
+        expect(assessment.reload.remarks.as_json).to eq original_remarks
+      end
+    end
+
+    context 'when there is no residual balance and assessed capital is below the lower threshold' do
+      let(:capital_summary) { create :capital_summary, lower_threshold: 3000, assessed_capital: 1000 }
+      let!(:current_account) { create :liquid_capital_item, description: 'Current accounts', value: 0, capital_summary: capital_summary }
+
+      it 'does not update the remarks class' do
+        original_remarks = assessment.remarks.as_json
+        described_class.call(assessment)
+        expect(assessment.reload.remarks.as_json).to eq original_remarks
+      end
+    end
+
+    context 'with multiple current accounts' do
+      context 'when there is a residual_balance in any account' do
+        let!(:current_account_1) { create :liquid_capital_item, description: 'Current accounts', value: 100, capital_summary: capital_summary }
+        let!(:current_account_2) { create :liquid_capital_item, description: 'Current accounts', value: -200, capital_summary: capital_summary }
+
+        it 'adds the remark when a residual balance exists' do
+          expect_any_instance_of(Remarks).to receive(:add).with(:current_account_balance, :residual_balance, [])
+          described_class.call(assessment)
+        end
+      end
+
+      context 'when there is no residual_balance in any account' do
+        let!(:current_account_1) { create :liquid_capital_item, description: 'Current accounts', value: 0, capital_summary: capital_summary }
+        let!(:current_account_2) { create :liquid_capital_item, description: 'Current accounts', value: -100, capital_summary: capital_summary }
+
+        it 'does not update the remarks class' do
+          original_remarks = assessment.remarks.as_json
+          described_class.call(assessment)
+          expect(assessment.reload.remarks.as_json).to eq original_remarks
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1606)

Related to Apply PR https://github.com/ministryofjustice/laa-apply-for-legal-aid/pull/1704

If an applicant's assessed capital is above the lower threshold and their current account balance is greater than zero, the application needs to be flagged for caseworker review.

This PR adds a remark generator to identify such cases and add a remark.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
