### PR TITLE
AP-1756 Add gem to implement content-security-policy headers

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -48,6 +48,9 @@ gem 'google_drive'
 # parse spreadsheets
 gem 'roo', '~> 2.8.3'
 
+# Manage security headers
+gem 'secure_headers'
+
 group :development, :test do
   gem 'awesome_print'
   gem 'dotenv-rails', '>= 2.7.6'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -271,6 +271,7 @@ GEM
       rubocop-ast (>= 0.4.0)
     ruby-progressbar (1.10.1)
     rubyzip (2.3.0)
+    secure_headers (6.3.1)
     sentry-raven (3.1.1)
       faraday (>= 1.0)
     shellany (0.0.1)
@@ -346,6 +347,7 @@ DEPENDENCIES
   rspec-rails (~> 4.0, >= 4.0.1)
   rubocop
   rubocop-performance
+  secure_headers
   sentry-raven
   shoulda-matchers
   simplecov

--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -1,0 +1,8 @@
+SecureHeaders::Configuration.configure do |config|
+  # rubocop:disable Lint/PercentStringArray
+  config.csp = {
+    default_src: %w['none'],
+    script_src: %w['none']
+  }
+  # rubocop:enable Lint/PercentStringArray
+end


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1756)

See 4.14 of the security testing report.

Adds the `secure_headers` gem and configures it to generate content-security-policy (CSP) headers. The recommendation was to add this header `Content-Security-Policy: script-src 'self'; object-src 'none'; require-trusted-types-for 'script';` however as CFE is an API-only application I have set it at its most restrictive (ie `'none'` for all) as no scripts/styles/images should ever be loaded.

The suggested `require-trusted-types-for-` element is described in [guidance](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy) as 'an experimental API that should not be used in production code' so I have omitted it.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
