### PR TITLE
AP-1755 Set nginx server-tokens to false

### DIFF
--- a/deploy/helm/templates/ingress.yaml
+++ b/deploy/helm/templates/ingress.yaml
@@ -3,8 +3,6 @@ apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
-  annotations:
-    nginx.org/server-tokens: off
   labels:
     app: {{ template "app.name" . }}
     chart: {{ template "app.chart" . }}
@@ -26,3 +24,13 @@ spec:
               serviceName: {{ $fullName }}
               servicePort: http
   {{- end }}
+---
+kind: ConfigMap
+apiVersion: networking.k8s.io/v1beta1
+metadata:
+  name: ingress-nginx-controller
+  namespace: laa-apply-for-legalaid-uat
+data:
+  proxy-connect-timeout: "10"
+  proxy-read-timeout: "120"
+  proxy-send-timeout: "120"

--- a/deploy/helm/templates/ingress.yaml
+++ b/deploy/helm/templates/ingress.yaml
@@ -3,6 +3,8 @@ apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
+  annotations:
+    nginx.org/server-tokens: off
   labels:
     app: {{ template "app.name" . }}
     chart: {{ template "app.chart" . }}


### PR DESCRIPTION
## AP-1755 Set nginx server-tokens to false

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1755)

-  Set nginx server-tokens to false to obfuscate server information in the http response e.g. when you curl the website cfe.../apidocs in the terminal

- This is part of the security fixes

## Checklist

Before you ask people to review this PR:

- [ ] Tests and rubocop should be passing: `bundle exec rake`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [ ] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [ ] The PR description should say what you changed and why, with a link to the JIRA story.
- [ ] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
