### PR TITLE
BUGFIX Allow public file sources to be loaded for apipie

### DIFF
--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -1,8 +1,10 @@
 SecureHeaders::Configuration.configure do |config|
   # rubocop:disable Lint/PercentStringArray
   config.csp = {
-    default_src: %w['none'],
-    script_src: %w['none']
+    default_src: %w['self'],
+    script_src: %w['self'],
+    img_src: %w['self' data:],
+    style_src: %w['self' 'unsafe-inline']
   }
   # rubocop:enable Lint/PercentStringArray
 end


### PR DESCRIPTION
Allow public file sources / resources to be loaded for apipie which wasn't because of the secure_headers csp change

After adding the secure_headers gem, assets from the public file were being blocked by the browser because it was not whitelisted. This has been seen with stylesheets and javascript not being loaded for apipie.

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1780)

- Allow origin source to be whitelisted e.g. 'self' this is because we don't gather external resources

![image](https://user-images.githubusercontent.com/25043924/97167672-20973d00-177f-11eb-843a-2d6c68ede9c0.png)

-----

![image](https://user-images.githubusercontent.com/25043924/97167158-3e17d700-177e-11eb-984c-68183b9b58fb.png)

-----
## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
