### PR TITLE
AP-1747: multi benefit flagging

### DIFF
--- a/app/controllers/state_benefits_controller.rb
+++ b/app/controllers/state_benefits_controller.rb
@@ -17,6 +17,7 @@ class StateBenefitsController < ApplicationController
       param :date, Date, date_option: :today_or_older, required: true, desc: 'The date payment received'
       param :amount, :currency, required: true, desc: 'Amount of payment'
       param :client_id, String, required: true, desc: 'Uniquely identifying string from client'
+      param :flags, Hash, desc: 'Line items that should be flagged to caseworkers for review'
     end
   end
 

--- a/app/services/creators/state_benefits_creator.rb
+++ b/app/services/creators/state_benefits_creator.rb
@@ -43,10 +43,17 @@ module Creators
         state_benefit.state_benefit_payments.create!(
           payment_date: payment_params[:date],
           amount: payment_params[:amount],
-          client_id: payment_params[:client_id]
+          client_id: payment_params[:client_id],
+          flags: generate_flags(payment_params)
         )
       end
       state_benefit
+    end
+
+    def generate_flags(hash)
+      return false unless hash[:flags].present?
+
+      hash[:flags].map { |k, v| k if v.eql?(true) }.compact
     end
   end
 end

--- a/app/services/remark_generators/multi_benefit_checker.rb
+++ b/app/services/remark_generators/multi_benefit_checker.rb
@@ -1,0 +1,32 @@
+module RemarkGenerators
+  class MultiBenefitChecker
+    def self.call(assessment, collection)
+      new(assessment, collection).call
+    end
+
+    def initialize(assessment, collection)
+      @assessment = assessment
+      @collection = collection
+    end
+
+    def call
+      populate_remarks if flagged?
+    end
+
+    private
+
+    def flagged?
+      @collection.map(&:flags).any?(['multi_benefit'])
+    end
+
+    def populate_remarks
+      my_remarks = @assessment.remarks
+      my_remarks.add(record_type, :multi_benefit, @collection.map(&:client_id))
+      @assessment.update!(remarks: my_remarks)
+    end
+
+    def record_type
+      @collection.first.class.to_s.underscore.tr('/', '_').to_sym
+    end
+  end
+end

--- a/app/services/remark_generators/orchestrator.rb
+++ b/app/services/remark_generators/orchestrator.rb
@@ -22,6 +22,7 @@ module RemarkGenerators
       check_amount_variations
       check_frequencies
       check_residual_balances
+      check_flags
     end
 
     private
@@ -46,6 +47,10 @@ module RemarkGenerators
 
     def check_residual_balances
       ResidualBalanceChecker.call(@assessment)
+    end
+
+    def check_flags
+      state_benefits&.each { |sb| MultiBenefitChecker.call(@assessment, sb.state_benefit_payments) }
     end
 
     def state_benefits

--- a/app/services/remarks.rb
+++ b/app/services/remarks.rb
@@ -17,7 +17,7 @@ class Remarks
     outgoings_rent_or_mortgage
     current_account_balance
   ].freeze
-  VALID_ISSUES = %i[unknown_frequency amount_variation residual_balance].freeze
+  VALID_ISSUES = %i[unknown_frequency amount_variation residual_balance multi_benefit].freeze
 
   def initialize
     @remarks_hash = {}

--- a/db/migrate/20201019103924_add_flags_to_state_benefit_payment.rb
+++ b/db/migrate/20201019103924_add_flags_to_state_benefit_payment.rb
@@ -1,0 +1,5 @@
+class AddFlagsToStateBenefitPayment < ActiveRecord::Migration[6.0]
+  def change
+    add_column :state_benefit_payments, :flags, :json
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_06_12_123146) do
+ActiveRecord::Schema.define(version: 2020_10_19_103924) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -197,6 +197,7 @@ ActiveRecord::Schema.define(version: 2020_06_12_123146) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.string "client_id"
+    t.json "flags"
     t.index ["state_benefit_id"], name: "index_state_benefit_payments_on_state_benefit_id"
   end
 

--- a/doc/apipie_examples.json
+++ b/doc/apipie_examples.json
@@ -2,14 +2,14 @@
   "applicants#create": [
     {
       "verb": "POST",
-      "path": "/assessments/f0a7d58a-4434-409c-9a5c-8fefc0639121/applicant",
+      "path": "/assessments/b8562d24-6055-4280-804e-1f19ea8a6e12/applicant",
       "versions": [
         "1.0"
       ],
       "query": null,
       "request_data": {
         "applicant": {
-          "date_of_birth": "2000-07-02",
+          "date_of_birth": "2000-10-26",
           "involvement_type": "applicant",
           "has_partner_opponent": false,
           "receives_qualifying_benefit": "yes"
@@ -27,14 +27,14 @@
     },
     {
       "verb": "POST",
-      "path": "/assessments/51427975-92e1-456a-a063-eed617a1730b/applicant",
+      "path": "/assessments/0a10fccf-a04a-4b27-90c2-63d681048029/applicant",
       "versions": [
         "1.0"
       ],
       "query": null,
       "request_data": {
         "applicant": {
-          "date_of_birth": "2000-07-02",
+          "date_of_birth": "2000-10-26",
           "involvement_type": "applicant",
           "has_partner_opponent": false,
           "receives_qualifying_benefit": true
@@ -66,7 +66,7 @@
       },
       "response_data": {
         "success": true,
-        "assessment_id": "cd4e794f-19fc-4b67-8f64-21624932f1a1",
+        "assessment_id": "3e806ed0-cddc-4e88-b742-eb5eae394d22",
         "errors": [
 
         ]
@@ -101,7 +101,7 @@
   "assessments#show": [
     {
       "verb": "GET",
-      "path": "/assessments/6c934f9a-614b-488d-807f-d11728829c7f",
+      "path": "/assessments/64d3d09f-bc11-45f3-b74e-75b0d835ae26",
       "versions": [
         "1.0"
       ],
@@ -109,16 +109,16 @@
       "request_data": null,
       "response_data": {
         "version": "2",
-        "timestamp": "2020-07-02T12:19:56.138+01:00",
+        "timestamp": "2020-10-26T08:16:32.423+00:00",
         "success": true,
         "assessment": {
-          "id": "6c934f9a-614b-488d-807f-d11728829c7f",
-          "client_reference_id": "CLIENT-REF-0014",
-          "submission_date": "2020-07-02",
+          "id": "64d3d09f-bc11-45f3-b74e-75b0d835ae26",
+          "client_reference_id": "CLIENT-REF-0010",
+          "submission_date": "2020-10-26",
           "matter_proceeding_type": "domestic_abuse",
           "assessment_result": "contribution_required",
           "applicant": {
-            "date_of_birth": "1992-11-17",
+            "date_of_birth": "1983-01-14",
             "involvement_type": "applicant",
             "has_partner_opponent": false,
             "receives_qualifying_benefit": true,
@@ -130,21 +130,21 @@
             "capital_items": {
               "liquid": [
                 {
-                  "description": "Qui impedit aliquam dolorem.",
-                  "value": "7626.68"
+                  "description": "Et nemo deserunt error.",
+                  "value": "7343.19"
                 }
               ],
               "non_liquid": [
                 {
-                  "description": "Ad expedita molestiae itaque.",
-                  "value": "9323.69"
+                  "description": "Voluptatem quia molestiae quos.",
+                  "value": "9590.75"
                 }
               ],
               "vehicles": [
                 {
-                  "value": "7234.25",
-                  "loan_amount_outstanding": "1325.09",
-                  "date_of_purchase": "2019-02-07",
+                  "value": "2259.77",
+                  "loan_amount_outstanding": "9260.13",
+                  "date_of_purchase": "2016-06-02",
                   "in_regular_use": true,
                   "included_in_assessment": false,
                   "assessed_value": "0.0"
@@ -152,47 +152,47 @@
               ],
               "properties": {
                 "main_home": {
-                  "value": "2636.95",
-                  "outstanding_mortgage": "1911.59",
-                  "percentage_owned": "0.77",
+                  "value": "7322.16",
+                  "outstanding_mortgage": "6816.28",
+                  "percentage_owned": "0.16",
                   "main_home": true,
-                  "shared_with_housing_assoc": true,
-                  "transaction_allowance": "79.11",
-                  "allowable_outstanding_mortgage": "1911.59",
-                  "net_value": "646.25",
-                  "net_equity": "-1970.4",
+                  "shared_with_housing_assoc": false,
+                  "transaction_allowance": "219.66",
+                  "allowable_outstanding_mortgage": "6816.28",
+                  "net_value": "286.22",
+                  "net_equity": "0.46",
                   "main_home_equity_disregard": "100000.0",
                   "assessed_equity": "0.0"
                 },
                 "additional_properties": [
                   {
-                    "value": "3930.26",
-                    "outstanding_mortgage": "8469.28",
-                    "percentage_owned": "6.68",
+                    "value": "9153.47",
+                    "outstanding_mortgage": "4069.01",
+                    "percentage_owned": "1.08",
                     "main_home": false,
-                    "shared_with_housing_assoc": false,
-                    "transaction_allowance": "117.91",
-                    "allowable_outstanding_mortgage": "8469.28",
-                    "net_value": "-4656.93",
-                    "net_equity": "-311.08",
+                    "shared_with_housing_assoc": true,
+                    "transaction_allowance": "274.6",
+                    "allowable_outstanding_mortgage": "4069.01",
+                    "net_value": "4809.86",
+                    "net_equity": "-4244.75",
                     "main_home_equity_disregard": "0.0",
                     "assessed_equity": "0.0"
                   }
                 ]
               }
             },
-            "total_liquid": "7626.68",
-            "total_non_liquid": "9323.69",
+            "total_liquid": "7343.19",
+            "total_non_liquid": "9590.75",
             "total_vehicle": "0.0",
             "total_property": "0.0",
             "total_mortgage_allowance": "100000.0",
-            "total_capital": "16950.37",
+            "total_capital": "16933.94",
             "pensioner_capital_disregard": "0.0",
-            "assessed_capital": "16950.37",
+            "assessed_capital": "16933.94",
             "lower_threshold": "3000.0",
             "upper_threshold": "999999999999.0",
             "assessment_result": "contribution_required",
-            "capital_contribution": "13950.37"
+            "capital_contribution": "13933.94"
           },
           "remarks": {
           }
@@ -204,7 +204,7 @@
     },
     {
       "verb": "GET",
-      "path": "/assessments/b8a12d18-ae00-415a-83e5-f76e0134ff0a",
+      "path": "/assessments/895e4255-259e-46fa-a8fb-d4e2cb71bf3b",
       "versions": [
         "1.0"
       ],
@@ -212,10 +212,10 @@
       "request_data": null,
       "response_data": {
         "version": "2",
-        "timestamp": "2020-07-02T12:19:56.291+01:00",
+        "timestamp": "2020-10-26T08:16:32.645+00:00",
         "success": true,
         "assessment": {
-          "id": "b8a12d18-ae00-415a-83e5-f76e0134ff0a",
+          "id": "895e4255-259e-46fa-a8fb-d4e2cb71bf3b",
           "client_reference_id": "NPE6-1",
           "submission_date": "2019-05-29",
           "matter_proceeding_type": "domestic_abuse",
@@ -228,6 +228,7 @@
             "self_employed": false
           },
           "gross_income": {
+            "monthly_student_loan": "0.0",
             "monthly_other_income": "1415.0",
             "monthly_state_benefits": "200.0",
             "total_gross_income": "1615.0",
@@ -381,14 +382,14 @@
           "remarks": {
             "state_benefit_payment": {
               "amount_variation": [
-                "87c97292-dbec-4b47-ab54-fd8c2221b8da",
-                "b3357d21-3e55-4082-be71-fbcc01bb8f2f",
-                "0214e25a-2519-45b9-b066-89862ac3c895"
+                "1092f4a1-f54f-4563-8941-c508f29386cd",
+                "200273af-d18f-4cf5-ba56-354e0f79b2da",
+                "187aa32d-c29c-4b90-8669-e90e988cb115"
               ],
               "unknown_frequency": [
-                "87c97292-dbec-4b47-ab54-fd8c2221b8da",
-                "b3357d21-3e55-4082-be71-fbcc01bb8f2f",
-                "0214e25a-2519-45b9-b066-89862ac3c895"
+                "1092f4a1-f54f-4563-8941-c508f29386cd",
+                "200273af-d18f-4cf5-ba56-354e0f79b2da",
+                "187aa32d-c29c-4b90-8669-e90e988cb115"
               ]
             }
           }
@@ -402,7 +403,7 @@
   "capitals#create": [
     {
       "verb": "POST",
-      "path": "/assessments/0feb84b5-c28a-4671-9956-5c22f7681a8a/capitals",
+      "path": "/assessments/cd97f745-dc17-4c51-8425-e9e4e920e9bb/capitals",
       "versions": [
         "1.0"
       ],
@@ -410,22 +411,22 @@
       "request_data": {
         "bank_accounts": [
           {
-            "description": "ABG SUNDAL COLLIER LIMITED 48188917",
-            "value": 66705.21
+            "description": "ALKEN ASSET MANAGEMENT 00293853",
+            "value": 39151.99
           },
           {
-            "description": "ABC INTERNATIONAL BANK PLC 68504890",
-            "value": 46946.09
+            "description": "ABN AMRO QUOTED INVESTMENTS (UK) LIMITED 02500679",
+            "value": 78707.34
           }
         ],
         "non_liquid_capital": [
           {
-            "description": "Life Endowment Policy",
-            "value": 20927.41
+            "description": "Ming Vase",
+            "value": 20204.71
           },
           {
-            "description": "R.J.Ewing Trust",
-            "value": 84521.84
+            "description": "FTSE tracker unit trust",
+            "value": 16716.54
           }
         ]
       },
@@ -441,7 +442,7 @@
     },
     {
       "verb": "POST",
-      "path": "/assessments/d4a9e732-3601-4985-a09a-abc9a430bd80/capitals",
+      "path": "/assessments/f38f81ce-e5f8-4dd5-a42e-0a7ad8a99e73/capitals",
       "versions": [
         "1.0"
       ],
@@ -449,22 +450,22 @@
       "request_data": {
         "bank_accounts": [
           {
-            "description": "ABBOTSTONE AGRICULTURAL PROPERTY UNIT TRUST 95627842",
-            "value": 94997.33
+            "description": "PGMS (GLASGOW) LIMITED 25720685",
+            "value": 28763.18
           },
           {
-            "description": "THE ROYAL BANK OF SCOTLAND PLC (FORMER RBS NV) 50887166",
-            "value": 91273.84
+            "description": "ABN AMRO FUND MANAGERS LIMITED 37396930",
+            "value": 60849.12
           }
         ],
         "non_liquid_capital": [
           {
-            "description": "Ming Vase",
-            "value": 55225.57
+            "description": "Van Gogh Sunflowers",
+            "value": 99610.54
           },
           {
-            "description": "Ming Vase",
-            "value": 56251.45
+            "description": "Aramco shares",
+            "value": 58095.56
           }
         ]
       },
@@ -482,7 +483,7 @@
   "dependants#create": [
     {
       "verb": "POST",
-      "path": "/assessments/e8761d3d-b0f1-4446-b093-138f3f0bdbeb/dependants",
+      "path": "/assessments/6755ce8d-466a-447d-bd50-7f3bff2b83f5/dependants",
       "versions": [
         "1.0"
       ],
@@ -490,17 +491,17 @@
       "request_data": {
         "dependants": [
           {
-            "date_of_birth": "1987-10-31",
-            "in_full_time_education": true,
+            "date_of_birth": "1997-10-25",
+            "in_full_time_education": false,
             "relationship": "adult_relative",
-            "monthly_income": 4153.3,
+            "monthly_income": 6643.99,
             "assets_value": 0.0
           },
           {
-            "date_of_birth": "1967-11-04",
-            "in_full_time_education": true,
+            "date_of_birth": "1961-05-03",
+            "in_full_time_education": false,
             "relationship": "adult_relative",
-            "monthly_income": 1537.17,
+            "monthly_income": 5028.69,
             "assets_value": 0.0
           }
         ]
@@ -517,7 +518,7 @@
     },
     {
       "verb": "POST",
-      "path": "/assessments/813ddf26-b7e0-43c9-bd50-a9c48f5b3069/dependants",
+      "path": "/assessments/f72888cc-63c4-43e9-a6cf-44616a464283/dependants",
       "versions": [
         "1.0"
       ],
@@ -525,17 +526,17 @@
       "request_data": {
         "dependants": [
           {
-            "date_of_birth": "1985-07-29",
+            "date_of_birth": "1969-04-29",
             "in_full_time_education": true,
             "relationship": "child_relative",
-            "monthly_income": 4562.6,
+            "monthly_income": 4890.5,
             "assets_value": 0.0
           },
           {
-            "date_of_birth": "1998-10-22",
-            "in_full_time_education": true,
+            "date_of_birth": "1994-01-11",
+            "in_full_time_education": false,
             "relationship": "adult_relative",
-            "monthly_income": 1142.88,
+            "monthly_income": 2745.57,
             "assets_value": 0.0
           }
         ]
@@ -552,7 +553,7 @@
     },
     {
       "verb": "POST",
-      "path": "/assessments/64bd5eb1-054a-4e1a-8fe4-42a63c48f748/dependants",
+      "path": "/assessments/008afcda-2933-40dc-92a6-6dc81e0583f9/dependants",
       "versions": [
         "1.0"
       ],
@@ -560,17 +561,17 @@
       "request_data": {
         "dependants": [
           {
-            "date_of_birth": "1995-06-16",
+            "date_of_birth": "1982-10-13",
             "in_full_time_education": null,
-            "relationship": "adult_relative",
-            "monthly_income": 6080.72,
+            "relationship": "child_relative",
+            "monthly_income": 345.99,
             "assets_value": 0.0
           },
           {
-            "date_of_birth": "1965-09-29",
+            "date_of_birth": "1985-04-13",
             "in_full_time_education": null,
             "relationship": "child_relative",
-            "monthly_income": 223.15,
+            "monthly_income": 1173.74,
             "assets_value": 0.0
           }
         ]
@@ -589,7 +590,7 @@
   "irregular_incomes#create": [
     {
       "verb": "POST",
-      "path": "/assessments/17fb9407-e2f5-48f7-b360-32761271d5d9/irregular_incomes",
+      "path": "/assessments/a4acb479-b28a-49ca-aeac-23f6eccfdb9c/irregular_incomes",
       "versions": [
         "1.0"
       ],
@@ -614,7 +615,7 @@
     },
     {
       "verb": "POST",
-      "path": "/assessments/63008a6e-4103-4d3c-995d-f8a7261a9508/irregular_incomes",
+      "path": "/assessments/32e34642-e25b-400a-98b3-bb3e3f729e13/irregular_incomes",
       "versions": [
         "1.0"
       ],
@@ -642,7 +643,7 @@
   "other_incomes#create": [
     {
       "verb": "POST",
-      "path": "/assessments/12ac432a-97c3-448a-bec0-fd601721a4ca/other_incomes",
+      "path": "/assessments/9f4cbba3-7c59-4459-97f0-1bf4d62d6c09/other_incomes",
       "versions": [
         "1.0"
       ],
@@ -650,22 +651,22 @@
       "request_data": {
         "other_incomes": [
           {
-            "source": "student_loan",
+            "source": "maintenance_in",
             "payments": [
               {
                 "date": "2019-11-01",
                 "amount": 1046.44,
-                "client_id": "adf14990-3e20-4a68-8dbb-80fcb32c6b28"
+                "client_id": "05459c0f-a620-4743-9f0c-b3daa93e5711"
               },
               {
                 "date": "2019-10-01",
                 "amount": 1034.33,
-                "client_id": "bb173071-73b0-4d26-b600-be6aafcfcd02"
+                "client_id": "10318f7b-289a-4fa5-a986-fc6f499fecd0"
               },
               {
                 "date": "2019-09-01",
                 "amount": 1033.44,
-                "client_id": "337a9042-02e8-489d-960c-20ab48a91188"
+                "client_id": "5cf62a12-c92b-4cc1-b8ca-eeb4efbcce21"
               }
             ]
           },
@@ -675,17 +676,17 @@
               {
                 "date": "2019-11-01",
                 "amount": 250.0,
-                "client_id": "f539315b-827c-464b-a1e7-d4108355d9c2"
+                "client_id": "e47b707b-d795-47c2-8b39-ccf022eae33b"
               },
               {
                 "date": "2019-10-01",
                 "amount": 266.02,
-                "client_id": "0d72a868-4b2b-4a3e-a53a-b97880ac5476"
+                "client_id": "b0c46cc7-8478-4658-a7f9-85ec85d420b1"
               },
               {
                 "date": "2019-09-01",
                 "amount": 250.0,
-                "client_id": "23401104-7911-408a-aa99-4d00457f3572"
+                "client_id": "f3ec68a3-8748-4ed5-971a-94d133e0efa0"
               }
             ]
           }
@@ -705,7 +706,7 @@
   "outgoings#create": [
     {
       "verb": "POST",
-      "path": "/assessments/4162640d-67f9-4361-b1e6-b36f6b785e2d/outgoings",
+      "path": "/assessments/28520200-075c-484f-8c9f-d6559ec7f12f/outgoings",
       "versions": [
         "1.0"
       ],
@@ -716,14 +717,14 @@
             "name": "child_care",
             "payments": [
               {
-                "payment_date": "2020-06-11",
-                "amount": 987.25,
-                "client_id": "781dad72-d689-4e77-8faf-4c77f681ec82"
+                "payment_date": "2020-10-05",
+                "amount": 363.81,
+                "client_id": "af36656e-3c7b-4718-90f2-2e52bb4b3b96"
               },
               {
-                "payment_date": "2020-06-11",
-                "amount": 414.71,
-                "client_id": "7e3f40d4-e19f-4298-af5d-21e8592145e0"
+                "payment_date": "2020-10-05",
+                "amount": 279.57,
+                "client_id": "95543eb0-5373-43bd-91e9-4e194e5d366b"
               }
             ]
           },
@@ -731,14 +732,14 @@
             "name": "maintenance_out",
             "payments": [
               {
-                "payment_date": "2020-06-11",
-                "amount": 465.65,
-                "client_id": "781dad72-d689-4e77-8faf-4c77f681ec82"
+                "payment_date": "2020-10-05",
+                "amount": 686.66,
+                "client_id": "af36656e-3c7b-4718-90f2-2e52bb4b3b96"
               },
               {
-                "payment_date": "2020-06-11",
-                "amount": 647.89,
-                "client_id": "7e3f40d4-e19f-4298-af5d-21e8592145e0"
+                "payment_date": "2020-10-05",
+                "amount": 473.51,
+                "client_id": "95543eb0-5373-43bd-91e9-4e194e5d366b"
               }
             ]
           },
@@ -746,16 +747,16 @@
             "name": "rent_or_mortgage",
             "payments": [
               {
-                "payment_date": "2020-06-11",
-                "amount": 542.91,
+                "payment_date": "2020-10-05",
+                "amount": 746.26,
                 "housing_cost_type": "rent",
-                "client_id": "781dad72-d689-4e77-8faf-4c77f681ec82"
+                "client_id": "af36656e-3c7b-4718-90f2-2e52bb4b3b96"
               },
               {
-                "payment_date": "2020-06-11",
-                "amount": 563.58,
+                "payment_date": "2020-10-05",
+                "amount": 102.35,
                 "housing_cost_type": "rent",
-                "client_id": "7e3f40d4-e19f-4298-af5d-21e8592145e0"
+                "client_id": "95543eb0-5373-43bd-91e9-4e194e5d366b"
               }
             ]
           }
@@ -784,14 +785,14 @@
             "name": "child_care",
             "payments": [
               {
-                "payment_date": "2020-06-11",
-                "amount": 835.86,
-                "client_id": "9f97bb7a-fb78-4585-897c-2d4aee0c3515"
+                "payment_date": "2020-10-05",
+                "amount": 783.66,
+                "client_id": "926cad50-8dc5-403a-bccf-cd0c333920af"
               },
               {
-                "payment_date": "2020-06-11",
-                "amount": 793.95,
-                "client_id": "417dc52a-ed57-43f1-b443-4f7b3d790443"
+                "payment_date": "2020-10-05",
+                "amount": 920.69,
+                "client_id": "f9fcc177-f0ce-4a18-94b2-afe18a596eb3"
               }
             ]
           },
@@ -799,14 +800,14 @@
             "name": "maintenance_out",
             "payments": [
               {
-                "payment_date": "2020-06-11",
-                "amount": 500.15,
-                "client_id": "9f97bb7a-fb78-4585-897c-2d4aee0c3515"
+                "payment_date": "2020-10-05",
+                "amount": 107.75,
+                "client_id": "926cad50-8dc5-403a-bccf-cd0c333920af"
               },
               {
-                "payment_date": "2020-06-11",
-                "amount": 808.69,
-                "client_id": "417dc52a-ed57-43f1-b443-4f7b3d790443"
+                "payment_date": "2020-10-05",
+                "amount": 673.78,
+                "client_id": "f9fcc177-f0ce-4a18-94b2-afe18a596eb3"
               }
             ]
           },
@@ -814,16 +815,16 @@
             "name": "rent_or_mortgage",
             "payments": [
               {
-                "payment_date": "2020-06-11",
-                "amount": 841.47,
-                "housing_cost_type": "rent",
-                "client_id": "9f97bb7a-fb78-4585-897c-2d4aee0c3515"
+                "payment_date": "2020-10-05",
+                "amount": 647.15,
+                "housing_cost_type": "board_and_lodging",
+                "client_id": "926cad50-8dc5-403a-bccf-cd0c333920af"
               },
               {
-                "payment_date": "2020-06-11",
-                "amount": 602.26,
-                "housing_cost_type": "rent",
-                "client_id": "417dc52a-ed57-43f1-b443-4f7b3d790443"
+                "payment_date": "2020-10-05",
+                "amount": 118.09,
+                "housing_cost_type": "board_and_lodging",
+                "client_id": "f9fcc177-f0ce-4a18-94b2-afe18a596eb3"
               }
             ]
           }
@@ -843,48 +844,7 @@
   "properties#create": [
     {
       "verb": "POST",
-      "path": "/assessments/52841ce1-4993-436b-84db-65d12e9b860e/properties",
-      "versions": [
-        "1.0"
-      ],
-      "query": null,
-      "request_data": {
-        "properties": {
-          "main_home": {
-            "value": 500000,
-            "outstanding_mortgage": 200,
-            "percentage_owned": 15,
-            "shared_with_housing_assoc": true
-          },
-          "additional_properties": [
-            {
-              "value": 1000,
-              "outstanding_mortgage": 0,
-              "percentage_owned": 99,
-              "shared_with_housing_assoc": false
-            },
-            {
-              "value": 10000,
-              "outstanding_mortgage": 40,
-              "percentage_owned": 80,
-              "shared_with_housing_assoc": true
-            }
-          ]
-        }
-      },
-      "response_data": {
-        "success": true,
-        "errors": [
-
-        ]
-      },
-      "code": 200,
-      "show_in_doc": 1,
-      "recorded": true
-    },
-    {
-      "verb": "POST",
-      "path": "/assessments/46e76389-0973-461d-895b-28dbe03c3595/properties",
+      "path": "/assessments/90ce5907-e626-4fb0-b08a-6902d7822e67/properties",
       "versions": [
         "1.0"
       ],
@@ -920,6 +880,47 @@
         ]
       },
       "code": 422,
+      "show_in_doc": 1,
+      "recorded": true
+    },
+    {
+      "verb": "POST",
+      "path": "/assessments/cb4fff96-a02f-4ac2-9ae7-cd4e5fdd9aa9/properties",
+      "versions": [
+        "1.0"
+      ],
+      "query": null,
+      "request_data": {
+        "properties": {
+          "main_home": {
+            "value": 500000,
+            "outstanding_mortgage": 200,
+            "percentage_owned": 15,
+            "shared_with_housing_assoc": true
+          },
+          "additional_properties": [
+            {
+              "value": 1000,
+              "outstanding_mortgage": 0,
+              "percentage_owned": 99,
+              "shared_with_housing_assoc": false
+            },
+            {
+              "value": 10000,
+              "outstanding_mortgage": 40,
+              "percentage_owned": 80,
+              "shared_with_housing_assoc": true
+            }
+          ]
+        }
+      },
+      "response_data": {
+        "success": true,
+        "errors": [
+
+        ]
+      },
+      "code": 200,
       "show_in_doc": 1,
       "recorded": true
     }
@@ -1496,7 +1497,7 @@
   "state_benefits#create": [
     {
       "verb": "POST",
-      "path": "/assessments/c72d5148-3823-4755-a4c3-ecb43f4b161c/state_benefits",
+      "path": "/assessments/7e3795b6-3344-47a8-9f5f-9ae2fed98c9e/state_benefits",
       "versions": [
         "1.0"
       ],
@@ -1504,83 +1505,22 @@
       "request_data": {
         "state_benefits": [
           {
-            "name": "benefit_type_3",
+            "name": "benefit_type_1",
             "payments": [
               {
                 "date": "2019-11-01",
                 "amount": 1046.44,
-                "client_id": "63f7731b-a013-4ef9-a7c9-5938345f4fd4"
+                "client_id": "06c3b20e-c4e8-4736-a153-6b30e48636b2"
               },
               {
                 "date": "2019-10-01",
                 "amount": 1034.33,
-                "client_id": "e9bfc9f8-04eb-459e-8b06-f26ae4455d16"
+                "client_id": "2ff1d644-5d11-4e1f-8e2f-50511688d19f"
               },
               {
                 "date": "2019-09-01",
                 "amount": 1033.44,
-                "client_id": "52f62d6f-0079-4d06-ae5d-2d0eb091d182"
-              }
-            ]
-          },
-          {
-            "name": "benefit_type_4",
-            "payments": [
-              {
-                "date": "2019-11-01",
-                "amount": 250.0,
-                "client_id": "63f7731b-a013-4ef9-a7c9-5938345f4fd4"
-              },
-              {
-                "date": "2019-10-01",
-                "amount": 266.02,
-                "client_id": "e9bfc9f8-04eb-459e-8b06-f26ae4455d16"
-              },
-              {
-                "date": "2019-09-01",
-                "amount": 250.0,
-                "client_id": "52f62d6f-0079-4d06-ae5d-2d0eb091d182"
-              }
-            ]
-          }
-        ]
-      },
-      "response_data": {
-        "success": true,
-        "errors": [
-
-        ]
-      },
-      "code": 200,
-      "show_in_doc": 1,
-      "recorded": true
-    },
-    {
-      "verb": "POST",
-      "path": "/assessments/2083cbee-3539-4698-be93-bd0e84531500/state_benefits",
-      "versions": [
-        "1.0"
-      ],
-      "query": null,
-      "request_data": {
-        "state_benefits": [
-          {
-            "name": "benefit_type_5",
-            "payments": [
-              {
-                "date": "2019-11-01",
-                "amount": 1046.44,
-                "client_id": "c7e9a901-5b78-4308-91ce-6daaad75efdd"
-              },
-              {
-                "date": "2019-10-01",
-                "amount": 1034.33,
-                "client_id": "5da32cd4-7803-41ec-a65e-ae52ab2b8318"
-              },
-              {
-                "date": "2019-09-01",
-                "amount": 1033.44,
-                "client_id": "3c6d483e-103d-4b2c-b9bc-cbcae360849b"
+                "client_id": "c107a948-93bd-4f33-b782-4d6469459864"
               }
             ]
           },
@@ -1589,17 +1529,20 @@
               {
                 "date": "2019-11-01",
                 "amount": 250.0,
-                "client_id": "c7e9a901-5b78-4308-91ce-6daaad75efdd"
+                "client_id": "06c3b20e-c4e8-4736-a153-6b30e48636b2"
               },
               {
                 "date": "2019-10-01",
                 "amount": 266.02,
-                "client_id": "5da32cd4-7803-41ec-a65e-ae52ab2b8318"
+                "client_id": "2ff1d644-5d11-4e1f-8e2f-50511688d19f"
               },
               {
                 "date": "2019-09-01",
                 "amount": 250.0,
-                "client_id": "3c6d483e-103d-4b2c-b9bc-cbcae360849b"
+                "client_id": "c107a948-93bd-4f33-b782-4d6469459864",
+                "flags": {
+                  "multi_benefit": true
+                }
               }
             ]
           }
@@ -1614,12 +1557,76 @@
       "code": 422,
       "show_in_doc": 1,
       "recorded": true
+    },
+    {
+      "verb": "POST",
+      "path": "/assessments/eeef1d5a-ab30-49ba-87ec-9ba35df4117a/state_benefits",
+      "versions": [
+        "1.0"
+      ],
+      "query": null,
+      "request_data": {
+        "state_benefits": [
+          {
+            "name": "benefit_type_3",
+            "payments": [
+              {
+                "date": "2019-11-01",
+                "amount": 1046.44,
+                "client_id": "bbc5862c-b18a-4c20-a20c-7448dcab51bc"
+              },
+              {
+                "date": "2019-10-01",
+                "amount": 1034.33,
+                "client_id": "12a7707e-aaac-4a18-9bef-af72cb8b17f3"
+              },
+              {
+                "date": "2019-09-01",
+                "amount": 1033.44,
+                "client_id": "28760155-0d6f-47a8-990e-8ea1952cddb2"
+              }
+            ]
+          },
+          {
+            "name": "benefit_type_4",
+            "payments": [
+              {
+                "date": "2019-11-01",
+                "amount": 250.0,
+                "client_id": "bbc5862c-b18a-4c20-a20c-7448dcab51bc"
+              },
+              {
+                "date": "2019-10-01",
+                "amount": 266.02,
+                "client_id": "12a7707e-aaac-4a18-9bef-af72cb8b17f3"
+              },
+              {
+                "date": "2019-09-01",
+                "amount": 250.0,
+                "client_id": "28760155-0d6f-47a8-990e-8ea1952cddb2",
+                "flags": {
+                  "multi_benefit": true
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "response_data": {
+        "success": true,
+        "errors": [
+
+        ]
+      },
+      "code": 200,
+      "show_in_doc": 1,
+      "recorded": true
     }
   ],
   "vehicles#create": [
     {
       "verb": "POST",
-      "path": "/assessments/e109ec91-42c6-4612-a01c-050a98cca6c6/vehicles",
+      "path": "/assessments/9a3bc416-1929-4182-b978-de9ad0f65a1a/vehicles",
       "versions": [
         "1.0"
       ],
@@ -1627,16 +1634,16 @@
       "request_data": {
         "vehicles": [
           {
-            "value": 8496.56,
-            "loan_amount_outstanding": 6144.22,
-            "date_of_purchase": "2020-02-21",
+            "value": 1184.88,
+            "loan_amount_outstanding": 4652.08,
+            "date_of_purchase": "2015-02-26",
             "in_regular_use": false
           },
           {
-            "value": 5862.69,
-            "loan_amount_outstanding": 2121.99,
-            "date_of_purchase": "2019-09-01",
-            "in_regular_use": false
+            "value": 9658.86,
+            "loan_amount_outstanding": 6398.84,
+            "date_of_purchase": "2016-04-25",
+            "in_regular_use": true
           }
         ]
       },
@@ -1660,15 +1667,15 @@
       "request_data": {
         "vehicles": [
           {
-            "value": 9995.86,
-            "loan_amount_outstanding": 3024.57,
-            "date_of_purchase": "2014-08-05",
-            "in_regular_use": true
+            "value": 1712.07,
+            "loan_amount_outstanding": 9279.13,
+            "date_of_purchase": "2019-09-21",
+            "in_regular_use": false
           },
           {
-            "value": 8601.88,
-            "loan_amount_outstanding": 4815.26,
-            "date_of_purchase": "2017-06-07",
+            "value": 1602.63,
+            "loan_amount_outstanding": 1055.83,
+            "date_of_purchase": "2016-05-30",
             "in_regular_use": false
           }
         ]

--- a/spec/factories/state_benefit_payment_factory.rb
+++ b/spec/factories/state_benefit_payment_factory.rb
@@ -4,5 +4,10 @@ FactoryBot.define do
 
     payment_date { Date.today }
     amount { 123.45 }
+    flags { nil }
+
+    trait :with_multi_benefit_flag do
+      flags { ['multi_benefit'] }
+    end
   end
 end

--- a/spec/requests/state_benefits_spec.rb
+++ b/spec/requests/state_benefits_spec.rb
@@ -49,6 +49,14 @@ RSpec.describe StateBenefitsController, type: :request do
           state_benefit = gross_income_summary.state_benefits.detect { |sb| sb.state_benefit_type == state_benefit_type_1 }
           expect(state_benefit.state_benefit_payments.map(&:client_id)).to match client_ids
         end
+
+        context 'when the flags field contains multi_benefit' do
+          it 'sets the multi_benefit flag' do
+            subject
+            state_benefit = gross_income_summary.state_benefits.detect { |sb| sb.state_benefit_type == state_benefit_type_2 }
+            expect(state_benefit.state_benefit_payments.map(&:flags)).to match [false, false, ['multi_benefit']]
+          end
+        end
       end
     end
 

--- a/spec/requests/state_benefits_spec.rb
+++ b/spec/requests/state_benefits_spec.rb
@@ -167,7 +167,10 @@ RSpec.describe StateBenefitsController, type: :request do
               {
                 date: '2019-09-01',
                 amount: 250.00,
-                client_id: client_ids[2]
+                client_id: client_ids[2],
+                flags: {
+                  multi_benefit: true
+                }
               }
             ]
           }

--- a/spec/services/remark_generators/multi_benefit_checker_spec.rb
+++ b/spec/services/remark_generators/multi_benefit_checker_spec.rb
@@ -1,0 +1,43 @@
+require 'rails_helper'
+
+module RemarkGenerators
+  RSpec.describe MultiBenefitChecker do
+    context 'state benefit payments' do
+      let(:amount) { 123.45 }
+      let(:dates) { [Date.today, 1.month.ago, 2.month.ago] }
+      let(:state_benefit) { create :state_benefit }
+      let(:assessment) { state_benefit.gross_income_summary.assessment }
+      let(:collection) { [payment_1, payment_2, payment_3] }
+      let!(:original_remarks) { assessment.remarks.as_json }
+
+      subject(:call) { described_class.call(assessment, collection) }
+
+      context 'no flags' do
+        let(:payment_1) { create :state_benefit_payment, state_benefit: state_benefit, amount: amount, payment_date: dates[0] }
+        let(:payment_2) { create :state_benefit_payment, state_benefit: state_benefit, amount: amount, payment_date: dates[1] }
+        let(:payment_3) { create :state_benefit_payment, state_benefit: state_benefit, amount: amount, payment_date: dates[2] }
+
+        it 'does not update the remarks class' do
+          subject
+          expect(assessment.reload.remarks.as_json).to eq original_remarks
+        end
+      end
+
+      context 'variation in amount' do
+        let(:payment_1) { create :state_benefit_payment, state_benefit: state_benefit, amount: amount, payment_date: dates[0] }
+        let(:payment_2) { create :state_benefit_payment, state_benefit: state_benefit, amount: amount, payment_date: dates[1] }
+        let(:payment_3) { create :state_benefit_payment, :with_multi_benefit_flag, state_benefit: state_benefit, amount: amount, payment_date: dates[2] }
+
+        it 'adds the remark' do
+          expect_any_instance_of(Remarks).to receive(:add).with(:state_benefit_payment, :multi_benefit, collection.map(&:client_id))
+          subject
+        end
+
+        it 'stores the changed the remarks class on the assessment' do
+          subject
+          expect(assessment.reload.remarks.as_json).not_to eq original_remarks
+        end
+      end
+    end
+  end
+end

--- a/spec/services/remark_generators/orchestrator_spec.rb
+++ b/spec/services/remark_generators/orchestrator_spec.rb
@@ -18,6 +18,7 @@ module RemarkGenerators
     end
 
     it 'calls the checkers with each collection' do
+      expect(MultiBenefitChecker).to receive(:call).with(assessment, state_benefit_payments)
       expect(AmountVariationChecker).to receive(:call).with(assessment, state_benefit_payments)
       expect(AmountVariationChecker).to receive(:call).with(assessment, other_income_payments)
       expect(AmountVariationChecker).to receive(:call).with(assessment, childcare_outgoings)


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1747)

Add a new flagging system that allows Apply to send flagged values to CFE. These can then be parsed and, if required, flag the assessment that is passed back to Apply
This is designed to be extendable, i.e. in the future we can add more values into the `flags` field and check for their presence too
These can then be alerted to case workers when the assessment is returned and processed in Apply.

**NOTE**: this can be merged before the AP-1747 ticket on Apply but may need fixes. 
I am currently testing both ends of the ticket on a local machine but end-to-end testing on UAT may be tricky!

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
