### PR TITLE
Tech-debt: Update ruby to 2.7

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ executors:
           GITHUB_TEAM_NAME_SLUG: laa-apply-for-legal-aid
   linting-executor:
     docker:
-      - image: circleci/ruby:2.6.6-node-browsers
+      - image: circleci/ruby:2.7.1-node-browsers
         environment:
           - RAILS_ENV=test
           - TZ: "Europe/London"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.6.6
+FROM ruby:2.7.1
 MAINTAINER apply for legal aid team
 ENV RAILS_ENV production
 RUN apt-get update -qq && apt-get install -y nodejs postgresql-client

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby '2.6.6'
+ruby '2.7.1'
 
 gem 'active_model_serializers', '~> 0.10.10'
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -360,7 +360,7 @@ DEPENDENCIES
   webmock
 
 RUBY VERSION
-   ruby 2.6.6p146
+   ruby 2.7.1p83
 
 BUNDLED WITH
    2.1.4

--- a/Guardfile
+++ b/Guardfile
@@ -8,5 +8,5 @@ guard :rspec, cmd: 'VERBOSE=true bundle exec rspec', all_on_start: false do
   watch(%r{^app/(.+)\.rb$}) { |m| "spec/#{m[1]}_spec.rb" }
   watch(%r{^lib/(.+)\.rb$}) { |m| "spec/lib/#{m[1]}_spec.rb" }
   watch(%r{^app/interfaces/api/(.+)\.rb$}) { |m| "spec/api/#{m[1]}_spec.rb" }
-  watch("#{rspec.spec_dir}/fixtures/integration_test_data.xlsx") { "#{rspec.spec_dir}/integration/test_runner_spec.rb" }
+  watch("spec/fixtures/integration_test_data.xlsx") { "spec/integration/test_runner_spec.rb" }
 end

--- a/app/services/calculators/monthly_salary_calculator.rb
+++ b/app/services/calculators/monthly_salary_calculator.rb
@@ -3,8 +3,8 @@ module Calculators
     PeriodError = Class.new(StandardError)
     NORMAL_VARIANCE_THRESHOLD = 60
 
-    def self.call(*args)
-      new(*args).monthly_equivalent
+    def self.call(**args)
+      new(**args).monthly_equivalent
     end
 
     attr_reader :time_series, :period_type

--- a/spec/support/salary_pattern_generator.rb
+++ b/spec/support/salary_pattern_generator.rb
@@ -1,6 +1,6 @@
 class SalaryPatternGenerator
-  def self.call(*args)
-    new(*args).call
+  def self.call(**args)
+    new(**args).call
   end
 
   attr_reader :period, :salary, :day_offset, :salary_offset, :start_at


### PR DESCRIPTION
## What

Update ruby to 2.7.2 to ensure we don't fall too far behind v3 is only 2 months away!
- [x] update ruby to 2.7.1
- [ ] fix warnings
- [ ] document unfixable warnings
- [ ] update ruby to 2.7.2

## Checklist

Before you ask people to review this PR:

- [ ] Tests and rubocop should be passing: `bundle exec rake`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [ ] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [ ] The PR description should say what you changed and why, with a link to the JIRA story.
- [ ] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
