### PR TITLE
AP-1806 Fix flagging of childcare payments

### DIFF
--- a/app/services/concerns/exemptable.rb
+++ b/app/services/concerns/exemptable.rb
@@ -1,0 +1,13 @@
+module Exemptable
+  def exempt_from_checking
+    childcare_payment? && childcare_disallowed?
+  end
+
+  def childcare_payment?
+    record_type == :outgoings_childcare
+  end
+
+  def childcare_disallowed?
+    @assessment.disposable_income_summary.childcare.zero?
+  end
+end

--- a/app/services/remark_generators/amount_variation_checker.rb
+++ b/app/services/remark_generators/amount_variation_checker.rb
@@ -1,13 +1,6 @@
 module RemarkGenerators
-  class AmountVariationChecker
-    def self.call(assessment, collection)
-      new(assessment, collection).call
-    end
-
-    def initialize(assessment, collection)
-      @assessment = assessment
-      @collection = collection
-    end
+  class AmountVariationChecker < BaseChecker
+    include Exemptable
 
     def call
       populate_remarks unless unique_amounts || exempt_from_checking
@@ -23,22 +16,6 @@ module RemarkGenerators
       my_remarks = @assessment.remarks
       my_remarks.add(record_type, :amount_variation, @collection.map(&:client_id))
       @assessment.update!(remarks: my_remarks)
-    end
-
-    def record_type
-      @collection.first.class.to_s.underscore.tr('/', '_').to_sym
-    end
-
-    def exempt_from_checking
-      childcare_payment? && childcare_disallowed?
-    end
-
-    def childcare_payment?
-      record_type == :outgoings_childcare
-    end
-
-    def childcare_disallowed?
-      @assessment.disposable_income_summary.childcare.zero?
     end
   end
 end

--- a/app/services/remark_generators/amount_variation_checker.rb
+++ b/app/services/remark_generators/amount_variation_checker.rb
@@ -10,7 +10,7 @@ module RemarkGenerators
     end
 
     def call
-      populate_remarks unless unique_amounts
+      populate_remarks unless unique_amounts || exempt_from_checking
     end
 
     private
@@ -27,6 +27,18 @@ module RemarkGenerators
 
     def record_type
       @collection.first.class.to_s.underscore.tr('/', '_').to_sym
+    end
+
+    def exempt_from_checking
+      childcare_payment? && childcare_disallowed?
+    end
+
+    def childcare_payment?
+      record_type == :outgoings_childcare
+    end
+
+    def childcare_disallowed?
+      @assessment.disposable_income_summary.childcare.zero?
     end
   end
 end

--- a/app/services/remark_generators/base_checker.rb
+++ b/app/services/remark_generators/base_checker.rb
@@ -1,0 +1,18 @@
+module RemarkGenerators
+  class BaseChecker
+    def self.call(assessment, collection)
+      new(assessment, collection).call
+    end
+
+    def initialize(assessment, collection)
+      @assessment = assessment
+      @collection = collection
+    end
+
+    private
+
+    def record_type
+      @collection.first.class.to_s.underscore.tr('/', '_').to_sym
+    end
+  end
+end

--- a/app/services/remark_generators/frequency_checker.rb
+++ b/app/services/remark_generators/frequency_checker.rb
@@ -10,7 +10,7 @@ module RemarkGenerators
     end
 
     def call
-      populate_remarks if unknown_frequency?
+      populate_remarks if unknown_frequency? && !exempt_from_checking
     end
 
     private
@@ -31,6 +31,18 @@ module RemarkGenerators
 
     def record_type
       @collection.first.class.to_s.underscore.tr('/', '_').to_sym
+    end
+
+    def exempt_from_checking
+      childcare_payment? && childcare_disallowed?
+    end
+
+    def childcare_payment?
+      record_type == :outgoings_childcare
+    end
+
+    def childcare_disallowed?
+      @assessment.disposable_income_summary.childcare.zero?
     end
   end
 end

--- a/app/services/remark_generators/frequency_checker.rb
+++ b/app/services/remark_generators/frequency_checker.rb
@@ -1,13 +1,6 @@
 module RemarkGenerators
-  class FrequencyChecker
-    def self.call(assessment, collection)
-      new(assessment, collection).call
-    end
-
-    def initialize(assessment, collection)
-      @assessment = assessment
-      @collection = collection
-    end
+  class FrequencyChecker < BaseChecker
+    include Exemptable
 
     def call
       populate_remarks if unknown_frequency? && !exempt_from_checking
@@ -27,22 +20,6 @@ module RemarkGenerators
       my_remarks = @assessment.remarks
       my_remarks.add(record_type, :unknown_frequency, @collection.map(&:client_id))
       @assessment.update!(remarks: my_remarks)
-    end
-
-    def record_type
-      @collection.first.class.to_s.underscore.tr('/', '_').to_sym
-    end
-
-    def exempt_from_checking
-      childcare_payment? && childcare_disallowed?
-    end
-
-    def childcare_payment?
-      record_type == :outgoings_childcare
-    end
-
-    def childcare_disallowed?
-      @assessment.disposable_income_summary.childcare.zero?
     end
   end
 end

--- a/app/services/remark_generators/multi_benefit_checker.rb
+++ b/app/services/remark_generators/multi_benefit_checker.rb
@@ -1,14 +1,5 @@
 module RemarkGenerators
-  class MultiBenefitChecker
-    def self.call(assessment, collection)
-      new(assessment, collection).call
-    end
-
-    def initialize(assessment, collection)
-      @assessment = assessment
-      @collection = collection
-    end
-
+  class MultiBenefitChecker < BaseChecker
     def call
       populate_remarks if flagged?
     end
@@ -23,10 +14,6 @@ module RemarkGenerators
       my_remarks = @assessment.remarks
       my_remarks.add(record_type, :multi_benefit, @collection.map(&:client_id))
       @assessment.update!(remarks: my_remarks)
-    end
-
-    def record_type
-      @collection.first.class.to_s.underscore.tr('/', '_').to_sym
     end
   end
 end

--- a/spec/integration/ap_1367_spec.rb
+++ b/spec/integration/ap_1367_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe 'Full Assessment with remarks' do
     post_outgoings(assessment_id)
     post_state_benefits(assessment_id)
     post_other_incomes(assessment_id)
+    post_irregular_income(assessment_id)
 
     get assessment_path(assessment_id), headers: v2_headers
     output_response(:get, :assessment)
@@ -60,6 +61,11 @@ RSpec.describe 'Full Assessment with remarks' do
   def post_state_benefits(assessment_id)
     post assessment_state_benefits_path(assessment_id), params: state_benefit_params, headers: headers
     output_response(:post, :state_benefits)
+  end
+
+  def post_irregular_income(assessment_id)
+    post assessment_irregular_incomes_path(assessment_id), params: student_loan_params, headers: headers
+    output_response(:post, :irregular_income)
   end
 
   def output_response(method, object)
@@ -221,6 +227,13 @@ RSpec.describe 'Full Assessment with remarks' do
             { 'date' => '2020-06-06',
               'amount' => 22.42,
               'client_id' => 'TX-state-benefits-3' }] }] }.to_json
+  end
+
+  def student_loan_params
+    { 'payments' =>
+           [{ 'income_type' => 'student_loan',
+              'frequency' => 'annual',
+              'amount' => 100.0 }] }.to_json
   end
 
   def expected_remarks

--- a/spec/services/remark_generators/amount_variation_checker_spec.rb
+++ b/spec/services/remark_generators/amount_variation_checker_spec.rb
@@ -81,6 +81,39 @@ module RemarkGenerators
           expect(assessment.reload.remarks.as_json).not_to eq original_remarks
         end
       end
+
+      context 'when childcare costs with an amount variation are declared' do
+        let(:collection) do
+          [
+            create(:childcare_outgoing, disposable_income_summary: disposable_income_summary, payment_date: dates[0], amount: amount),
+            create(:childcare_outgoing, disposable_income_summary: disposable_income_summary, payment_date: dates[1], amount: amount + 0.01),
+            create(:childcare_outgoing, disposable_income_summary: disposable_income_summary, payment_date: dates[2], amount: amount)
+          ]
+        end
+
+        context 'if the childcare costs are allowed as an outgoing' do
+          before { disposable_income_summary.childcare = 1 }
+
+          it 'adds the remark' do
+            expect_any_instance_of(Remarks).to receive(:add).with(:outgoings_childcare, :amount_variation, collection.map(&:client_id))
+            described_class.call(assessment, collection)
+          end
+
+          it 'stores the changed the remarks class on the assessment' do
+            original_remarks = assessment.remarks.as_json
+            described_class.call(assessment, collection)
+            expect(assessment.reload.remarks.as_json).not_to eq original_remarks
+          end
+        end
+
+        context 'if the childcare costs are not allowed as an outgoing' do
+          it 'does not update the remarks class' do
+            original_remarks = assessment.remarks.as_json
+            described_class.call(assessment, collection)
+            expect(assessment.reload.remarks.as_json).to eq original_remarks
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1806)

Childcare payments are being flagged for amount variation/frequency issues even if they have been disallowed from the calculation.

This change adds extra checks so that childcare is only flagged if the payments are included in the calculation, which only happens if the applicant is employed or in receipt of a student loan.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
