### PR TITLE
Allow submission date to be in the future for integration tests

### DIFF
--- a/.github/workflows/manual-integration-tests.yml
+++ b/.github/workflows/manual-integration-tests.yml
@@ -53,5 +53,6 @@ jobs:
           CLIENT_ID: ${{ secrets.CLIENT_ID }}
           PRIVATE_KEY: ${{ secrets.PRIVATE_KEY }}
           PRIVATE_KEY_ID: ${{ secrets.PRIVATE_KEY_ID }}
+          ALLOW_FUTURE_SUBMISSION_DATE: true
         run: |
           bundle exec rspec spec/integration/test_runner_spec.rb

--- a/README.md
+++ b/README.md
@@ -43,7 +43,11 @@ PRIVATE_KEY_ID
 PRIVATE_KEY
 CLIENT_EMAIL
 CLIENT_ID
+ALLOW_FUTURE_SUBMISSION_DATE=<true or false>
 ```
+
+Set ALLOW_FUTURE_SUBMISSION_DATE to true, if you want to allow submission dates to be in the future for integration tests
+
 A copy of the `.env` file including the current values can be found in the `Shared-LAA` section of LastPass
 
 ## Integration tests

--- a/app/controllers/assessments_controller.rb
+++ b/app/controllers/assessments_controller.rb
@@ -13,7 +13,7 @@ class AssessmentsController < ApplicationController
   api :POST, 'assessments', 'Create assessment'
   formats ['json']
   param :client_reference_id, String, "The client's reference number for this application (free text)"
-  param :submission_date, Date, date_option: :today_or_older, required: true, desc: 'The date of the original submission'
+  param :submission_date, Date, date_option: :submission_date_today_or_older, required: true, desc: 'The date of the original submission'
   param :matter_proceeding_type, Assessment.matter_proceeding_types.values, required: true, desc: 'The matter type of the case'
 
   returns code: :ok, desc: 'Successful response' do

--- a/app/validators/date_validator.rb
+++ b/app/validators/date_validator.rb
@@ -18,12 +18,7 @@ class DateValidator < Apipie::Validator::BaseValidator
 
     date = Date.parse(value)
 
-    case option
-    when :today_or_older
-      return true if date <= Date.today
-    else
-      raise "date option '#{option}' not recognised"
-    end
+    validate_options(option, date)
   end
 
   def description
@@ -33,6 +28,21 @@ class DateValidator < Apipie::Validator::BaseValidator
   end
 
   private
+
+  def validate_options(option, date)
+    case option
+    when :today_or_older
+      return true if date <= Date.today
+    when :submission_date_today_or_older
+      return true if date <= Date.today || allow_future_submission_date?
+    else
+      raise "date option '#{option}' not recognised"
+    end
+  end
+
+  def allow_future_submission_date?
+    ActiveModel::Type::Boolean.new.cast(Rails.configuration.x.application.allow_future_submission_date)
+  end
 
   def date_parsable?(string)
     date_hash = Date._parse(string)

--- a/config/application.rb
+++ b/config/application.rb
@@ -32,6 +32,9 @@ module CheckFinancialEligibility
     # Skip views, helpers and assets when generating a new resource.
     config.api_only = true
 
+    # Allow future submission date for integration testing
+    config.x.application.allow_future_submission_date = ENV['ALLOW_FUTURE_SUBMISSION_DATE']
+
     config.autoload_paths += %W[#{config.root}/app/validators]
   end
 end

--- a/spec/validators/date_validator_spec.rb
+++ b/spec/validators/date_validator_spec.rb
@@ -38,6 +38,34 @@ RSpec.describe DateValidator do
       end
     end
 
+    context ':submission_date_today_or_older' do
+      let(:option) { :submission_date_today_or_older }
+
+      it 'returns true for today' do
+        input = Date.today.to_s
+        expect(subject.validate(input)).to be_truthy
+      end
+
+      it 'returns true for date in past' do
+        input = 2.days.ago.to_s
+        expect(subject.validate(input)).to be_truthy
+      end
+
+      it 'returns false for date in future' do
+        input = 2.days.from_now.to_s
+        expect(subject.validate(input)).to be_falsey
+      end
+
+      context 'override for integration testing' do
+        before { allow(Rails.configuration.x.application).to receive(:allow_future_submission_date).and_return(true) }
+
+        it 'returns true for date in future' do
+          input = 2.days.from_now.to_s
+          expect(subject.validate(input)).to be_truthy
+        end
+      end
+    end
+
     context 'with unknown option' do
       let(:option) { :unknown }
 


### PR DESCRIPTION
## ~~Allow submission date to be in the future for integration tests~~

This is now done in this ticket
[Link to story](https://dsdmoj.atlassian.net/browse/AP-1869)


~~This means that we can test policy changes before the policy change date without getting an error~~

- ~~Create a custom date validation option for submission dates as there are other attributes using :today_or_older~~

- ~~Test this~~

- ~~**Update github actions workflow for the integration tests**~~

- ~~Update the readme with ALLOW_FUTURE_SUBMISSION_DATE environment variable, which defaults to false.~~

- ~~In order to use this in integration testing you do: ALLOW_FUTURE_SUBMISSION_DATE=true bundle exec rspec spec/integration/test_runner_spec.rb~~


## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
