### PR TITLE
AP-1869 Policy change on property mortgage cap

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,11 @@ PRIVATE_KEY_ID
 PRIVATE_KEY
 CLIENT_EMAIL
 CLIENT_ID
+ALLOW_FUTURE_SUBMISSION_DATE
 ```
+
+Set ALLOW_FUTURE_SUBMISSION_DATE to true to allow integration tests to run with submission dates that are in the future
+
 A copy of the `.env` file including the current values can be found in the `Shared-LAA` section of LastPass
 
 ## Integration tests

--- a/app/controllers/assessments_controller.rb
+++ b/app/controllers/assessments_controller.rb
@@ -13,7 +13,7 @@ class AssessmentsController < ApplicationController
   api :POST, 'assessments', 'Create assessment'
   formats ['json']
   param :client_reference_id, String, "The client's reference number for this application (free text)"
-  param :submission_date, Date, date_option: :today_or_older, required: true, desc: 'The date of the original submission'
+  param :submission_date, Date, date_option: :submission_date_today_or_older, required: true, desc: 'The date of the original submission'
   param :matter_proceeding_type, Assessment.matter_proceeding_types.values, required: true, desc: 'The matter type of the case'
 
   returns code: :ok, desc: 'Successful response' do

--- a/app/models/threshold.rb
+++ b/app/models/threshold.rb
@@ -16,7 +16,7 @@ class Threshold
     end
 
     def value_for(item, at: Time.now)
-      key = data.keys.select { |time| time < at }.max || data.keys.min
+      key = data.keys.select { |time| time <= at }.max || data.keys.min
       threshold = data[key]
       threshold.value(item.to_sym)
     end

--- a/app/validators/date_validator.rb
+++ b/app/validators/date_validator.rb
@@ -18,12 +18,22 @@ class DateValidator < Apipie::Validator::BaseValidator
 
     date = Date.parse(value)
 
+    validate_options(option, date)
+  end
+
+  def validate_options(option, date)
     case option
     when :today_or_older
       return true if date <= Date.today
+    when :submission_date_today_or_older
+      return true if (date <= Date.today || allow_future_submission_date?)
     else
       raise "date option '#{option}' not recognised"
     end
+  end
+
+  def allow_future_submission_date?
+    Rails.configuration.x.application.allow_future_submission_date
   end
 
   def description

--- a/app/validators/date_validator.rb
+++ b/app/validators/date_validator.rb
@@ -21,12 +21,20 @@ class DateValidator < Apipie::Validator::BaseValidator
     validate_options(option, date)
   end
 
+  def description
+    text = ['Date must be parsable']
+    text << 'in the past' if option == :today_or_older
+    "#{text.to_sentence}. For example: '2019-05-23'"
+  end
+
+  private
+  
   def validate_options(option, date)
     case option
     when :today_or_older
       return true if date <= Date.today
     when :submission_date_today_or_older
-      return true if (date <= Date.today || allow_future_submission_date?)
+      return true if date <= Date.today || allow_future_submission_date?
     else
       raise "date option '#{option}' not recognised"
     end
@@ -35,14 +43,6 @@ class DateValidator < Apipie::Validator::BaseValidator
   def allow_future_submission_date?
     Rails.configuration.x.application.allow_future_submission_date
   end
-
-  def description
-    text = ['Date must be parsable']
-    text << 'in the past' if option == :today_or_older
-    "#{text.to_sentence}. For example: '2019-05-23'"
-  end
-
-  private
 
   def date_parsable?(string)
     date_hash = Date._parse(string)

--- a/app/validators/date_validator.rb
+++ b/app/validators/date_validator.rb
@@ -28,7 +28,7 @@ class DateValidator < Apipie::Validator::BaseValidator
   end
 
   private
-  
+
   def validate_options(option, date)
     case option
     when :today_or_older

--- a/config/application.rb
+++ b/config/application.rb
@@ -32,6 +32,8 @@ module CheckFinancialEligibility
     # Skip views, helpers and assets when generating a new resource.
     config.api_only = true
 
+    config.x.application.allow_future_submission_date = ENV['ALLOW_FUTURE_SUBMISSION_DATE'] || false
+
     config.autoload_paths += %W[#{config.root}/app/validators]
   end
 end

--- a/config/thresholds/28-Jan-2021.yml
+++ b/config/thresholds/28-Jan-2021.yml
@@ -1,0 +1,64 @@
+---
+gross_income_upper: 2657
+infinite_gross_income_upper: 999_999_999_999
+dependant_step: 222
+dependant_increase_starts_after: 4
+disposable_income_lower: 315
+disposable_income_upper: 733
+capital_lower: 3_000
+capital_upper: 8_000
+pensioner_capital_disregard:
+  minimum_age_in_years: 60
+  passported: 100_000
+  non_passported: 100_000
+  # capital to disregard if monthly disposable income (excluding income derived from capital) is below these figures
+  monthly_income_values:
+    [0, 25.99]: 100_000
+    [26.0, 50.99]: 90_000
+    [51.0, 75.99]: 80_000
+    [76.0, 100.99]: 70_000
+    [101.0, 125.99]: 60_000
+    [126.0, 150.99]: 50_000
+    [151.0, 175.99]: 40_000
+    [176.0, 200.99]: 30_000
+    [201.0, 225.99]: 20_000
+    [226.0, 315.99]: 10_000
+    [316.0]: 0
+property_notional_sale_costs_percentage: 3.0
+property_maximum_mortgage_allowance: 999_999_999_999
+property_disregard:
+  main_home: 100_000
+  additional_property: 0.0
+vehicle_disregard: 15_000
+vehicle_out_of_scope_months: 36
+
+dependant_allowances:
+  child_under_15: 291.49
+  child_aged_15: 291.49
+  child_16_and_over: 291.49
+  adult: 291.49
+  adult_capital_threshold: 8_000
+
+single_monthly_housing_costs_cap: 545
+
+disposable_income_contribution_bands:
+  band_zero:
+    threshold: 0.0
+    disregard: 0.0
+    percentage: 0.0
+    base: 0.0
+  band_a:
+    threshold: 315.0
+    disregard: 311.0
+    percentage: 35.0
+    base: 0
+  band_b:
+    threshold: 466
+    disregard: 465
+    percentage: 45.0
+    base: 53.90
+  band_c:
+    threshold: 617
+    disregard: 616
+    percentage: 70.0
+    base: 121.85

--- a/spec/services/calculators/property_calculator_spec.rb
+++ b/spec/services/calculators/property_calculator_spec.rb
@@ -151,9 +151,9 @@ module Calculators
               expect(main_home.transaction_allowance).to eq 14_009.79 # 3% of 466,993
               expect(main_home.allowable_outstanding_mortgage).to eq 266_000.0
               expect(main_home.net_value).to eq 186_983.21 # 466,993 - 14,009.79 - 266_000.0
-              expect(main_home.net_equity).to eq 124643.01 # 66.66% of 186_983.21
+              expect(main_home.net_equity).to eq 124_643.01 # 66.66% of 186_983.21
               expect(main_home.main_home_equity_disregard).to eq 100_000.0
-              expect(main_home.assessed_equity).to eq 24643.01
+              expect(main_home.assessed_equity).to eq 24_643.01
             end
           end
         end
@@ -197,9 +197,9 @@ module Calculators
               expect(main_home.transaction_allowance).to eq 14_009.79 # 3% of 466,993
               expect(main_home.allowable_outstanding_mortgage).to eq 266_000.0
               expect(main_home.net_value).to eq 186_983.21 # 466,993 - 14,009.79 - 266_000.0
-              expect(main_home.net_equity).to eq 124643.01 # 66.66% of 186_983.21
+              expect(main_home.net_equity).to eq 124_643.01 # 66.66% of 186_983.21
               expect(main_home.main_home_equity_disregard).to eq 100_000.0
-              expect(main_home.assessed_equity).to eq 24643.01
+              expect(main_home.assessed_equity).to eq 24_643.01
             end
           end
         end
@@ -289,8 +289,8 @@ module Calculators
               main_home.reload
               expect(main_home.transaction_allowance).to eq 6_600.0
               expect(main_home.allowable_outstanding_mortgage).to eq 35_000.0
-              expect(main_home.net_value).to eq 178400.0
-              expect(main_home.net_equity).to eq 178400.0
+              expect(main_home.net_value).to eq 178_400.0
+              expect(main_home.net_equity).to eq 178_400.0
               expect(main_home.main_home_equity_disregard).to eq 100_000.0
               expect(main_home.assessed_equity).to eq 78_400.0
             end
@@ -326,12 +326,12 @@ module Calculators
           let(:submission_date) { Time.local(2021, 1, day) }
           let!(:additional_property) do
             create :property,
-                  :additional_property,
-                  :not_shared_ownership,
-                  capital_summary: capital_summary,
-                  value: 350_000,
-                  outstanding_mortgage: 200_000,
-                  percentage_owned: 100.0
+                   :additional_property,
+                   :not_shared_ownership,
+                   capital_summary: capital_summary,
+                   value: 350_000,
+                   outstanding_mortgage: 200_000,
+                   percentage_owned: 100.0
           end
 
           it 'deducts outstanding_mortgage instead of mortgage cap' do
@@ -357,7 +357,7 @@ module Calculators
       context 'submission date on or after 28/1/2021' do
         let(:day) { [28, 30].sample }
         let(:submission_date) { Time.local(2021, 1, day) }
-        
+
         it 'returns 999_999_999_999' do
           expect(service.remaining_mortgage_allowance).to eq 999_999_999_999
         end

--- a/spec/validators/date_validator_spec.rb
+++ b/spec/validators/date_validator_spec.rb
@@ -38,6 +38,36 @@ RSpec.describe DateValidator do
       end
     end
 
+    context 'with submission_date_today_or_older option' do
+      let(:option) { :submission_date_today_or_older }
+
+      before { allow(Rails.configuration.x.application).to receive(:allow_future_submission_date).and_return false }
+
+      it 'returns true for today' do
+        input = Date.today.to_s
+        expect(subject.validate(input)).to be_truthy
+      end
+
+      it 'returns true for date in past' do
+        input = 2.days.ago.to_s
+        expect(subject.validate(input)).to be_truthy
+      end
+
+      it 'returns false for date in future' do
+        input = 2.days.from_now.to_s
+        expect(subject.validate(input)).to be_falsey
+      end
+
+      context 'allow submission date to be future is configured to true' do
+        before { allow(Rails.configuration.x.application).to receive(:allow_future_submission_date).and_return true }
+
+        it 'returns true for date in future' do
+          input = 2.days.from_now.to_s
+          expect(subject.validate(input)).to be_truthy
+        end
+      end
+    end
+
     context 'with unknown option' do
       let(:option) { :unknown }
 


### PR DESCRIPTION
## AP-1869 Policy change on property mortgage cap

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1869)

1. Add configuration (config/thresholds/28-Jan-2021.yml) for when submission date is on or after 28th January 2021 - the policy change date. 

**To do the above:**

- Remove the mortgage cap by placing its value at 999_999_999_999, which subsequently draws back to using the outstanding mortgage instead of the fixed value of 100_000 in the property calculations.

- Add a new environment variable ALLOW_FUTURE_SUBMISSION_DATE to allow integration tests to run. Otherwise, they will fail because some of our tests in the means spreadsheet has submission dates in the future.

- Use the ALLOW_FUTURE_SUBMISSION_DATE in the date validator to decide whether or not to skip date validation on the submission date. There is :today_or_older validations elsewhere so created :submission_date_today_or_older

- Add tests

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
