### PR TITLE
Implement API interaction playback rake task

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+e
 [![CircleCI](https://circleci.com/gh/ministryofjustice/check-financial-eligibility/tree/master.svg?style=svg)](https://circleci.com/gh/ministryofjustice/check-financial-eligibility/tree/master)
 
 # Ministry of Justice
@@ -65,3 +66,20 @@ or more simply:
 
 * ```rake integration``` to run verbose, or
 * ```rake integration[silent]``` to run in silent mode
+
+## Replaying live API interactions for debugging purposes
+
+In the event that you need to investigate why a CFE result was produced on live, there is 
+a way to replay the API calls of the original application and debug the assessment process
+on a local machine
+
+1) Record the original api payloads and calls on the Apply system
+   Run the rake task `rake cfe:record_payloads`.  This will print to the screen a YAML 
+   representation of the calls to the API with the actual payloads
+   
+2) Copy and paste that output to the file `tmp/api_payloads.yml` in this repo
+
+3) Start a CFE server locally on port 4000, and add breakpoints at the required places
+
+4) Run the rake task `rake replay`: this will read the `tmp/api_payloads.yml` file and 
+   replay the original API calls and payloads enabling you to re-create the conditions.s 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-e
 [![CircleCI](https://circleci.com/gh/ministryofjustice/check-financial-eligibility/tree/master.svg?style=svg)](https://circleci.com/gh/ministryofjustice/check-financial-eligibility/tree/master)
 
 # Ministry of Justice

--- a/app/models/assessment.rb
+++ b/app/models/assessment.rb
@@ -22,7 +22,7 @@ class Assessment < ApplicationRecord
 
   delegate :determine_result!, to: :capital_summary
 
-  # Always instanitate a new Remarks object from a nil value
+  # Always instantiate a new Remarks object from a nil value
   def remarks
     attributes['remarks'] || Remarks.new
   end

--- a/lib/task_helpers/payload_player.rb
+++ b/lib/task_helpers/payload_player.rb
@@ -1,0 +1,77 @@
+class PayloadPlayer
+  POST_HEADERS = { 'Content-Type' => 'application/json' }.freeze
+  GET_ASSESSMENT_REGEX = %r{^/assessments/[0-9a-f-]{36}$}.freeze
+  POST_ASSESSMENT_REGEX = %r{^/assessments/([0-9a-f-]{36})}.freeze
+  SERVER_HOST = 'http://localhost:4000'.freeze
+
+  def self.call
+    new.call
+  end
+
+  def initialize
+    @yaml = YAML.load_file(Rails.root.join('tmp/api_replay.yml'))
+    @assessment_id = nil
+  end
+
+  def call
+    @yaml.each do |request|
+      play(request)
+    end
+  end
+
+  private
+
+  def play(request)
+    case request[:method]
+    when 'POST'
+      play_post(request)
+    when 'GET'
+      play_get(request)
+    else
+      raise 'Unrecognised http method'
+    end
+  end
+
+  def play_post(request)
+    puts '>>>> playing POST request'
+    substitute_assessment_id(request)
+    print_request(request)
+    response = Faraday.post(url(request), request[:payload], POST_HEADERS)
+    @assessment_id = JSON.parse(response.body)['assessment_id'] if request[:path] == '/assessments'
+    print_response(response)
+    puts "********\n\n"
+  end
+
+  def play_get(request)
+    puts '>>>> playing GET request'
+    substitute_assessment_id(request)
+    print_request(request)
+    response = Faraday.get(url(request))
+    print_response(response)
+    puts "********\n\n"
+  end
+
+  def url(request)
+    "#{SERVER_HOST}#{request[:path]}"
+  end
+
+  def substitute_assessment_id(request)
+    return if request[:path] == '/assessments'
+
+    request[:path] =~ POST_ASSESSMENT_REGEX
+    replaceable_id = Regexp.last_match(1)
+    request[:path] = request[:path].sub(replaceable_id, @assessment_id)
+  end
+
+  def print_request(request)
+    puts "method: #{request[:method]}"
+    puts "path: #{request[:path]}"
+    puts "payload: #{request[:payload]}"
+  end
+
+  def print_response(response)
+    puts "response status: #{response.status}"
+    puts 'response payload:'
+    pp JSON.parse(response.body)
+  end
+end

--- a/lib/tasks/payload_player.rake
+++ b/lib/tasks/payload_player.rake
@@ -1,0 +1,5 @@
+desc 'Replays payload recorded with rake cfe:record_payloads on apply - Expects server to  be running on port 4000 - Expects YAML file in  tmp/api_replay.yml'
+task replay: :environment do
+  require_relative '../task_helpers/payload_player'
+  PayloadPlayer.call
+end


### PR DESCRIPTION
## Implement API interaction playback rake task

This PR implements a rake task which will play back CFE interaction recorded with the `rake cfe:record_payloads` rake task in the Apply system so that potential bugs can be examined locally.

Usage:

- Copy and paste the output from the Apply `rake cfe:record_payloads` rake task into a file `tmp/api_payloads.yml` in this repo.
- Start a CFE server locally listening on port 4000 `rails s -p 4000`
- Run `rake playback`

This will cause all the requests to be sent to the local instance on 4000 allowing you to examine the records created and/or debug the calculations.


Before you ask people to review this PR:

- [ ] Tests and rubocop should be passing: `bundle exec rake`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [ ] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [ ] The PR description should say what you changed and why, with a link to the JIRA story.
- [ ] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
