### PR TITLE
Place test environment variable in circleci config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,6 +31,7 @@ executors:
           - PGHOST=localhost
           - PGUSER=user
           - TZ: "Europe/London"
+          - ALLOW_FUTURE_SUBMISSION_DATE: true
       - image: postgres:10.5
         environment:
           - POSTGRES_USER=user


### PR DESCRIPTION
## Place test environment variable in circleci config

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1895)

- Set the ALLOW_FUTURE_SUBMISSION_DATE env variable in our app circleci config file.


At the moment we have ALLOW_FUTURE_SUBMISSION_DATE set in the circleci project settings on circleci. This PR specifies that we want it set in our app's /circleci/config.yml just for the test container that runs the integration tests.

We set ALLOW_FUTURE_SUBMISSION_DATE to true so that integration tests pass with the means spreadsheet that has submission dates in the future (for future policy change purposes)

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
