### PR TITLE
AP-1928 Implement explicit remarks endpoint

### DIFF
--- a/app/controllers/explicit_remarks_controller.rb
+++ b/app/controllers/explicit_remarks_controller.rb
@@ -11,7 +11,7 @@ class ExplicitRemarksController < ApplicationController
 
     END_OF_TEXT
   end
-  api :POST, 'assessments/:assessment_id/remark', 'Add remarks to an assessment (create assessment first with POST /assessments)'
+  api :POST, 'assessments/:assessment_id/explicit_remarks', 'Add remarks to an assessment (create assessment first with POST /assessments)'
   formats ['json']
   param :assessment_id, :uuid, required: true, desc: 'The assessment id to which these remarks relate - must have been created prior to this call with POST /assessments'
   param :explicit_remarks, Array, required: true, desc: 'An Array of Objects describing a a category or remarks' do

--- a/app/controllers/explicit_remarks_controller.rb
+++ b/app/controllers/explicit_remarks_controller.rb
@@ -1,0 +1,48 @@
+class ExplicitRemarksController < ApplicationController
+  VALID_REMARK_CATEGORIES = %w[income_disregards].freeze
+
+  resource_description do
+    description <<-END_OF_TEXT
+    == Description
+      This endpoint will allow remarks to be sent to CFE which will be included in the
+      assessment result
+
+        POST /remarks
+
+    END_OF_TEXT
+  end
+  api :POST, 'assessments/:assessment_id/remark', 'Add remarks to an assessment (create assessment first with POST /assessments)'
+  formats ['json']
+  param :assessment_id, :uuid, required: true, desc: 'The assessment id to which these remarks relate - must have been created prior to this call with POST /assessments'
+  param :explicit_remarks, Array, required: true, desc: 'An Array of Objects describing a a category or remarks' do
+    param :category, VALID_REMARK_CATEGORIES, required: true, desc: "The category of remark. Currently, only 'income disregard' is supported"
+    param :details, Array, of: String, required: true
+  end
+
+  returns code: :ok, desc: 'Successful response' do
+    property :success, ['true'], desc: 'Success flag shows true'
+    property :errors, [], desc: 'Empty array of error messages'
+  end
+  returns code: :unprocessable_entity do
+    property :success, ['false'], desc: 'Success flag shows false'
+    property :errors, array_of: String, desc: 'Description of why object invalid'
+  end
+
+  def create
+    creation_service
+    if creation_service.success?
+      render_success
+    else
+      render_unprocessable(creation_service.errors)
+    end
+  end
+
+  private
+
+  def creation_service
+    @creation_service ||= Creators::ExplicitRemarksCreator.call(
+      assessment_id: params[:assessment_id],
+      remarks_attributes: params[:explicit_remarks]
+    )
+  end
+end

--- a/app/models/assessment.rb
+++ b/app/models/assessment.rb
@@ -17,6 +17,7 @@ class Assessment < ApplicationRecord
   has_many :vehicles, through: :capital_summary
   has_many :capital_items, through: :capital_summary
   has_many :assessment_errors
+  has_many :explicit_remarks
 
   enum matter_proceeding_type: enum_hash_for(:domestic_abuse)
 
@@ -24,6 +25,6 @@ class Assessment < ApplicationRecord
 
   # Always instantiate a new Remarks object from a nil value
   def remarks
-    attributes['remarks'] || Remarks.new
+    attributes['remarks'] || Remarks.new(id)
   end
 end

--- a/app/models/explicit_remark.rb
+++ b/app/models/explicit_remark.rb
@@ -1,0 +1,15 @@
+class ExplicitRemark < ApplicationRecord
+  belongs_to :assessment
+
+  validates :category, inclusion: { in: ExplicitRemarksController::VALID_REMARK_CATEGORIES,
+                                    message: '%<value>s is not a valid remark category' }
+
+  def self.remarks_by_category(assessment_id)
+    where(assessment_id: assessment_id)
+      .order(:category, :remark)
+      .pluck(:category, :remark)
+      .group_by(&:first)
+      .transform_values { |xr| xr.map(&:last) }
+      .symbolize_keys
+  end
+end

--- a/app/services/creators/explicit_remarks_creator.rb
+++ b/app/services/creators/explicit_remarks_creator.rb
@@ -1,0 +1,46 @@
+module Creators
+  class ExplicitRemarksCreator < BaseCreator
+    def initialize(assessment_id:, remarks_attributes: nil)
+      super()
+      @assessment_id = assessment_id
+      @remarks_attributes = remarks_attributes
+    end
+
+    def call
+      create
+      self
+    end
+
+    def create
+      create_remarks
+    rescue CreationError => e
+      errors << e.errors
+    end
+
+    def create_remarks
+      ExplicitRemark.transaction do
+        @remarks_attributes.each do |remark_category|
+          create_remark_category(remark_category)
+        end
+      end
+    rescue StandardError => e
+      raise CreationError, "#{e.class} - #{e.message}"
+    end
+
+    def create_remark_category(remark_category)
+      category = remark_category[:category]
+      remarks = remark_category[:details]
+      remarks.each { |remark| create_remark(category, remark) }
+    end
+
+    def create_remark(category, remark)
+      rec = ExplicitRemark.create(assessment_id: @assessment_id,
+                                  category: category,
+                                  remark: remark)
+      return if rec.valid?
+
+      @errors = rec.errors.full_messages
+      raise ActiveRecord::Rollback
+    end
+  end
+end

--- a/app/services/remarks.rb
+++ b/app/services/remarks.rb
@@ -19,7 +19,8 @@ class Remarks
   ].freeze
   VALID_ISSUES = %i[unknown_frequency amount_variation residual_balance multi_benefit].freeze
 
-  def initialize
+  def initialize(assessment_id)
+    @assessment_id = assessment_id
     @remarks_hash = {}
   end
 
@@ -31,7 +32,7 @@ class Remarks
   end
 
   def as_json
-    @remarks_hash
+    @remarks_hash.merge! ExplicitRemark.remarks_by_category(@assessment_id)
   end
 
   private

--- a/config/initializers/apipie.rb
+++ b/config/initializers/apipie.rb
@@ -33,7 +33,7 @@ Apipie.configure do |config|
       POST /assessments/:assessment_id/other_incomes      # adds data about applicant's other sources of income
       POST /assessments/:assessment_id/outgoings          # adds data about applicant's outgoings
       POST /assessments/:assessment_id/properties         # adds data about properties owned by the applicant
-      POST /assessments/:assessment_id/remarks            # adds remarks to be included on the means report
+      POST /assessments/:assessment_id/explicit_remarks   # adds remarks to be included on the means report
       POST /assessments/:assessment_id/state_benefits     # adds data about applicant's income from state benefits
       POST /assessments/:assessment_id/vehicles           # adds data about vehicles owned by the applicant
 

--- a/config/initializers/apipie.rb
+++ b/config/initializers/apipie.rb
@@ -29,10 +29,11 @@ Apipie.configure do |config|
       POST /assessments/:assessment_id/applicant          # adds data about the applicant
       POST /assessments/:assessment_id/capitals           # adds data about liquid assets (i.e. bank accounts) and non-liquid assets (valuable items, trusts, etc)
       POST /assessments/:assessment_id/dependants         # adds data about any dependants the applicant may have
+      POST /assessments/:assessment_id/irregular_incomes  # adds data about applicant's irregular income
+      POST /assessments/:assessment_id/other_incomes      # adds data about applicant's other sources of income
       POST /assessments/:assessment_id/outgoings          # adds data about applicant's outgoings
       POST /assessments/:assessment_id/properties         # adds data about properties owned by the applicant
-      POST /assessments/:assessment_id/other_incomes      # adds data about applicant's other sources of income
-      POST /assessments/:assessment_id/irregular_incomes  # adds data about applicant's irregular income
+      POST /assessments/:assessment_id/remarks            # adds remarks to be included on the means report
       POST /assessments/:assessment_id/state_benefits     # adds data about applicant's income from state benefits
       POST /assessments/:assessment_id/vehicles           # adds data about vehicles owned by the applicant
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,7 @@ Rails.application.routes.draw do
     resources :other_incomes, only: [:create]
     resource :irregular_incomes, only: [:create]
     resources :state_benefits, only: [:create]
+    resources :explicit_remarks, only: [:create]
   end
   resources :state_benefit_type, only: [:index]
 

--- a/db/migrate/20201221151158_create_explicit_remarks.rb
+++ b/db/migrate/20201221151158_create_explicit_remarks.rb
@@ -1,0 +1,11 @@
+class CreateExplicitRemarks < ActiveRecord::Migration[6.0]
+  def change
+    create_table :explicit_remarks do |t|
+      t.uuid :assessment_id
+      t.string :category
+      t.string :remark
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_10_19_103924) do
+ActiveRecord::Schema.define(version: 2020_12_21_151158) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -113,6 +113,14 @@ ActiveRecord::Schema.define(version: 2020_10_19_103924) do
     t.decimal "income_contribution", default: "0.0"
     t.decimal "legal_aid", default: "0.0", null: false
     t.index ["assessment_id"], name: "index_disposable_income_summaries_on_assessment_id"
+  end
+
+  create_table "explicit_remarks", force: :cascade do |t|
+    t.uuid "assessment_id"
+    t.string "category"
+    t.string "remark"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "gross_income_summaries", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/doc/apipie_examples.json
+++ b/doc/apipie_examples.json
@@ -2,39 +2,14 @@
   "applicants#create": [
     {
       "verb": "POST",
-      "path": "/assessments/b8562d24-6055-4280-804e-1f19ea8a6e12/applicant",
+      "path": "/assessments/7933e816-bdab-48af-b87a-aa096fd3f3c7/applicant",
       "versions": [
         "1.0"
       ],
       "query": null,
       "request_data": {
         "applicant": {
-          "date_of_birth": "2000-10-26",
-          "involvement_type": "applicant",
-          "has_partner_opponent": false,
-          "receives_qualifying_benefit": "yes"
-        }
-      },
-      "response_data": {
-        "success": false,
-        "errors": [
-          "Invalid parameter 'receives_qualifying_benefit' value \"yes\": Must be one of: <code>true</code>, <code>false</code>, <code>1</code>, <code>0</code>."
-        ]
-      },
-      "code": 422,
-      "show_in_doc": 1,
-      "recorded": true
-    },
-    {
-      "verb": "POST",
-      "path": "/assessments/0a10fccf-a04a-4b27-90c2-63d681048029/applicant",
-      "versions": [
-        "1.0"
-      ],
-      "query": null,
-      "request_data": {
-        "applicant": {
-          "date_of_birth": "2000-10-26",
+          "date_of_birth": "2000-12-21",
           "involvement_type": "applicant",
           "has_partner_opponent": false,
           "receives_qualifying_benefit": true
@@ -47,6 +22,31 @@
         ]
       },
       "code": 200,
+      "show_in_doc": 1,
+      "recorded": true
+    },
+    {
+      "verb": "POST",
+      "path": "/assessments/3b93b7f4-c7aa-4ab7-b715-18738e1a0875/applicant",
+      "versions": [
+        "1.0"
+      ],
+      "query": null,
+      "request_data": {
+        "applicant": {
+          "date_of_birth": "2000-12-21",
+          "involvement_type": "applicant",
+          "has_partner_opponent": false,
+          "receives_qualifying_benefit": "yes"
+        }
+      },
+      "response_data": {
+        "success": false,
+        "errors": [
+          "Invalid parameter 'receives_qualifying_benefit' value \"yes\": Must be one of: <code>true</code>, <code>false</code>, <code>1</code>, <code>0</code>."
+        ]
+      },
+      "code": 422,
       "show_in_doc": 1,
       "recorded": true
     }
@@ -66,7 +66,7 @@
       },
       "response_data": {
         "success": true,
-        "assessment_id": "3e806ed0-cddc-4e88-b742-eb5eae394d22",
+        "assessment_id": "91201fcd-0e99-406f-b849-8b5d165d29f3",
         "errors": [
 
         ]
@@ -101,7 +101,7 @@
   "assessments#show": [
     {
       "verb": "GET",
-      "path": "/assessments/64d3d09f-bc11-45f3-b74e-75b0d835ae26",
+      "path": "/assessments/ad05269f-eb63-4d2e-919e-82c9b68b76f7",
       "versions": [
         "1.0"
       ],
@@ -109,113 +109,10 @@
       "request_data": null,
       "response_data": {
         "version": "2",
-        "timestamp": "2020-10-26T08:16:32.423+00:00",
+        "timestamp": "2020-12-21T14:51:50.887+00:00",
         "success": true,
         "assessment": {
-          "id": "64d3d09f-bc11-45f3-b74e-75b0d835ae26",
-          "client_reference_id": "CLIENT-REF-0010",
-          "submission_date": "2020-10-26",
-          "matter_proceeding_type": "domestic_abuse",
-          "assessment_result": "contribution_required",
-          "applicant": {
-            "date_of_birth": "1983-01-14",
-            "involvement_type": "applicant",
-            "has_partner_opponent": false,
-            "receives_qualifying_benefit": true,
-            "self_employed": false
-          },
-          "gross_income": null,
-          "disposable_income": null,
-          "capital": {
-            "capital_items": {
-              "liquid": [
-                {
-                  "description": "Et nemo deserunt error.",
-                  "value": "7343.19"
-                }
-              ],
-              "non_liquid": [
-                {
-                  "description": "Voluptatem quia molestiae quos.",
-                  "value": "9590.75"
-                }
-              ],
-              "vehicles": [
-                {
-                  "value": "2259.77",
-                  "loan_amount_outstanding": "9260.13",
-                  "date_of_purchase": "2016-06-02",
-                  "in_regular_use": true,
-                  "included_in_assessment": false,
-                  "assessed_value": "0.0"
-                }
-              ],
-              "properties": {
-                "main_home": {
-                  "value": "7322.16",
-                  "outstanding_mortgage": "6816.28",
-                  "percentage_owned": "0.16",
-                  "main_home": true,
-                  "shared_with_housing_assoc": false,
-                  "transaction_allowance": "219.66",
-                  "allowable_outstanding_mortgage": "6816.28",
-                  "net_value": "286.22",
-                  "net_equity": "0.46",
-                  "main_home_equity_disregard": "100000.0",
-                  "assessed_equity": "0.0"
-                },
-                "additional_properties": [
-                  {
-                    "value": "9153.47",
-                    "outstanding_mortgage": "4069.01",
-                    "percentage_owned": "1.08",
-                    "main_home": false,
-                    "shared_with_housing_assoc": true,
-                    "transaction_allowance": "274.6",
-                    "allowable_outstanding_mortgage": "4069.01",
-                    "net_value": "4809.86",
-                    "net_equity": "-4244.75",
-                    "main_home_equity_disregard": "0.0",
-                    "assessed_equity": "0.0"
-                  }
-                ]
-              }
-            },
-            "total_liquid": "7343.19",
-            "total_non_liquid": "9590.75",
-            "total_vehicle": "0.0",
-            "total_property": "0.0",
-            "total_mortgage_allowance": "100000.0",
-            "total_capital": "16933.94",
-            "pensioner_capital_disregard": "0.0",
-            "assessed_capital": "16933.94",
-            "lower_threshold": "3000.0",
-            "upper_threshold": "999999999999.0",
-            "assessment_result": "contribution_required",
-            "capital_contribution": "13933.94"
-          },
-          "remarks": {
-          }
-        }
-      },
-      "code": 200,
-      "show_in_doc": 1,
-      "recorded": true
-    },
-    {
-      "verb": "GET",
-      "path": "/assessments/895e4255-259e-46fa-a8fb-d4e2cb71bf3b",
-      "versions": [
-        "1.0"
-      ],
-      "query": null,
-      "request_data": null,
-      "response_data": {
-        "version": "2",
-        "timestamp": "2020-10-26T08:16:32.645+00:00",
-        "success": true,
-        "assessment": {
-          "id": "895e4255-259e-46fa-a8fb-d4e2cb71bf3b",
+          "id": "ad05269f-eb63-4d2e-919e-82c9b68b76f7",
           "client_reference_id": "NPE6-1",
           "submission_date": "2019-05-29",
           "matter_proceeding_type": "domestic_abuse",
@@ -382,16 +279,119 @@
           "remarks": {
             "state_benefit_payment": {
               "amount_variation": [
-                "1092f4a1-f54f-4563-8941-c508f29386cd",
-                "200273af-d18f-4cf5-ba56-354e0f79b2da",
-                "187aa32d-c29c-4b90-8669-e90e988cb115"
+                "37351d64-caf7-4952-9b6a-1373e38c12b8",
+                "d8291758-20a0-4c1e-8db1-c626edb60f52",
+                "35e6351a-85bd-434d-a777-211f1d0cce3d"
               ],
               "unknown_frequency": [
-                "1092f4a1-f54f-4563-8941-c508f29386cd",
-                "200273af-d18f-4cf5-ba56-354e0f79b2da",
-                "187aa32d-c29c-4b90-8669-e90e988cb115"
+                "37351d64-caf7-4952-9b6a-1373e38c12b8",
+                "d8291758-20a0-4c1e-8db1-c626edb60f52",
+                "35e6351a-85bd-434d-a777-211f1d0cce3d"
               ]
             }
+          }
+        }
+      },
+      "code": 200,
+      "show_in_doc": 1,
+      "recorded": true
+    },
+    {
+      "verb": "GET",
+      "path": "/assessments/5d1b4d37-a944-4dcd-b29b-d5704193c5ea",
+      "versions": [
+        "1.0"
+      ],
+      "query": null,
+      "request_data": null,
+      "response_data": {
+        "version": "2",
+        "timestamp": "2020-12-21T14:51:51.196+00:00",
+        "success": true,
+        "assessment": {
+          "id": "5d1b4d37-a944-4dcd-b29b-d5704193c5ea",
+          "client_reference_id": "CLIENT-REF-0003",
+          "submission_date": "2020-12-21",
+          "matter_proceeding_type": "domestic_abuse",
+          "assessment_result": "eligible",
+          "applicant": {
+            "date_of_birth": "1951-06-03",
+            "involvement_type": "applicant",
+            "has_partner_opponent": false,
+            "receives_qualifying_benefit": true,
+            "self_employed": false
+          },
+          "gross_income": null,
+          "disposable_income": null,
+          "capital": {
+            "capital_items": {
+              "liquid": [
+                {
+                  "description": "Sequi voluptates dolor porro.",
+                  "value": "3695.52"
+                }
+              ],
+              "non_liquid": [
+                {
+                  "description": "Id tenetur placeat a.",
+                  "value": "9271.22"
+                }
+              ],
+              "vehicles": [
+                {
+                  "value": "1024.76",
+                  "loan_amount_outstanding": "6015.82",
+                  "date_of_purchase": "2020-06-23",
+                  "in_regular_use": false,
+                  "included_in_assessment": true,
+                  "assessed_value": "1024.76"
+                }
+              ],
+              "properties": {
+                "main_home": {
+                  "value": "7050.21",
+                  "outstanding_mortgage": "8217.61",
+                  "percentage_owned": "1.84",
+                  "main_home": true,
+                  "shared_with_housing_assoc": false,
+                  "transaction_allowance": "211.51",
+                  "allowable_outstanding_mortgage": "8217.61",
+                  "net_value": "-1378.91",
+                  "net_equity": "-25.37",
+                  "main_home_equity_disregard": "100000.0",
+                  "assessed_equity": "0.0"
+                },
+                "additional_properties": [
+                  {
+                    "value": "6125.32",
+                    "outstanding_mortgage": "3886.77",
+                    "percentage_owned": "8.74",
+                    "main_home": false,
+                    "shared_with_housing_assoc": true,
+                    "transaction_allowance": "183.76",
+                    "allowable_outstanding_mortgage": "3886.77",
+                    "net_value": "2054.79",
+                    "net_equity": "-3535.18",
+                    "main_home_equity_disregard": "0.0",
+                    "assessed_equity": "0.0"
+                  }
+                ]
+              }
+            },
+            "total_liquid": "3695.52",
+            "total_non_liquid": "9271.22",
+            "total_vehicle": "1024.76",
+            "total_property": "0.0",
+            "total_mortgage_allowance": "100000.0",
+            "total_capital": "13991.5",
+            "pensioner_capital_disregard": "100000.0",
+            "assessed_capital": "-86008.5",
+            "lower_threshold": "3000.0",
+            "upper_threshold": "999999999999.0",
+            "assessment_result": "eligible",
+            "capital_contribution": "0.0"
+          },
+          "remarks": {
           }
         }
       },
@@ -403,7 +403,7 @@
   "capitals#create": [
     {
       "verb": "POST",
-      "path": "/assessments/cd97f745-dc17-4c51-8425-e9e4e920e9bb/capitals",
+      "path": "/assessments/6148416a-9185-4582-bd34-ce26df443628/capitals",
       "versions": [
         "1.0"
       ],
@@ -411,61 +411,22 @@
       "request_data": {
         "bank_accounts": [
           {
-            "description": "ALKEN ASSET MANAGEMENT 00293853",
-            "value": 39151.99
+            "description": "THE ROYAL BANK OF SCOTLAND PLC (FORMER RBS NV) 35471065",
+            "value": 22547.62
           },
           {
-            "description": "ABN AMRO QUOTED INVESTMENTS (UK) LIMITED 02500679",
-            "value": 78707.34
-          }
-        ],
-        "non_liquid_capital": [
-          {
-            "description": "Ming Vase",
-            "value": 20204.71
-          },
-          {
-            "description": "FTSE tracker unit trust",
-            "value": 16716.54
-          }
-        ]
-      },
-      "response_data": {
-        "success": false,
-        "errors": [
-          "No such assessment id"
-        ]
-      },
-      "code": 422,
-      "show_in_doc": 1,
-      "recorded": true
-    },
-    {
-      "verb": "POST",
-      "path": "/assessments/f38f81ce-e5f8-4dd5-a42e-0a7ad8a99e73/capitals",
-      "versions": [
-        "1.0"
-      ],
-      "query": null,
-      "request_data": {
-        "bank_accounts": [
-          {
-            "description": "PGMS (GLASGOW) LIMITED 25720685",
-            "value": 28763.18
-          },
-          {
-            "description": "ABN AMRO FUND MANAGERS LIMITED 37396930",
-            "value": 60849.12
+            "description": "ABBEY LIFE 23633114",
+            "value": 70291.61
           }
         ],
         "non_liquid_capital": [
           {
             "description": "Van Gogh Sunflowers",
-            "value": 99610.54
+            "value": 91852.88
           },
           {
-            "description": "Aramco shares",
-            "value": 58095.56
+            "description": "FTSE tracker unit trust",
+            "value": 71442.86
           }
         ]
       },
@@ -476,6 +437,45 @@
         ]
       },
       "code": 200,
+      "show_in_doc": 1,
+      "recorded": true
+    },
+    {
+      "verb": "POST",
+      "path": "/assessments/f8d11361-331a-4992-8c24-74c0e82d2446/capitals",
+      "versions": [
+        "1.0"
+      ],
+      "query": null,
+      "request_data": {
+        "bank_accounts": [
+          {
+            "description": "UBS CLEARING AND EXECUTION SERVICES LIMITED 77997750",
+            "value": 11038.64
+          },
+          {
+            "description": "ABG SUNDAL COLLIER LIMITED 55775046",
+            "value": 37381.48
+          }
+        ],
+        "non_liquid_capital": [
+          {
+            "description": "Van Gogh Sunflowers",
+            "value": 29591.13
+          },
+          {
+            "description": "FTSE tracker unit trust",
+            "value": 76509.07
+          }
+        ]
+      },
+      "response_data": {
+        "success": false,
+        "errors": [
+          "No such assessment id"
+        ]
+      },
+      "code": 422,
       "show_in_doc": 1,
       "recorded": true
     }
@@ -483,7 +483,7 @@
   "dependants#create": [
     {
       "verb": "POST",
-      "path": "/assessments/6755ce8d-466a-447d-bd50-7f3bff2b83f5/dependants",
+      "path": "/assessments/64cfdd71-0f3d-4e5d-bbb6-533158ed73d5/dependants",
       "versions": [
         "1.0"
       ],
@@ -491,52 +491,17 @@
       "request_data": {
         "dependants": [
           {
-            "date_of_birth": "1997-10-25",
-            "in_full_time_education": false,
-            "relationship": "adult_relative",
-            "monthly_income": 6643.99,
-            "assets_value": 0.0
-          },
-          {
-            "date_of_birth": "1961-05-03",
-            "in_full_time_education": false,
-            "relationship": "adult_relative",
-            "monthly_income": 5028.69,
-            "assets_value": 0.0
-          }
-        ]
-      },
-      "response_data": {
-        "success": true,
-        "errors": [
-
-        ]
-      },
-      "code": 200,
-      "show_in_doc": 1,
-      "recorded": true
-    },
-    {
-      "verb": "POST",
-      "path": "/assessments/f72888cc-63c4-43e9-a6cf-44616a464283/dependants",
-      "versions": [
-        "1.0"
-      ],
-      "query": null,
-      "request_data": {
-        "dependants": [
-          {
-            "date_of_birth": "1969-04-29",
+            "date_of_birth": "1963-01-05",
             "in_full_time_education": true,
             "relationship": "child_relative",
-            "monthly_income": 4890.5,
+            "monthly_income": 354.82,
             "assets_value": 0.0
           },
           {
-            "date_of_birth": "1994-01-11",
+            "date_of_birth": "1984-11-23",
             "in_full_time_education": false,
-            "relationship": "adult_relative",
-            "monthly_income": 2745.57,
+            "relationship": "child_relative",
+            "monthly_income": 2001.95,
             "assets_value": 0.0
           }
         ]
@@ -553,7 +518,7 @@
     },
     {
       "verb": "POST",
-      "path": "/assessments/008afcda-2933-40dc-92a6-6dc81e0583f9/dependants",
+      "path": "/assessments/bc4205cf-7dd8-4bc3-b112-80ad17320d01/dependants",
       "versions": [
         "1.0"
       ],
@@ -561,17 +526,52 @@
       "request_data": {
         "dependants": [
           {
-            "date_of_birth": "1982-10-13",
-            "in_full_time_education": null,
+            "date_of_birth": "2000-03-16",
+            "in_full_time_education": true,
             "relationship": "child_relative",
-            "monthly_income": 345.99,
+            "monthly_income": 2742.39,
             "assets_value": 0.0
           },
           {
-            "date_of_birth": "1985-04-13",
+            "date_of_birth": "1968-02-12",
+            "in_full_time_education": true,
+            "relationship": "child_relative",
+            "monthly_income": 33.53,
+            "assets_value": 0.0
+          }
+        ]
+      },
+      "response_data": {
+        "success": true,
+        "errors": [
+
+        ]
+      },
+      "code": 200,
+      "show_in_doc": 1,
+      "recorded": true
+    },
+    {
+      "verb": "POST",
+      "path": "/assessments/e34a5afe-c7d5-41bb-9594-4102dc0b1ba0/dependants",
+      "versions": [
+        "1.0"
+      ],
+      "query": null,
+      "request_data": {
+        "dependants": [
+          {
+            "date_of_birth": "1971-08-16",
             "in_full_time_education": null,
             "relationship": "child_relative",
-            "monthly_income": 1173.74,
+            "monthly_income": 2676.22,
+            "assets_value": 0.0
+          },
+          {
+            "date_of_birth": "1971-10-23",
+            "in_full_time_education": null,
+            "relationship": "adult_relative",
+            "monthly_income": 5914.36,
             "assets_value": 0.0
           }
         ]
@@ -590,7 +590,7 @@
   "irregular_incomes#create": [
     {
       "verb": "POST",
-      "path": "/assessments/a4acb479-b28a-49ca-aeac-23f6eccfdb9c/irregular_incomes",
+      "path": "/assessments/e76b51f9-0f51-4fa4-98f8-9ca2d8c8f110/irregular_incomes",
       "versions": [
         "1.0"
       ],
@@ -615,7 +615,7 @@
     },
     {
       "verb": "POST",
-      "path": "/assessments/32e34642-e25b-400a-98b3-bb3e3f729e13/irregular_incomes",
+      "path": "/assessments/2c59cf5a-faa9-45d3-bce8-31b6bcc1637a/irregular_incomes",
       "versions": [
         "1.0"
       ],
@@ -643,7 +643,7 @@
   "other_incomes#create": [
     {
       "verb": "POST",
-      "path": "/assessments/9f4cbba3-7c59-4459-97f0-1bf4d62d6c09/other_incomes",
+      "path": "/assessments/a0c79f1e-1937-464b-ae3e-45e597786eba/other_incomes",
       "versions": [
         "1.0"
       ],
@@ -656,17 +656,17 @@
               {
                 "date": "2019-11-01",
                 "amount": 1046.44,
-                "client_id": "05459c0f-a620-4743-9f0c-b3daa93e5711"
+                "client_id": "6be41703-52b2-4d48-a9bc-bf9283789d24"
               },
               {
                 "date": "2019-10-01",
                 "amount": 1034.33,
-                "client_id": "10318f7b-289a-4fa5-a986-fc6f499fecd0"
+                "client_id": "6d6f5fca-dbc9-40cc-a1d2-c2f4bd2679d5"
               },
               {
                 "date": "2019-09-01",
                 "amount": 1033.44,
-                "client_id": "5cf62a12-c92b-4cc1-b8ca-eeb4efbcce21"
+                "client_id": "110f364c-2e4a-4b3a-ab27-a8954673b0e9"
               }
             ]
           },
@@ -676,17 +676,17 @@
               {
                 "date": "2019-11-01",
                 "amount": 250.0,
-                "client_id": "e47b707b-d795-47c2-8b39-ccf022eae33b"
+                "client_id": "9dbf8c52-2fd7-48c7-b89a-ef7f3fe8d353"
               },
               {
                 "date": "2019-10-01",
                 "amount": 266.02,
-                "client_id": "b0c46cc7-8478-4658-a7f9-85ec85d420b1"
+                "client_id": "7deae8a0-2796-4cec-bd55-796b56af6833"
               },
               {
                 "date": "2019-09-01",
                 "amount": 250.0,
-                "client_id": "f3ec68a3-8748-4ed5-971a-94d133e0efa0"
+                "client_id": "2aaee775-e890-41bb-8855-c1d36ffb5444"
               }
             ]
           }
@@ -706,7 +706,7 @@
   "outgoings#create": [
     {
       "verb": "POST",
-      "path": "/assessments/28520200-075c-484f-8c9f-d6559ec7f12f/outgoings",
+      "path": "/assessments/c6717894-5a91-416e-ab4c-6240b3fc8d70/outgoings",
       "versions": [
         "1.0"
       ],
@@ -717,14 +717,14 @@
             "name": "child_care",
             "payments": [
               {
-                "payment_date": "2020-10-05",
-                "amount": 363.81,
-                "client_id": "af36656e-3c7b-4718-90f2-2e52bb4b3b96"
+                "payment_date": "2020-11-30",
+                "amount": 103.74,
+                "client_id": "aa2ea3f4-8fba-4386-ae29-136f29e4bdc2"
               },
               {
-                "payment_date": "2020-10-05",
-                "amount": 279.57,
-                "client_id": "95543eb0-5373-43bd-91e9-4e194e5d366b"
+                "payment_date": "2020-11-30",
+                "amount": 479.05,
+                "client_id": "55056403-02ff-45da-a6f0-c8f7e40eca4c"
               }
             ]
           },
@@ -732,14 +732,14 @@
             "name": "maintenance_out",
             "payments": [
               {
-                "payment_date": "2020-10-05",
-                "amount": 686.66,
-                "client_id": "af36656e-3c7b-4718-90f2-2e52bb4b3b96"
+                "payment_date": "2020-11-30",
+                "amount": 229.93,
+                "client_id": "aa2ea3f4-8fba-4386-ae29-136f29e4bdc2"
               },
               {
-                "payment_date": "2020-10-05",
-                "amount": 473.51,
-                "client_id": "95543eb0-5373-43bd-91e9-4e194e5d366b"
+                "payment_date": "2020-11-30",
+                "amount": 266.79,
+                "client_id": "55056403-02ff-45da-a6f0-c8f7e40eca4c"
               }
             ]
           },
@@ -747,16 +747,16 @@
             "name": "rent_or_mortgage",
             "payments": [
               {
-                "payment_date": "2020-10-05",
-                "amount": 746.26,
-                "housing_cost_type": "rent",
-                "client_id": "af36656e-3c7b-4718-90f2-2e52bb4b3b96"
+                "payment_date": "2020-11-30",
+                "amount": 767.18,
+                "housing_cost_type": "mortgage",
+                "client_id": "aa2ea3f4-8fba-4386-ae29-136f29e4bdc2"
               },
               {
-                "payment_date": "2020-10-05",
-                "amount": 102.35,
-                "housing_cost_type": "rent",
-                "client_id": "95543eb0-5373-43bd-91e9-4e194e5d366b"
+                "payment_date": "2020-11-30",
+                "amount": 495.72,
+                "housing_cost_type": "mortgage",
+                "client_id": "55056403-02ff-45da-a6f0-c8f7e40eca4c"
               }
             ]
           }
@@ -785,14 +785,14 @@
             "name": "child_care",
             "payments": [
               {
-                "payment_date": "2020-10-05",
-                "amount": 783.66,
-                "client_id": "926cad50-8dc5-403a-bccf-cd0c333920af"
+                "payment_date": "2020-11-30",
+                "amount": 768.42,
+                "client_id": "632cd306-5be6-488b-93af-62c173b7f0b5"
               },
               {
-                "payment_date": "2020-10-05",
-                "amount": 920.69,
-                "client_id": "f9fcc177-f0ce-4a18-94b2-afe18a596eb3"
+                "payment_date": "2020-11-30",
+                "amount": 569.47,
+                "client_id": "627acba9-8180-4704-ad4a-178a89937cd2"
               }
             ]
           },
@@ -800,14 +800,14 @@
             "name": "maintenance_out",
             "payments": [
               {
-                "payment_date": "2020-10-05",
-                "amount": 107.75,
-                "client_id": "926cad50-8dc5-403a-bccf-cd0c333920af"
+                "payment_date": "2020-11-30",
+                "amount": 594.03,
+                "client_id": "632cd306-5be6-488b-93af-62c173b7f0b5"
               },
               {
-                "payment_date": "2020-10-05",
-                "amount": 673.78,
-                "client_id": "f9fcc177-f0ce-4a18-94b2-afe18a596eb3"
+                "payment_date": "2020-11-30",
+                "amount": 502.78,
+                "client_id": "627acba9-8180-4704-ad4a-178a89937cd2"
               }
             ]
           },
@@ -815,16 +815,16 @@
             "name": "rent_or_mortgage",
             "payments": [
               {
-                "payment_date": "2020-10-05",
-                "amount": 647.15,
-                "housing_cost_type": "board_and_lodging",
-                "client_id": "926cad50-8dc5-403a-bccf-cd0c333920af"
+                "payment_date": "2020-11-30",
+                "amount": 115.88,
+                "housing_cost_type": "rent",
+                "client_id": "632cd306-5be6-488b-93af-62c173b7f0b5"
               },
               {
-                "payment_date": "2020-10-05",
-                "amount": 118.09,
-                "housing_cost_type": "board_and_lodging",
-                "client_id": "f9fcc177-f0ce-4a18-94b2-afe18a596eb3"
+                "payment_date": "2020-11-30",
+                "amount": 288.37,
+                "housing_cost_type": "rent",
+                "client_id": "627acba9-8180-4704-ad4a-178a89937cd2"
               }
             ]
           }
@@ -844,7 +844,48 @@
   "properties#create": [
     {
       "verb": "POST",
-      "path": "/assessments/90ce5907-e626-4fb0-b08a-6902d7822e67/properties",
+      "path": "/assessments/e48a487b-ebe7-4194-b01f-2ad165b6cf26/properties",
+      "versions": [
+        "1.0"
+      ],
+      "query": null,
+      "request_data": {
+        "properties": {
+          "main_home": {
+            "value": 500000,
+            "outstanding_mortgage": 200,
+            "percentage_owned": 15,
+            "shared_with_housing_assoc": true
+          },
+          "additional_properties": [
+            {
+              "value": 1000,
+              "outstanding_mortgage": 0,
+              "percentage_owned": 99,
+              "shared_with_housing_assoc": false
+            },
+            {
+              "value": 10000,
+              "outstanding_mortgage": 40,
+              "percentage_owned": 80,
+              "shared_with_housing_assoc": true
+            }
+          ]
+        }
+      },
+      "response_data": {
+        "success": true,
+        "errors": [
+
+        ]
+      },
+      "code": 200,
+      "show_in_doc": 1,
+      "recorded": true
+    },
+    {
+      "verb": "POST",
+      "path": "/assessments/8dc91a9d-e7b9-41b6-b00d-127cc0517927/properties",
       "versions": [
         "1.0"
       ],
@@ -882,37 +923,26 @@
       "code": 422,
       "show_in_doc": 1,
       "recorded": true
-    },
+    }
+  ],
+  "remarks#create": [
     {
       "verb": "POST",
-      "path": "/assessments/cb4fff96-a02f-4ac2-9ae7-cd4e5fdd9aa9/properties",
+      "path": "/assessments/162aaea9-4c67-4803-a632-bf807f0e0b93/remarks",
       "versions": [
         "1.0"
       ],
       "query": null,
       "request_data": {
-        "properties": {
-          "main_home": {
-            "value": 500000,
-            "outstanding_mortgage": 200,
-            "percentage_owned": 15,
-            "shared_with_housing_assoc": true
-          },
-          "additional_properties": [
-            {
-              "value": 1000,
-              "outstanding_mortgage": 0,
-              "percentage_owned": 99,
-              "shared_with_housing_assoc": false
-            },
-            {
-              "value": 10000,
-              "outstanding_mortgage": 40,
-              "percentage_owned": 80,
-              "shared_with_housing_assoc": true
-            }
-          ]
-        }
+        "remarks": [
+          {
+            "category": "income_disregards",
+            "details": [
+              "employment",
+              "charity"
+            ]
+          }
+        ]
       },
       "response_data": {
         "success": true,
@@ -1497,7 +1527,7 @@
   "state_benefits#create": [
     {
       "verb": "POST",
-      "path": "/assessments/7e3795b6-3344-47a8-9f5f-9ae2fed98c9e/state_benefits",
+      "path": "/assessments/c65a36aa-b0a0-4e7d-abb1-5c08e880cce0/state_benefits",
       "versions": [
         "1.0"
       ],
@@ -1505,22 +1535,22 @@
       "request_data": {
         "state_benefits": [
           {
-            "name": "benefit_type_1",
+            "name": "benefit_type_3",
             "payments": [
               {
                 "date": "2019-11-01",
                 "amount": 1046.44,
-                "client_id": "06c3b20e-c4e8-4736-a153-6b30e48636b2"
+                "client_id": "33d057e7-5b94-4c6e-a16d-d1a86485d544"
               },
               {
                 "date": "2019-10-01",
                 "amount": 1034.33,
-                "client_id": "2ff1d644-5d11-4e1f-8e2f-50511688d19f"
+                "client_id": "073e216f-578b-4779-9625-972ae44ba7a6"
               },
               {
                 "date": "2019-09-01",
                 "amount": 1033.44,
-                "client_id": "c107a948-93bd-4f33-b782-4d6469459864"
+                "client_id": "755b5e92-cb14-4d1e-975d-abdb1569692a"
               }
             ]
           },
@@ -1529,17 +1559,17 @@
               {
                 "date": "2019-11-01",
                 "amount": 250.0,
-                "client_id": "06c3b20e-c4e8-4736-a153-6b30e48636b2"
+                "client_id": "33d057e7-5b94-4c6e-a16d-d1a86485d544"
               },
               {
                 "date": "2019-10-01",
                 "amount": 266.02,
-                "client_id": "2ff1d644-5d11-4e1f-8e2f-50511688d19f"
+                "client_id": "073e216f-578b-4779-9625-972ae44ba7a6"
               },
               {
                 "date": "2019-09-01",
                 "amount": 250.0,
-                "client_id": "c107a948-93bd-4f33-b782-4d6469459864",
+                "client_id": "755b5e92-cb14-4d1e-975d-abdb1569692a",
                 "flags": {
                   "multi_benefit": true
                 }
@@ -1560,7 +1590,7 @@
     },
     {
       "verb": "POST",
-      "path": "/assessments/eeef1d5a-ab30-49ba-87ec-9ba35df4117a/state_benefits",
+      "path": "/assessments/e9330783-92cf-47b2-8e42-ef69f5facfe4/state_benefits",
       "versions": [
         "1.0"
       ],
@@ -1568,42 +1598,42 @@
       "request_data": {
         "state_benefits": [
           {
-            "name": "benefit_type_3",
+            "name": "benefit_type_5",
             "payments": [
               {
                 "date": "2019-11-01",
                 "amount": 1046.44,
-                "client_id": "bbc5862c-b18a-4c20-a20c-7448dcab51bc"
+                "client_id": "569ae65c-381a-4b21-94ab-aa4af972ad53"
               },
               {
                 "date": "2019-10-01",
                 "amount": 1034.33,
-                "client_id": "12a7707e-aaac-4a18-9bef-af72cb8b17f3"
+                "client_id": "7ed7cb17-9eea-49de-b30b-95120b45edb7"
               },
               {
                 "date": "2019-09-01",
                 "amount": 1033.44,
-                "client_id": "28760155-0d6f-47a8-990e-8ea1952cddb2"
+                "client_id": "120f560b-34a8-4e97-9469-568004f814fe"
               }
             ]
           },
           {
-            "name": "benefit_type_4",
+            "name": "benefit_type_6",
             "payments": [
               {
                 "date": "2019-11-01",
                 "amount": 250.0,
-                "client_id": "bbc5862c-b18a-4c20-a20c-7448dcab51bc"
+                "client_id": "569ae65c-381a-4b21-94ab-aa4af972ad53"
               },
               {
                 "date": "2019-10-01",
                 "amount": 266.02,
-                "client_id": "12a7707e-aaac-4a18-9bef-af72cb8b17f3"
+                "client_id": "7ed7cb17-9eea-49de-b30b-95120b45edb7"
               },
               {
                 "date": "2019-09-01",
                 "amount": 250.0,
-                "client_id": "28760155-0d6f-47a8-990e-8ea1952cddb2",
+                "client_id": "120f560b-34a8-4e97-9469-568004f814fe",
                 "flags": {
                   "multi_benefit": true
                 }
@@ -1626,7 +1656,7 @@
   "vehicles#create": [
     {
       "verb": "POST",
-      "path": "/assessments/9a3bc416-1929-4182-b978-de9ad0f65a1a/vehicles",
+      "path": "/assessments/9e111653-2389-448a-8723-3a9bef54db25/vehicles",
       "versions": [
         "1.0"
       ],
@@ -1634,15 +1664,15 @@
       "request_data": {
         "vehicles": [
           {
-            "value": 1184.88,
-            "loan_amount_outstanding": 4652.08,
-            "date_of_purchase": "2015-02-26",
-            "in_regular_use": false
+            "value": 7755.32,
+            "loan_amount_outstanding": 1910.67,
+            "date_of_purchase": "2015-05-30",
+            "in_regular_use": true
           },
           {
-            "value": 9658.86,
-            "loan_amount_outstanding": 6398.84,
-            "date_of_purchase": "2016-04-25",
+            "value": 1597.71,
+            "loan_amount_outstanding": 9279.25,
+            "date_of_purchase": "2018-10-05",
             "in_regular_use": true
           }
         ]
@@ -1667,15 +1697,15 @@
       "request_data": {
         "vehicles": [
           {
-            "value": 1712.07,
-            "loan_amount_outstanding": 9279.13,
-            "date_of_purchase": "2019-09-21",
-            "in_regular_use": false
+            "value": 1618.27,
+            "loan_amount_outstanding": 3498.25,
+            "date_of_purchase": "2017-12-23",
+            "in_regular_use": true
           },
           {
-            "value": 1602.63,
-            "loan_amount_outstanding": 1055.83,
-            "date_of_purchase": "2016-05-30",
+            "value": 3492.25,
+            "loan_amount_outstanding": 3703.59,
+            "date_of_purchase": "2015-02-15",
             "in_regular_use": false
           }
         ]

--- a/doc/apipie_examples.json
+++ b/doc/apipie_examples.json
@@ -2,39 +2,14 @@
   "applicants#create": [
     {
       "verb": "POST",
-      "path": "/assessments/7933e816-bdab-48af-b87a-aa096fd3f3c7/applicant",
+      "path": "/assessments/946195f3-6ef5-403b-ba69-26706232f3a2/applicant",
       "versions": [
         "1.0"
       ],
       "query": null,
       "request_data": {
         "applicant": {
-          "date_of_birth": "2000-12-21",
-          "involvement_type": "applicant",
-          "has_partner_opponent": false,
-          "receives_qualifying_benefit": true
-        }
-      },
-      "response_data": {
-        "success": true,
-        "errors": [
-
-        ]
-      },
-      "code": 200,
-      "show_in_doc": 1,
-      "recorded": true
-    },
-    {
-      "verb": "POST",
-      "path": "/assessments/3b93b7f4-c7aa-4ab7-b715-18738e1a0875/applicant",
-      "versions": [
-        "1.0"
-      ],
-      "query": null,
-      "request_data": {
-        "applicant": {
-          "date_of_birth": "2000-12-21",
+          "date_of_birth": "2000-12-22",
           "involvement_type": "applicant",
           "has_partner_opponent": false,
           "receives_qualifying_benefit": "yes"
@@ -47,6 +22,31 @@
         ]
       },
       "code": 422,
+      "show_in_doc": 1,
+      "recorded": true
+    },
+    {
+      "verb": "POST",
+      "path": "/assessments/bfbae27e-9306-4b70-9420-36d28c58c033/applicant",
+      "versions": [
+        "1.0"
+      ],
+      "query": null,
+      "request_data": {
+        "applicant": {
+          "date_of_birth": "2000-12-22",
+          "involvement_type": "applicant",
+          "has_partner_opponent": false,
+          "receives_qualifying_benefit": true
+        }
+      },
+      "response_data": {
+        "success": true,
+        "errors": [
+
+        ]
+      },
+      "code": 200,
       "show_in_doc": 1,
       "recorded": true
     }
@@ -66,7 +66,7 @@
       },
       "response_data": {
         "success": true,
-        "assessment_id": "91201fcd-0e99-406f-b849-8b5d165d29f3",
+        "assessment_id": "d7305b43-54a6-4d38-9dfb-0e20fbe39fcc",
         "errors": [
 
         ]
@@ -101,7 +101,7 @@
   "assessments#show": [
     {
       "verb": "GET",
-      "path": "/assessments/ad05269f-eb63-4d2e-919e-82c9b68b76f7",
+      "path": "/assessments/df0412b4-b431-4fcc-9d44-d8ff5f11d317",
       "versions": [
         "1.0"
       ],
@@ -109,10 +109,113 @@
       "request_data": null,
       "response_data": {
         "version": "2",
-        "timestamp": "2020-12-21T14:51:50.887+00:00",
+        "timestamp": "2020-12-22T09:37:42.832+00:00",
         "success": true,
         "assessment": {
-          "id": "ad05269f-eb63-4d2e-919e-82c9b68b76f7",
+          "id": "df0412b4-b431-4fcc-9d44-d8ff5f11d317",
+          "client_reference_id": "CLIENT-REF-0014",
+          "submission_date": "2020-12-22",
+          "matter_proceeding_type": "domestic_abuse",
+          "assessment_result": "contribution_required",
+          "applicant": {
+            "date_of_birth": "1974-05-15",
+            "involvement_type": "applicant",
+            "has_partner_opponent": false,
+            "receives_qualifying_benefit": true,
+            "self_employed": false
+          },
+          "gross_income": null,
+          "disposable_income": null,
+          "capital": {
+            "capital_items": {
+              "liquid": [
+                {
+                  "description": "Repellendus velit sit animi.",
+                  "value": "7999.76"
+                }
+              ],
+              "non_liquid": [
+                {
+                  "description": "Voluptatem illo assumenda aliquam.",
+                  "value": "1142.77"
+                }
+              ],
+              "vehicles": [
+                {
+                  "value": "7382.57",
+                  "loan_amount_outstanding": "9081.53",
+                  "date_of_purchase": "2017-04-21",
+                  "in_regular_use": true,
+                  "included_in_assessment": false,
+                  "assessed_value": "0.0"
+                }
+              ],
+              "properties": {
+                "main_home": {
+                  "value": "5415.55",
+                  "outstanding_mortgage": "4284.72",
+                  "percentage_owned": "9.34",
+                  "main_home": true,
+                  "shared_with_housing_assoc": true,
+                  "transaction_allowance": "162.47",
+                  "allowable_outstanding_mortgage": "4284.72",
+                  "net_value": "968.36",
+                  "net_equity": "-3941.38",
+                  "main_home_equity_disregard": "100000.0",
+                  "assessed_equity": "0.0"
+                },
+                "additional_properties": [
+                  {
+                    "value": "3297.24",
+                    "outstanding_mortgage": "5271.23",
+                    "percentage_owned": "3.19",
+                    "main_home": false,
+                    "shared_with_housing_assoc": true,
+                    "transaction_allowance": "98.92",
+                    "allowable_outstanding_mortgage": "5271.23",
+                    "net_value": "-2072.91",
+                    "net_equity": "-5264.97",
+                    "main_home_equity_disregard": "0.0",
+                    "assessed_equity": "0.0"
+                  }
+                ]
+              }
+            },
+            "total_liquid": "7999.76",
+            "total_non_liquid": "1142.77",
+            "total_vehicle": "0.0",
+            "total_property": "0.0",
+            "total_mortgage_allowance": "100000.0",
+            "total_capital": "9142.53",
+            "pensioner_capital_disregard": "0.0",
+            "assessed_capital": "9142.53",
+            "lower_threshold": "3000.0",
+            "upper_threshold": "999999999999.0",
+            "assessment_result": "contribution_required",
+            "capital_contribution": "6142.53"
+          },
+          "remarks": {
+          }
+        }
+      },
+      "code": 200,
+      "show_in_doc": 1,
+      "recorded": true
+    },
+    {
+      "verb": "GET",
+      "path": "/assessments/5039b234-dd31-4d80-81a6-89796b7d961d",
+      "versions": [
+        "1.0"
+      ],
+      "query": null,
+      "request_data": null,
+      "response_data": {
+        "version": "2",
+        "timestamp": "2020-12-22T09:37:43.044+00:00",
+        "success": true,
+        "assessment": {
+          "id": "5039b234-dd31-4d80-81a6-89796b7d961d",
           "client_reference_id": "NPE6-1",
           "submission_date": "2019-05-29",
           "matter_proceeding_type": "domestic_abuse",
@@ -279,119 +382,16 @@
           "remarks": {
             "state_benefit_payment": {
               "amount_variation": [
-                "37351d64-caf7-4952-9b6a-1373e38c12b8",
-                "d8291758-20a0-4c1e-8db1-c626edb60f52",
-                "35e6351a-85bd-434d-a777-211f1d0cce3d"
+                "3dd82193-9069-4ee4-bf10-c89e8ad382cd",
+                "387d289d-c08f-412f-8c75-4c7735b5d77f",
+                "3397bb48-f3c8-4deb-be94-50596b2fe607"
               ],
               "unknown_frequency": [
-                "37351d64-caf7-4952-9b6a-1373e38c12b8",
-                "d8291758-20a0-4c1e-8db1-c626edb60f52",
-                "35e6351a-85bd-434d-a777-211f1d0cce3d"
+                "3dd82193-9069-4ee4-bf10-c89e8ad382cd",
+                "387d289d-c08f-412f-8c75-4c7735b5d77f",
+                "3397bb48-f3c8-4deb-be94-50596b2fe607"
               ]
             }
-          }
-        }
-      },
-      "code": 200,
-      "show_in_doc": 1,
-      "recorded": true
-    },
-    {
-      "verb": "GET",
-      "path": "/assessments/5d1b4d37-a944-4dcd-b29b-d5704193c5ea",
-      "versions": [
-        "1.0"
-      ],
-      "query": null,
-      "request_data": null,
-      "response_data": {
-        "version": "2",
-        "timestamp": "2020-12-21T14:51:51.196+00:00",
-        "success": true,
-        "assessment": {
-          "id": "5d1b4d37-a944-4dcd-b29b-d5704193c5ea",
-          "client_reference_id": "CLIENT-REF-0003",
-          "submission_date": "2020-12-21",
-          "matter_proceeding_type": "domestic_abuse",
-          "assessment_result": "eligible",
-          "applicant": {
-            "date_of_birth": "1951-06-03",
-            "involvement_type": "applicant",
-            "has_partner_opponent": false,
-            "receives_qualifying_benefit": true,
-            "self_employed": false
-          },
-          "gross_income": null,
-          "disposable_income": null,
-          "capital": {
-            "capital_items": {
-              "liquid": [
-                {
-                  "description": "Sequi voluptates dolor porro.",
-                  "value": "3695.52"
-                }
-              ],
-              "non_liquid": [
-                {
-                  "description": "Id tenetur placeat a.",
-                  "value": "9271.22"
-                }
-              ],
-              "vehicles": [
-                {
-                  "value": "1024.76",
-                  "loan_amount_outstanding": "6015.82",
-                  "date_of_purchase": "2020-06-23",
-                  "in_regular_use": false,
-                  "included_in_assessment": true,
-                  "assessed_value": "1024.76"
-                }
-              ],
-              "properties": {
-                "main_home": {
-                  "value": "7050.21",
-                  "outstanding_mortgage": "8217.61",
-                  "percentage_owned": "1.84",
-                  "main_home": true,
-                  "shared_with_housing_assoc": false,
-                  "transaction_allowance": "211.51",
-                  "allowable_outstanding_mortgage": "8217.61",
-                  "net_value": "-1378.91",
-                  "net_equity": "-25.37",
-                  "main_home_equity_disregard": "100000.0",
-                  "assessed_equity": "0.0"
-                },
-                "additional_properties": [
-                  {
-                    "value": "6125.32",
-                    "outstanding_mortgage": "3886.77",
-                    "percentage_owned": "8.74",
-                    "main_home": false,
-                    "shared_with_housing_assoc": true,
-                    "transaction_allowance": "183.76",
-                    "allowable_outstanding_mortgage": "3886.77",
-                    "net_value": "2054.79",
-                    "net_equity": "-3535.18",
-                    "main_home_equity_disregard": "0.0",
-                    "assessed_equity": "0.0"
-                  }
-                ]
-              }
-            },
-            "total_liquid": "3695.52",
-            "total_non_liquid": "9271.22",
-            "total_vehicle": "1024.76",
-            "total_property": "0.0",
-            "total_mortgage_allowance": "100000.0",
-            "total_capital": "13991.5",
-            "pensioner_capital_disregard": "100000.0",
-            "assessed_capital": "-86008.5",
-            "lower_threshold": "3000.0",
-            "upper_threshold": "999999999999.0",
-            "assessment_result": "eligible",
-            "capital_contribution": "0.0"
-          },
-          "remarks": {
           }
         }
       },
@@ -403,7 +403,7 @@
   "capitals#create": [
     {
       "verb": "POST",
-      "path": "/assessments/6148416a-9185-4582-bd34-ce26df443628/capitals",
+      "path": "/assessments/87dc839c-1a50-49cb-8352-637eb32b6ca6/capitals",
       "versions": [
         "1.0"
       ],
@@ -411,61 +411,22 @@
       "request_data": {
         "bank_accounts": [
           {
-            "description": "THE ROYAL BANK OF SCOTLAND PLC (FORMER RBS NV) 35471065",
-            "value": 22547.62
+            "description": "ABINGWORTH MANAGEMENT LIMITED 92394294",
+            "value": 51840.18
           },
           {
-            "description": "ABBEY LIFE 23633114",
-            "value": 70291.61
+            "description": "PGMS (GLASGOW) LIMITED 28124484",
+            "value": 86640.45
           }
         ],
         "non_liquid_capital": [
           {
-            "description": "Van Gogh Sunflowers",
-            "value": 91852.88
+            "description": "Life Endowment Policy",
+            "value": 23344.06
           },
           {
-            "description": "FTSE tracker unit trust",
-            "value": 71442.86
-          }
-        ]
-      },
-      "response_data": {
-        "success": true,
-        "errors": [
-
-        ]
-      },
-      "code": 200,
-      "show_in_doc": 1,
-      "recorded": true
-    },
-    {
-      "verb": "POST",
-      "path": "/assessments/f8d11361-331a-4992-8c24-74c0e82d2446/capitals",
-      "versions": [
-        "1.0"
-      ],
-      "query": null,
-      "request_data": {
-        "bank_accounts": [
-          {
-            "description": "UBS CLEARING AND EXECUTION SERVICES LIMITED 77997750",
-            "value": 11038.64
-          },
-          {
-            "description": "ABG SUNDAL COLLIER LIMITED 55775046",
-            "value": 37381.48
-          }
-        ],
-        "non_liquid_capital": [
-          {
-            "description": "Van Gogh Sunflowers",
-            "value": 29591.13
-          },
-          {
-            "description": "FTSE tracker unit trust",
-            "value": 76509.07
+            "description": "Life Endowment Policy",
+            "value": 24925.21
           }
         ]
       },
@@ -476,6 +437,45 @@
         ]
       },
       "code": 422,
+      "show_in_doc": 1,
+      "recorded": true
+    },
+    {
+      "verb": "POST",
+      "path": "/assessments/6af014a4-407f-490a-a098-a839681e803c/capitals",
+      "versions": [
+        "1.0"
+      ],
+      "query": null,
+      "request_data": {
+        "bank_accounts": [
+          {
+            "description": "PGMS (GLASGOW) LIMITED 88731481",
+            "value": 70239.71
+          },
+          {
+            "description": "AAC CAPITAL PARTNERS LIMITED 05232247",
+            "value": 69380.22
+          }
+        ],
+        "non_liquid_capital": [
+          {
+            "description": "Ming Vase",
+            "value": 75661.33
+          },
+          {
+            "description": "Aramco shares",
+            "value": 75893.54
+          }
+        ]
+      },
+      "response_data": {
+        "success": true,
+        "errors": [
+
+        ]
+      },
+      "code": 200,
       "show_in_doc": 1,
       "recorded": true
     }
@@ -483,7 +483,7 @@
   "dependants#create": [
     {
       "verb": "POST",
-      "path": "/assessments/64cfdd71-0f3d-4e5d-bbb6-533158ed73d5/dependants",
+      "path": "/assessments/6dfc6e35-115f-4cfe-b14e-ab7c2443fc94/dependants",
       "versions": [
         "1.0"
       ],
@@ -491,17 +491,17 @@
       "request_data": {
         "dependants": [
           {
-            "date_of_birth": "1963-01-05",
-            "in_full_time_education": true,
-            "relationship": "child_relative",
-            "monthly_income": 354.82,
+            "date_of_birth": "1956-04-06",
+            "in_full_time_education": false,
+            "relationship": "adult_relative",
+            "monthly_income": 6994.16,
             "assets_value": 0.0
           },
           {
-            "date_of_birth": "1984-11-23",
+            "date_of_birth": "2002-11-04",
             "in_full_time_education": false,
             "relationship": "child_relative",
-            "monthly_income": 2001.95,
+            "monthly_income": 5604.39,
             "assets_value": 0.0
           }
         ]
@@ -518,7 +518,7 @@
     },
     {
       "verb": "POST",
-      "path": "/assessments/bc4205cf-7dd8-4bc3-b112-80ad17320d01/dependants",
+      "path": "/assessments/ed22db05-a464-40ba-a08f-cc5ed89d10b7/dependants",
       "versions": [
         "1.0"
       ],
@@ -526,17 +526,17 @@
       "request_data": {
         "dependants": [
           {
-            "date_of_birth": "2000-03-16",
+            "date_of_birth": "1973-09-12",
             "in_full_time_education": true,
-            "relationship": "child_relative",
-            "monthly_income": 2742.39,
+            "relationship": "adult_relative",
+            "monthly_income": 4.94,
             "assets_value": 0.0
           },
           {
-            "date_of_birth": "1968-02-12",
-            "in_full_time_education": true,
+            "date_of_birth": "1993-06-19",
+            "in_full_time_education": false,
             "relationship": "child_relative",
-            "monthly_income": 33.53,
+            "monthly_income": 548.97,
             "assets_value": 0.0
           }
         ]
@@ -553,7 +553,7 @@
     },
     {
       "verb": "POST",
-      "path": "/assessments/e34a5afe-c7d5-41bb-9594-4102dc0b1ba0/dependants",
+      "path": "/assessments/f85e0a5a-e403-4305-86b7-4ef31edaea49/dependants",
       "versions": [
         "1.0"
       ],
@@ -561,17 +561,17 @@
       "request_data": {
         "dependants": [
           {
-            "date_of_birth": "1971-08-16",
+            "date_of_birth": "1989-07-01",
             "in_full_time_education": null,
-            "relationship": "child_relative",
-            "monthly_income": 2676.22,
+            "relationship": "adult_relative",
+            "monthly_income": 3739.62,
             "assets_value": 0.0
           },
           {
-            "date_of_birth": "1971-10-23",
+            "date_of_birth": "1963-11-30",
             "in_full_time_education": null,
-            "relationship": "adult_relative",
-            "monthly_income": 5914.36,
+            "relationship": "child_relative",
+            "monthly_income": 5879.41,
             "assets_value": 0.0
           }
         ]
@@ -587,35 +587,68 @@
       "recorded": true
     }
   ],
-  "irregular_incomes#create": [
+  "explicit_remarks#create": [
     {
       "verb": "POST",
-      "path": "/assessments/e76b51f9-0f51-4fa4-98f8-9ca2d8c8f110/irregular_incomes",
+      "path": "/assessments/a4a41b2d-c4a7-464b-a615-42f0063db40e/explicit_remarks",
       "versions": [
         "1.0"
       ],
       "query": null,
       "request_data": {
-        "payments": [
+        "explicit_remarks": [
           {
-            "frequency": "annual",
-            "amount": 123456.78
+            "category": "income_disregards",
+            "details": [
+              "employment",
+              "charity"
+            ]
+          }
+        ]
+      },
+      "response_data": {
+        "success": true,
+        "errors": [
+
+        ]
+      },
+      "code": 200,
+      "show_in_doc": 1,
+      "recorded": true
+    },
+    {
+      "verb": "POST",
+      "path": "/assessments/2dd5cdd0-411f-411a-aca2-19902f847146/explicit_remarks",
+      "versions": [
+        "1.0"
+      ],
+      "query": null,
+      "request_data": {
+        "explicit_remarks": [
+          {
+            "category": "other_stuff",
+            "details": [
+              "employment",
+              "charity"
+            ]
           }
         ]
       },
       "response_data": {
         "success": false,
         "errors": [
-          "Missing parameter income_type"
+          "Invalid parameter 'category' value \"other_stuff\": Must be one of: <code>income_disregards</code>."
         ]
       },
       "code": 422,
       "show_in_doc": 1,
       "recorded": true
-    },
+    }
+  ],
+  "irregular_incomes#create": [
     {
       "verb": "POST",
-      "path": "/assessments/2c59cf5a-faa9-45d3-bce8-31b6bcc1637a/irregular_incomes",
+      "path": "/assessments/16023b1b-bdee-4369-8b87-5607ded2b275/irregular_incomes",
       "versions": [
         "1.0"
       ],
@@ -638,12 +671,37 @@
       "code": 200,
       "show_in_doc": 1,
       "recorded": true
+    },
+    {
+      "verb": "POST",
+      "path": "/assessments/b72d7c9f-0010-4acd-887c-1a13c2697c10/irregular_incomes",
+      "versions": [
+        "1.0"
+      ],
+      "query": null,
+      "request_data": {
+        "payments": [
+          {
+            "frequency": "annual",
+            "amount": 123456.78
+          }
+        ]
+      },
+      "response_data": {
+        "success": false,
+        "errors": [
+          "Missing parameter income_type"
+        ]
+      },
+      "code": 422,
+      "show_in_doc": 1,
+      "recorded": true
     }
   ],
   "other_incomes#create": [
     {
       "verb": "POST",
-      "path": "/assessments/a0c79f1e-1937-464b-ae3e-45e597786eba/other_incomes",
+      "path": "/assessments/4aa4c54c-e38b-40d4-a17f-5484948bb77b/other_incomes",
       "versions": [
         "1.0"
       ],
@@ -656,17 +714,17 @@
               {
                 "date": "2019-11-01",
                 "amount": 1046.44,
-                "client_id": "6be41703-52b2-4d48-a9bc-bf9283789d24"
+                "client_id": "5da8e7bf-3b01-42e7-91e5-3fdce65acadb"
               },
               {
                 "date": "2019-10-01",
                 "amount": 1034.33,
-                "client_id": "6d6f5fca-dbc9-40cc-a1d2-c2f4bd2679d5"
+                "client_id": "f39978a2-06ae-4367-ad91-d3d66c36b62f"
               },
               {
                 "date": "2019-09-01",
                 "amount": 1033.44,
-                "client_id": "110f364c-2e4a-4b3a-ab27-a8954673b0e9"
+                "client_id": "a5adaa30-75c5-4d4a-9e6d-16b1b1ad1014"
               }
             ]
           },
@@ -676,17 +734,17 @@
               {
                 "date": "2019-11-01",
                 "amount": 250.0,
-                "client_id": "9dbf8c52-2fd7-48c7-b89a-ef7f3fe8d353"
+                "client_id": "52894df4-9f9c-4a0d-b82c-b63e2601ef87"
               },
               {
                 "date": "2019-10-01",
                 "amount": 266.02,
-                "client_id": "7deae8a0-2796-4cec-bd55-796b56af6833"
+                "client_id": "2a879ef4-2373-4562-ba77-f8fd6189fc1b"
               },
               {
                 "date": "2019-09-01",
                 "amount": 250.0,
-                "client_id": "2aaee775-e890-41bb-8855-c1d36ffb5444"
+                "client_id": "0006ede3-3acb-4f83-8ea6-ab5fb4611c3d"
               }
             ]
           }
@@ -706,7 +764,7 @@
   "outgoings#create": [
     {
       "verb": "POST",
-      "path": "/assessments/c6717894-5a91-416e-ab4c-6240b3fc8d70/outgoings",
+      "path": "/assessments/4da2a43a-2fc3-4815-b85d-a4551ad212be/outgoings",
       "versions": [
         "1.0"
       ],
@@ -717,14 +775,14 @@
             "name": "child_care",
             "payments": [
               {
-                "payment_date": "2020-11-30",
-                "amount": 103.74,
-                "client_id": "aa2ea3f4-8fba-4386-ae29-136f29e4bdc2"
+                "payment_date": "2020-12-01",
+                "amount": 736.28,
+                "client_id": "818b58b4-09f1-4ca8-abb6-af6455db1cd8"
               },
               {
-                "payment_date": "2020-11-30",
-                "amount": 479.05,
-                "client_id": "55056403-02ff-45da-a6f0-c8f7e40eca4c"
+                "payment_date": "2020-12-01",
+                "amount": 500.59,
+                "client_id": "0177a955-47b7-4f11-8518-b95e656d25b4"
               }
             ]
           },
@@ -732,14 +790,14 @@
             "name": "maintenance_out",
             "payments": [
               {
-                "payment_date": "2020-11-30",
-                "amount": 229.93,
-                "client_id": "aa2ea3f4-8fba-4386-ae29-136f29e4bdc2"
+                "payment_date": "2020-12-01",
+                "amount": 285.97,
+                "client_id": "818b58b4-09f1-4ca8-abb6-af6455db1cd8"
               },
               {
-                "payment_date": "2020-11-30",
-                "amount": 266.79,
-                "client_id": "55056403-02ff-45da-a6f0-c8f7e40eca4c"
+                "payment_date": "2020-12-01",
+                "amount": 565.02,
+                "client_id": "0177a955-47b7-4f11-8518-b95e656d25b4"
               }
             ]
           },
@@ -747,16 +805,16 @@
             "name": "rent_or_mortgage",
             "payments": [
               {
-                "payment_date": "2020-11-30",
-                "amount": 767.18,
-                "housing_cost_type": "mortgage",
-                "client_id": "aa2ea3f4-8fba-4386-ae29-136f29e4bdc2"
+                "payment_date": "2020-12-01",
+                "amount": 499.44,
+                "housing_cost_type": "board_and_lodging",
+                "client_id": "818b58b4-09f1-4ca8-abb6-af6455db1cd8"
               },
               {
-                "payment_date": "2020-11-30",
-                "amount": 495.72,
-                "housing_cost_type": "mortgage",
-                "client_id": "55056403-02ff-45da-a6f0-c8f7e40eca4c"
+                "payment_date": "2020-12-01",
+                "amount": 698.52,
+                "housing_cost_type": "board_and_lodging",
+                "client_id": "0177a955-47b7-4f11-8518-b95e656d25b4"
               }
             ]
           }
@@ -785,14 +843,14 @@
             "name": "child_care",
             "payments": [
               {
-                "payment_date": "2020-11-30",
-                "amount": 768.42,
-                "client_id": "632cd306-5be6-488b-93af-62c173b7f0b5"
+                "payment_date": "2020-12-01",
+                "amount": 509.89,
+                "client_id": "4f31ab75-a490-4ee9-bd78-4b605d0dca30"
               },
               {
-                "payment_date": "2020-11-30",
-                "amount": 569.47,
-                "client_id": "627acba9-8180-4704-ad4a-178a89937cd2"
+                "payment_date": "2020-12-01",
+                "amount": 809.92,
+                "client_id": "366f676c-9bd6-4bd3-bdff-7fd313b31bed"
               }
             ]
           },
@@ -800,14 +858,14 @@
             "name": "maintenance_out",
             "payments": [
               {
-                "payment_date": "2020-11-30",
-                "amount": 594.03,
-                "client_id": "632cd306-5be6-488b-93af-62c173b7f0b5"
+                "payment_date": "2020-12-01",
+                "amount": 119.98,
+                "client_id": "4f31ab75-a490-4ee9-bd78-4b605d0dca30"
               },
               {
-                "payment_date": "2020-11-30",
-                "amount": 502.78,
-                "client_id": "627acba9-8180-4704-ad4a-178a89937cd2"
+                "payment_date": "2020-12-01",
+                "amount": 147.39,
+                "client_id": "366f676c-9bd6-4bd3-bdff-7fd313b31bed"
               }
             ]
           },
@@ -815,16 +873,16 @@
             "name": "rent_or_mortgage",
             "payments": [
               {
-                "payment_date": "2020-11-30",
-                "amount": 115.88,
-                "housing_cost_type": "rent",
-                "client_id": "632cd306-5be6-488b-93af-62c173b7f0b5"
+                "payment_date": "2020-12-01",
+                "amount": 406.38,
+                "housing_cost_type": "board_and_lodging",
+                "client_id": "4f31ab75-a490-4ee9-bd78-4b605d0dca30"
               },
               {
-                "payment_date": "2020-11-30",
-                "amount": 288.37,
-                "housing_cost_type": "rent",
-                "client_id": "627acba9-8180-4704-ad4a-178a89937cd2"
+                "payment_date": "2020-12-01",
+                "amount": 600.31,
+                "housing_cost_type": "board_and_lodging",
+                "client_id": "366f676c-9bd6-4bd3-bdff-7fd313b31bed"
               }
             ]
           }
@@ -844,7 +902,7 @@
   "properties#create": [
     {
       "verb": "POST",
-      "path": "/assessments/e48a487b-ebe7-4194-b01f-2ad165b6cf26/properties",
+      "path": "/assessments/5baf5802-fedb-43ae-88c1-0241c59cc102/properties",
       "versions": [
         "1.0"
       ],
@@ -885,7 +943,7 @@
     },
     {
       "verb": "POST",
-      "path": "/assessments/8dc91a9d-e7b9-41b6-b00d-127cc0517927/properties",
+      "path": "/assessments/18c78b20-ed6d-4109-8663-12491735af35/properties",
       "versions": [
         "1.0"
       ],
@@ -1527,7 +1585,7 @@
   "state_benefits#create": [
     {
       "verb": "POST",
-      "path": "/assessments/c65a36aa-b0a0-4e7d-abb1-5c08e880cce0/state_benefits",
+      "path": "/assessments/a20fea0c-6352-446d-b5c5-f6966cca66c1/state_benefits",
       "versions": [
         "1.0"
       ],
@@ -1540,17 +1598,17 @@
               {
                 "date": "2019-11-01",
                 "amount": 1046.44,
-                "client_id": "33d057e7-5b94-4c6e-a16d-d1a86485d544"
+                "client_id": "3408d332-e6a3-41fe-b64b-e944fe26fa63"
               },
               {
                 "date": "2019-10-01",
                 "amount": 1034.33,
-                "client_id": "073e216f-578b-4779-9625-972ae44ba7a6"
+                "client_id": "05bfeb9e-e06f-4f47-97f2-a5ccf28a26d8"
               },
               {
                 "date": "2019-09-01",
                 "amount": 1033.44,
-                "client_id": "755b5e92-cb14-4d1e-975d-abdb1569692a"
+                "client_id": "132508b5-98bd-4d62-bfe2-78b76d85ef5e"
               }
             ]
           },
@@ -1559,17 +1617,17 @@
               {
                 "date": "2019-11-01",
                 "amount": 250.0,
-                "client_id": "33d057e7-5b94-4c6e-a16d-d1a86485d544"
+                "client_id": "3408d332-e6a3-41fe-b64b-e944fe26fa63"
               },
               {
                 "date": "2019-10-01",
                 "amount": 266.02,
-                "client_id": "073e216f-578b-4779-9625-972ae44ba7a6"
+                "client_id": "05bfeb9e-e06f-4f47-97f2-a5ccf28a26d8"
               },
               {
                 "date": "2019-09-01",
                 "amount": 250.0,
-                "client_id": "755b5e92-cb14-4d1e-975d-abdb1569692a",
+                "client_id": "132508b5-98bd-4d62-bfe2-78b76d85ef5e",
                 "flags": {
                   "multi_benefit": true
                 }
@@ -1590,7 +1648,7 @@
     },
     {
       "verb": "POST",
-      "path": "/assessments/e9330783-92cf-47b2-8e42-ef69f5facfe4/state_benefits",
+      "path": "/assessments/8258a538-a656-4ea0-b647-3898227ed41b/state_benefits",
       "versions": [
         "1.0"
       ],
@@ -1603,17 +1661,17 @@
               {
                 "date": "2019-11-01",
                 "amount": 1046.44,
-                "client_id": "569ae65c-381a-4b21-94ab-aa4af972ad53"
+                "client_id": "e8a1c258-ce5c-43c1-83f1-90c63a88f85c"
               },
               {
                 "date": "2019-10-01",
                 "amount": 1034.33,
-                "client_id": "7ed7cb17-9eea-49de-b30b-95120b45edb7"
+                "client_id": "9c188962-4f5f-47a8-9c50-4af20ba751f6"
               },
               {
                 "date": "2019-09-01",
                 "amount": 1033.44,
-                "client_id": "120f560b-34a8-4e97-9469-568004f814fe"
+                "client_id": "c54fa6ce-6ef2-465b-9c17-8c549a96b8c2"
               }
             ]
           },
@@ -1623,17 +1681,17 @@
               {
                 "date": "2019-11-01",
                 "amount": 250.0,
-                "client_id": "569ae65c-381a-4b21-94ab-aa4af972ad53"
+                "client_id": "e8a1c258-ce5c-43c1-83f1-90c63a88f85c"
               },
               {
                 "date": "2019-10-01",
                 "amount": 266.02,
-                "client_id": "7ed7cb17-9eea-49de-b30b-95120b45edb7"
+                "client_id": "9c188962-4f5f-47a8-9c50-4af20ba751f6"
               },
               {
                 "date": "2019-09-01",
                 "amount": 250.0,
-                "client_id": "120f560b-34a8-4e97-9469-568004f814fe",
+                "client_id": "c54fa6ce-6ef2-465b-9c17-8c549a96b8c2",
                 "flags": {
                   "multi_benefit": true
                 }
@@ -1656,7 +1714,7 @@
   "vehicles#create": [
     {
       "verb": "POST",
-      "path": "/assessments/9e111653-2389-448a-8723-3a9bef54db25/vehicles",
+      "path": "/assessments/33e9e032-481a-4b6b-be1d-fca7369d387b/vehicles",
       "versions": [
         "1.0"
       ],
@@ -1664,16 +1722,16 @@
       "request_data": {
         "vehicles": [
           {
-            "value": 7755.32,
-            "loan_amount_outstanding": 1910.67,
-            "date_of_purchase": "2015-05-30",
+            "value": 7955.27,
+            "loan_amount_outstanding": 7843.88,
+            "date_of_purchase": "2016-10-18",
             "in_regular_use": true
           },
           {
-            "value": 1597.71,
-            "loan_amount_outstanding": 9279.25,
-            "date_of_purchase": "2018-10-05",
-            "in_regular_use": true
+            "value": 6276.31,
+            "loan_amount_outstanding": 6275.04,
+            "date_of_purchase": "2016-09-16",
+            "in_regular_use": false
           }
         ]
       },
@@ -1697,15 +1755,15 @@
       "request_data": {
         "vehicles": [
           {
-            "value": 1618.27,
-            "loan_amount_outstanding": 3498.25,
-            "date_of_purchase": "2017-12-23",
-            "in_regular_use": true
+            "value": 7180.16,
+            "loan_amount_outstanding": 1050.85,
+            "date_of_purchase": "2018-09-28",
+            "in_regular_use": false
           },
           {
-            "value": 3492.25,
-            "loan_amount_outstanding": 3703.59,
-            "date_of_purchase": "2015-02-15",
+            "value": 4634.03,
+            "loan_amount_outstanding": 7465.63,
+            "date_of_purchase": "2019-07-31",
             "in_regular_use": false
           }
         ]

--- a/spec/factories/explicit_remark_factory.rb
+++ b/spec/factories/explicit_remark_factory.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :explicit_remark do
+    assessment
+    category { 'income_disregards' }
+    remark { Faker::Lorem.sentence(word_count: (3..6).to_a.sample) }
+  end
+end

--- a/spec/integration/ap_1367_spec.rb
+++ b/spec/integration/ap_1367_spec.rb
@@ -28,7 +28,8 @@ RSpec.describe 'Full Assessment with remarks' do
 
     remarks = parsed_response[:assessment][:remarks]
     expect(remarks[:state_benefit_payment]).to eq expected_remarks[:state_benefit_payment]
-    expect(remarks[:other_income_payment]).to eq expected_remarks[:other_income_payment]
+    expect(remarks[:other_income_payment][:amount_variation]).to match_array expected_remarks[:other_income_payment][:amount_variation]
+    expect(remarks[:other_income_payment][:unknown_frequency]).to match_array expected_remarks[:other_income_payment][:unknown_frequency]
     expect(remarks[:outgoings_maintenance]).to eq expected_remarks[:outgoings_maintenance]
     expect(remarks[:outgoings_housing_cost]).to eq expected_remarks[:outgoings_housing_cost]
     expect(remarks[:outgoings_childcare]).to eq expected_remarks[:outgoings_childcare]

--- a/spec/integration/remarks_spec.rb
+++ b/spec/integration/remarks_spec.rb
@@ -20,7 +20,8 @@ RSpec.describe 'Full Assessment with remarks' do
     post_other_incomes(assessment_id)
     post_outgoings(assessment_id)
     post_state_benefits(assessment_id)
-
+    post_explicit_remarks(assessment_id)
+    
     get assessment_path(assessment_id), headers: v2_headers
     output_response(:get, :assessment)
     expect(parsed_response[:assessment][:remarks]).to match_array(expected_remarks)
@@ -55,6 +56,11 @@ RSpec.describe 'Full Assessment with remarks' do
   def post_state_benefits(assessment_id)
     post assessment_state_benefits_path(assessment_id), params: state_benefit_params, headers: headers
     output_response(:post, :state_benefits)
+  end
+
+  def post_explicit_remarks(assessment_id)
+    post assessment_explicit_remarks_path(assessment_id), params: explicit_remarks_params, headers: headers
+    output_response(:post, :explicit_remarks)
   end
 
   def output_response(method, object)
@@ -283,6 +289,20 @@ RSpec.describe 'Full Assessment with remarks' do
     }.to_json
   end
 
+  def explicit_remarks_params
+    {
+      explicit_remarks: [
+        {
+          category: 'income_disregards',
+          details: [
+            'Grenfell tower fund',
+            'Some other fund'
+          ]
+        }
+      ]
+    }.to_json
+  end
+
   def expected_remarks
     {
       state_benefit_payment: {
@@ -317,7 +337,11 @@ RSpec.describe 'Full Assessment with remarks' do
           client_id,
           client_id
         ]
-      }
+      },
+      income_disregards: [
+        "Grenfell tower fund",
+        "Some other fund"
+      ]
     }
   end
 end

--- a/spec/integration/remarks_spec.rb
+++ b/spec/integration/remarks_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe 'Full Assessment with remarks' do
     post_outgoings(assessment_id)
     post_state_benefits(assessment_id)
     post_explicit_remarks(assessment_id)
-    
+
     get assessment_path(assessment_id), headers: v2_headers
     output_response(:get, :assessment)
     expect(parsed_response[:assessment][:remarks]).to match_array(expected_remarks)
@@ -339,8 +339,8 @@ RSpec.describe 'Full Assessment with remarks' do
         ]
       },
       income_disregards: [
-        "Grenfell tower fund",
-        "Some other fund"
+        'Grenfell tower fund',
+        'Some other fund'
       ]
     }
   end

--- a/spec/models/assessment_spec.rb
+++ b/spec/models/assessment_spec.rb
@@ -24,19 +24,21 @@ RSpec.describe Assessment, type: :model do
       it 'instantiates a new empty Remarks object' do
         assessment = create :assessment, remarks: nil
         expect(assessment.remarks.class).to eq Remarks
-        expect(assessment.remarks.as_json).to eq Remarks.new.as_json
+        expect(assessment.remarks.as_json).to eq Remarks.new(assessment.id).as_json
       end
     end
 
     context 'saving and reloading' do
       let(:remarks) do
-        r = Remarks.new
+        r = Remarks.new(assessment.id)
         r.add(:other_income_payment, :unknown_frequency, %w[abc def])
         r.add(:other_income_payment, :amount_variation, %w[ghu jkl])
         r
       end
 
-      let(:assessment) { create :assessment, remarks: remarks }
+      let(:assessment) { create :assessment }
+
+      before { assessment.remarks = remarks }
 
       it 'reconstitutes into a remarks class with the same values' do
         expect(assessment.remarks.as_json).to eq remarks.as_json

--- a/spec/models/explicit_remark_spec.rb
+++ b/spec/models/explicit_remark_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+RSpec.describe ExplicitRemark do
+  let(:assessment1) { create :assessment }
+  let(:assessment2) { create :assessment }
+
+  describe '.remarks_by_category' do
+    before do
+      create :explicit_remark, assessment: assessment2, remark: 'Remark no. 2'
+      create :explicit_remark, assessment: assessment2, remark: 'Remark no. 3'
+      create :explicit_remark, assessment: assessment2, remark: 'Remark no. 1'
+    end
+
+    context 'no remarks for specified assessment' do
+      it 'returns an empty hash' do
+        expect(ExplicitRemark.remarks_by_category(assessment1.id)).to eq({})
+      end
+    end
+
+    context 'remarks exist for specified assessment' do
+      let(:expected_results) do
+        {
+          income_disregards: [
+            'Remark no. 1',
+            'Remark no. 2',
+            'Remark no. 3'
+          ]
+        }
+      end
+      it 'returns the results in alphabetical order' do
+        expect(ExplicitRemark.remarks_by_category(assessment2.id)).to eq(expected_results)
+      end
+    end
+  end
+end

--- a/spec/requests/explicit_remarks_spec.rb
+++ b/spec/requests/explicit_remarks_spec.rb
@@ -1,0 +1,88 @@
+require 'rails_helper'
+
+RSpec.describe ExplicitRemarksController, type: :request do
+  describe 'POST /assessments/:assessment_id/remarks' do
+    let(:assessment) { create :assessment }
+    let(:headers) { { 'CONTENT_TYPE' => 'application/json' } }
+    let(:request_payload) do
+      {
+        explicit_remarks: [
+          {
+            category: 'income_disregards',
+            details: %w[
+              employment
+              charity
+            ]
+          }
+        ]
+      }
+    end
+
+    context 'valid payload' do
+      before do
+        post assessment_explicit_remarks_path(assessment.id), params: payload.to_json, headers: headers
+      end
+
+      context ' success', :show_in_doc do
+        let(:payload) { valid_payload }
+
+        it 'it successful' do
+          expect(response).to be_successful
+        end
+      end
+
+      context 'invalid payload' do
+        let(:payload) { invalid_payload }
+
+        it 'is not successful', :show_in_doc do
+          expect(response).to have_http_status(:unprocessable_entity)
+        end
+
+        it 'shows errors in the response' do
+          parsed_response = JSON.parse(response.body, symbolize_names: true)
+          expect(parsed_response[:success]).to be false
+          expect(parsed_response[:errors].size).to eq 1
+          expect(parsed_response[:errors].first).to eq %(Invalid parameter 'category' value "other_stuff": Must be one of: <code>income_disregards</code>.)
+        end
+      end
+
+      context 'error in creation service' do
+        let(:payload) { valid_payload }
+
+        it 'returns unprocessable entity' do
+          allow_any_instance_of(Creators::ExplicitRemarksCreator).to receive(:success?).and_return(false)
+          post assessment_explicit_remarks_path(assessment.id), params: payload.to_json, headers: headers
+          expect(response).to have_http_status(:unprocessable_entity)
+        end
+      end
+    end
+
+    def valid_payload
+      {
+        explicit_remarks: [
+          {
+            category: 'income_disregards',
+            details: %w[
+              employment
+              charity
+            ]
+          }
+        ]
+      }
+    end
+
+    def invalid_payload
+      {
+        explicit_remarks: [
+          {
+            category: 'other_stuff',
+            details: %w[
+              employment
+              charity
+            ]
+          }
+        ]
+      }
+    end
+  end
+end

--- a/spec/services/creators/explicit_remarks_creator_spec.rb
+++ b/spec/services/creators/explicit_remarks_creator_spec.rb
@@ -1,0 +1,73 @@
+require 'rails_helper'
+
+RSpec.describe Creators::ExplicitRemarksCreator do
+  let(:assessment) { create :assessment }
+
+  subject { described_class.call(assessment_id: assessment.id, remarks_attributes: params) }
+
+  context 'valid payload' do
+    let(:params) { valid_params }
+
+    it 'creates the expected number of records' do
+      expect { subject }.to change { ExplicitRemark.count }.by(2)
+    end
+
+    it 'is successful' do
+      expect(subject.success?).to be true
+    end
+
+    it 'creates the right records' do
+      subject
+      expect(ExplicitRemark.where(assessment_id: assessment.id, category: 'income_disregards').map(&:remark)).to match_array(%w[disregard_1 disregard_2])
+    end
+  end
+
+  context 'invalid_params' do
+    context 'unknown category' do
+      let(:params) { invalid_params }
+
+      it 'does not write any records' do
+        expect { subject }.not_to change { ExplicitRemark.count }
+      end
+
+      it 'is not successful' do
+        expect(subject.success?).to be false
+      end
+
+      it 'updates the error array' do
+        expect(subject.errors).to eq ['Category other_stuff is not a valid remark category']
+      end
+    end
+  end
+
+  context 'unknown exception raised' do
+    let(:params) { valid_params }
+    it 'raises a Creation error' do
+      allow_any_instance_of(described_class).to receive(:create_remark_category).and_raise(ArgumentError, 'Argument error detailed message')
+      expect(subject.success?).to be false
+      expect(subject.errors).to eq ['ArgumentError - Argument error detailed message']
+    end
+  end
+
+  def valid_params
+    [
+      {
+        category: 'income_disregards',
+        details: %w[disregard_1 disregard_2]
+      }
+    ]
+  end
+
+  def invalid_params
+    [
+      {
+        category: 'income_disregards',
+        details: %w[xxxx zzzzz]
+      },
+      {
+        category: 'other_stuff',
+        details: %w[xxxx zzzzz]
+      }
+    ]
+  end
+end

--- a/spec/services/remarks_spec.rb
+++ b/spec/services/remarks_spec.rb
@@ -1,12 +1,20 @@
 require 'rails_helper'
 
 RSpec.describe Remarks do
-  let(:remarks) { Remarks.new }
+  let(:assessment) { create :assessment }
+  let(:remarks) { Remarks.new(assessment.id) }
 
   describe '#remarks_hash' do
     context 'no remarks' do
       it 'returns and empty hash' do
         expect(remarks.remarks_hash).to eq({})
+      end
+    end
+
+    context 'with remarks' do
+      it 'returns a hash of remarks' do
+        remarks.add(:other_income_payment, :unknown_frequency, %w[abc def])
+        expect(remarks.remarks_hash).to eq({ other_income_payment: { unknown_frequency: %w[abc def] } })
       end
     end
   end
@@ -81,6 +89,19 @@ RSpec.describe Remarks do
     it 'returns the @remarks_hash' do
       remarks.add(:other_income_payment, :unknown_frequency, ['abc'])
       expect(remarks.as_json).to eq remarks.remarks_hash
+    end
+
+    context 'with explicit remarks' do
+      before do
+        create :explicit_remark, assessment: assessment, remark: 'Jacob Creuzfeldt disease fund'
+        create :explicit_remark, assessment: assessment, remark: 'Grenfell tower fund'
+      end
+
+      it 'adds in the explicit remarks' do
+        remarks.add(:other_income_payment, :unknown_frequency, %w[abc def])
+        expect(remarks.as_json).to have_key(:income_disregards)
+        expect(remarks.as_json[:income_disregards]).to eq ['Grenfell tower fund', 'Jacob Creuzfeldt disease fund']
+      end
     end
   end
 end


### PR DESCRIPTION
## Implement explicit remarks endpoint

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1928)

Allow client to specify explicit remarks (currently limited to income disregards) which are then included in the assessment result (and will be used by Apply to generate the means report and draw the caseworker's attention to the fact that income disregards have been specified).

 - Created:
   -  `ExplicitRemarksController`
   - `ExplicitRemarksCreationService`
   - `ExplicitRemark` model
- Altered the `Remarks` model to take assessment id, and include any explicit remarks in the generation of the assessment result payload.

## Checklist

Before you ask people to review this PR:

- [ ] Tests and rubocop should be passing: `bundle exec rake`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [ ] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [ ] The PR description should say what you changed and why, with a link to the JIRA story.
- [ ] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
