### PR TITLE
BugFix Don't send exception object to Raven.capture message

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,11 +4,12 @@ class ApplicationController < ActionController::API
     render json: { success: false, errors: ["#{e.class}: #{e.message}"] }, status: :unprocessable_entity
   end
   rescue_from Apipie::ParamError do |e|
-    render_unprocessable([e.message])
+    Raven.capture_exception(e)
+    render json: { success: false, errors: [e.message] }, status: :unprocessable_entity
   end
 
   def render_unprocessable(message)
-    Raven.capture_exception(message)
+    Raven.capture_message(message)
     render json: { success: false, errors: message }, status: :unprocessable_entity
   end
 


### PR DESCRIPTION
We capture api param errors with an array of string instead of an exception object for simplification, so that user
don't receive the error class in a response.

Solution is to have a seperate Raven.capture_exception when capturing param errors because render_unprocessable is used from child controllers to signify an internal error but without providing error class info etc.

This fixes the below (also found here [sentry](https://sentry.io/organizations/ministryofjustice/issues/2111912118/?project=5404900&query=is%3Aunresolved)):
```
NoMethodError

undefined method `backtrace' for #<Array:0x000055c94d4f9e00>
```

I believe this will stop CFE from sending a 500 error to a consumer (Apply app) and instead send the 422 :unprocessable_entity param error in json format whilst also sending a raven capture exception to alert the team.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
