### PR TITLE
AP-1915 - Run CFE on Alpine docker image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -165,7 +165,8 @@ jobs:
     executor: basic-executor
     steps:
     - checkout
-    - setup_remote_docker
+    - setup_remote_docker:
+        version: 19.03.13
     - *update_packages
     - *install_git_crypt
     - *decrypt_secrets

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,6 +8,8 @@ AllCops:
   SuggestExtensions: false
   Exclude:
     - 'db/schema.rb'
+    - 'log/**/*'
+    - 'tmp/**/*'
     - 'vendor/**/*'
     - 'node_modules/**/*'
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,18 @@
-FROM ruby:2.7.2
+FROM ruby:2.7.2-alpine3.12
 MAINTAINER apply for legal aid team
+
 ENV RAILS_ENV production
-RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
-RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
-RUN apt-get update -qq && apt-get install -y nodejs yarn postgresql-client
+
+RUN set -ex
+
+RUN apk --no-cache add --virtual build-dependencies \
+                    build-base \
+                    postgresql-dev \
+&& apk --no-cache add \
+                  postgresql-client \
+                  nodejs \
+                  yarn
+
 RUN mkdir /myapp
 WORKDIR /myapp
 
@@ -22,6 +31,8 @@ COPY . /myapp
 RUN yarn --prod
 
 RUN bundle exec rake assets:precompile SECRET_KEY_BASE=a-real-secret-key-is-not-needed-here
+
+RUN apk del build-dependencies
 
 EXPOSE 3000
 

--- a/Gemfile
+++ b/Gemfile
@@ -91,4 +91,4 @@ group :test do
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
-gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]
+gem 'tzinfo-data'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -324,6 +324,8 @@ GEM
     timecop (0.9.2)
     tzinfo (1.2.9)
       thread_safe (~> 0.1)
+    tzinfo-data (1.2020.6)
+      tzinfo (>= 1.0.0)
     uber (0.1.0)
     unicode-display_width (1.7.0)
     vcr (6.0.0)


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1915)

Switches CFE from the `ruby:2.7.2` docker image to the smaller `ruby:2.7.2-alpine3.12` image, also used by Apply, resulting in smaller image sizes and consistent tech stacks.

Image size reduced from 1.34gb to 931mb.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
