### PR TITLE
AP-1983: Add bank, cash and all_sources for disposable incomes for assessment version 3

### DIFF
--- a/app/constants/cfe_constants.rb
+++ b/app/constants/cfe_constants.rb
@@ -2,7 +2,7 @@ module CFEConstants
   # Versions
   #
   DEFAULT_ASSESSMENT_VERSION = '2'.freeze
-  LATEST_ASSESSMENT_VERSION = '3'.freeze
+  VALID_ASSESSMENT_VERSIONS = %w[2 3].freeze
 
   # Income categories
   #

--- a/app/controllers/assessments_controller.rb
+++ b/app/controllers/assessments_controller.rb
@@ -67,12 +67,13 @@ class AssessmentsController < ApplicationController
   def determine_version_and_process
     assessment.version = determine_version
 
-    case assessment.version
-    when CFEConstants::DEFAULT_ASSESSMENT_VERSION, CFEConstants::LATEST_ASSESSMENT_VERSION
-      show_assessment
-    else
-      raise CheckFinancialEligibilityError, 'Unsupported version specified in AcceptHeader'
-    end
+    raise CheckFinancialEligibilityError, 'Unsupported version specified in AcceptHeader' unless valid_assessment_version?
+
+    show_assessment
+  end
+
+  def valid_assessment_version?
+    CFEConstants::VALID_ASSESSMENT_VERSIONS.include?(assessment.version)
   end
 
   def show_assessment

--- a/app/models/assessment.rb
+++ b/app/models/assessment.rb
@@ -26,6 +26,10 @@ class Assessment < ApplicationRecord
 
   attr_accessor :version
 
+  def v3?
+    @version == '3'
+  end
+
   # Always instantiate a new Remarks object from a nil value
   def remarks
     attributes['remarks'] || Remarks.new(id)

--- a/app/models/cash_transaction.rb
+++ b/app/models/cash_transaction.rb
@@ -1,7 +1,9 @@
 class CashTransaction < ApplicationRecord
   belongs_to :cash_transaction_category
 
-  scope :by_category_id, ->(id) do
-    where(cash_transaction_category_id: id)
+  scope :by_operation_and_category, ->(assessment, operation, category_name) do
+    joins(:cash_transaction_category)
+      .where(cash_transaction_category: { name: category_name, operation: operation, gross_income_summary_id: assessment.gross_income_summary.id })
+      .order(:date)
   end
 end

--- a/app/models/cash_transaction_category.rb
+++ b/app/models/cash_transaction_category.rb
@@ -17,18 +17,6 @@ class CashTransactionCategory < ApplicationRecord
     message: 'is not a valid debit category: %<value>s'
   }, if: :debit?
 
-  scope :credits_by_category, ->(category) do
-    record = find_by(operation: :credit, name: category)
-    transactions(record&.id)
-  end
-
-  scope :debits_by_category, ->(category) do
-    record = find_by(operation: :debit, name: category)
-    transactions(record&.id)
-  end
-
-  scope :transactions, ->(id) { CashTransaction.by_category_id(id) }
-
   def credit?
     operation == 'credit'
   end

--- a/app/models/cash_transaction_category.rb
+++ b/app/models/cash_transaction_category.rb
@@ -22,6 +22,11 @@ class CashTransactionCategory < ApplicationRecord
     transactions(record&.id)
   end
 
+  scope :debits_by_category, ->(category) do
+    record = find_by(operation: :debit, name: category)
+    transactions(record&.id)
+  end
+
   scope :transactions, ->(id) { CashTransaction.by_category_id(id) }
 
   def credit?

--- a/app/models/disposable_income_summary.rb
+++ b/app/models/disposable_income_summary.rb
@@ -18,9 +18,10 @@ class DisposableIncomeSummary < ApplicationRecord
     _prefix: false
   )
 
-  def calculate_monthly_childcare_amount!
+  def calculate_monthly_childcare_amount!(eligible, cash_amount)
     calculate_monthly_equivalent!(target_field: :child_care_bank,
-                                  collection: childcare_outgoings)
+                                  collection: eligible ? childcare_outgoings : [])
+    update!(child_care_cash: eligible ? cash_amount : 0.0)
   end
 
   def calculate_monthly_rent_or_mortgage_amount!

--- a/app/models/disposable_income_summary.rb
+++ b/app/models/disposable_income_summary.rb
@@ -9,6 +9,8 @@ class DisposableIncomeSummary < ApplicationRecord
   has_many :maintenance_outgoings, dependent: :destroy, class_name: 'Outgoings::Maintenance'
   has_many :legal_aid_outgoings, dependent: :destroy, class_name: 'Outgoings::LegalAid'
 
+  delegate :version, to: :assessment
+
   enum(
     assessment_result: enum_hash_for(
       :pending, :eligible, :ineligible, :contribution_required
@@ -17,17 +19,17 @@ class DisposableIncomeSummary < ApplicationRecord
   )
 
   def calculate_monthly_childcare_amount!
-    calculate_monthly_equivalent!(target_field: :childcare,
+    calculate_monthly_equivalent!(target_field: :child_care_bank,
                                   collection: childcare_outgoings)
   end
 
   def calculate_monthly_maintenance_amount!
-    calculate_monthly_equivalent!(target_field: :maintenance,
+    calculate_monthly_equivalent!(target_field: :maintenance_out_bank,
                                   collection: maintenance_outgoings)
   end
 
   def calculate_monthly_legal_aid_amount!
-    calculate_monthly_equivalent!(target_field: :legal_aid,
+    calculate_monthly_equivalent!(target_field: :legal_aid_bank,
                                   collection: legal_aid_outgoings)
   end
 end

--- a/app/models/disposable_income_summary.rb
+++ b/app/models/disposable_income_summary.rb
@@ -23,6 +23,12 @@ class DisposableIncomeSummary < ApplicationRecord
                                   collection: childcare_outgoings)
   end
 
+  def calculate_monthly_rent_or_mortgage_amount!
+    monthly_amount = calculate_monthly_equivalent(collection: housing_cost_outgoings,
+                                                  amount_method: :allowable_amount)
+    update!(rent_or_mortgage_bank: monthly_amount)
+  end
+
   def calculate_monthly_maintenance_amount!
     calculate_monthly_equivalent!(target_field: :maintenance_out_bank,
                                   collection: maintenance_outgoings)

--- a/app/models/disposable_income_summary.rb
+++ b/app/models/disposable_income_summary.rb
@@ -9,7 +9,7 @@ class DisposableIncomeSummary < ApplicationRecord
   has_many :maintenance_outgoings, dependent: :destroy, class_name: 'Outgoings::Maintenance'
   has_many :legal_aid_outgoings, dependent: :destroy, class_name: 'Outgoings::LegalAid'
 
-  delegate :version, to: :assessment
+  delegate :v3?, to: :assessment
 
   enum(
     assessment_result: enum_hash_for(

--- a/app/models/gross_income_summary.rb
+++ b/app/models/gross_income_summary.rb
@@ -7,7 +7,7 @@ class GrossIncomeSummary < ApplicationRecord
   has_many :irregular_income_payments, dependent: :destroy
   has_many :cash_transaction_categories, dependent: :destroy
 
-  delegate :version, to: :assessment
+  delegate :v3?, to: :assessment
 
   enum(
     assessment_result: enum_hash_for(

--- a/app/models/other_income_source.rb
+++ b/app/models/other_income_source.rb
@@ -8,7 +8,7 @@ class OtherIncomeSource < ApplicationRecord
   validates :name, inclusion: { in: CFEConstants::HUMANIZED_INCOME_CATEGORIES }
 
   delegate :assessment, to: :gross_income_summary
-  delegate :version, to: :assessment
+  delegate :v3?, to: :assessment
 
   def calculate_monthly_income!
     calculate_monthly_equivalent!(target_field: :monthly_income,

--- a/app/services/calculators/housing_costs_calculator.rb
+++ b/app/services/calculators/housing_costs_calculator.rb
@@ -18,7 +18,7 @@ module Calculators
     end
 
     def gross_housing_costs
-      @gross_housing_costs ||= assessment_v3? ? gross_housing_costs_all_payments : gross_housing_costs_bank_payments_only
+      @gross_housing_costs ||= assessment.v3? ? gross_housing_costs_all_sources : gross_housing_costs_bank
     end
 
     def monthly_housing_benefit
@@ -27,25 +27,21 @@ module Calculators
 
     private
 
-    def cash_housing_costs
+    def gross_housing_costs_cash
       monthly_transaction_amount_by(operation: :debit, category: :rent_or_mortgage)
     end
 
-    def gross_housing_costs_all_payments
-      gross_housing_costs_bank_payments_only + cash_housing_costs
+    def gross_housing_costs_all_sources
+      gross_housing_costs_bank + gross_housing_costs_cash
     end
 
-    def gross_housing_costs_bank_payments_only
+    def gross_housing_costs_bank
       disposable_income_summary.calculate_monthly_rent_or_mortgage_amount!
       disposable_income_summary.rent_or_mortgage_bank
     end
 
-    def assessment_v3?
-      assessment.version == CFEConstants::LATEST_ASSESSMENT_VERSION
-    end
-
     def monthly_actual_housing_costs
-      @monthly_actual_housing_costs ||= assessment_v3? ? calculate_actual_housing_costs + cash_housing_costs : calculate_actual_housing_costs
+      @monthly_actual_housing_costs ||= assessment.v3? ? calculate_actual_housing_costs + gross_housing_costs_cash : calculate_actual_housing_costs
     end
 
     def calculate_actual_housing_costs

--- a/app/services/collators/childcare_collator.rb
+++ b/app/services/collators/childcare_collator.rb
@@ -1,15 +1,19 @@
 module Collators
   class ChildcareCollator < BaseWorkflowService
-    def call
-      return unless eligible_for_childcare_costs?
+    include Transactions
 
-      collate!
+    def call
+      disposable_income_summary.calculate_monthly_childcare_amount!(eligible_for_childcare_costs?, monthly_child_care_cash)
     end
 
     private
 
     def eligible_for_childcare_costs?
       applicant_has_dependent_child? && (applicant_employed? || applicant_has_student_loan?)
+    end
+
+    def monthly_child_care_cash
+      monthly_transaction_amount_by(operation: :debit, category: :child_care)
     end
 
     def applicant_has_dependent_child?
@@ -29,10 +33,6 @@ module Collators
       return true if irregular_income_payments&.present?
 
       false
-    end
-
-    def collate!
-      disposable_income_summary.calculate_monthly_childcare_amount!
     end
   end
 end

--- a/app/services/collators/childcare_collator.rb
+++ b/app/services/collators/childcare_collator.rb
@@ -1,12 +1,16 @@
 module Collators
   class ChildcareCollator < BaseWorkflowService
     def call
-      return unless applicant_has_dependent_child?
+      return unless eligible_for_childcare_costs?
 
-      collate! if applicant_employed? || applicant_has_student_loan?
+      collate!
     end
 
     private
+
+    def eligible_for_childcare_costs?
+      applicant_has_dependent_child? && (applicant_employed? || applicant_has_student_loan?)
+    end
 
     def applicant_has_dependent_child?
       assessment.dependants.each do |dependant|

--- a/app/services/collators/disposable_income_collator.rb
+++ b/app/services/collators/disposable_income_collator.rb
@@ -8,10 +8,14 @@ module Collators
 
     delegate :net_housing_costs,
              :rent_or_mortgage_bank,
+             :rent_or_mortgage_cash,
              :child_care_bank,
+             :child_care_cash,
              :maintenance_out_bank,
+             :maintenance_out_cash,
              :dependant_allowance,
-             :legal_aid_bank, to: :disposable_income_summary
+             :legal_aid_bank,
+             :legal_aid_cash, to: :disposable_income_summary
 
     delegate :total_gross_income, to: :gross_income_summary
 
@@ -33,13 +37,17 @@ module Collators
 
     def populate_attrs_v3(attrs)
       OUTGOING_CATEGORIES.each do |category|
-        monthly_cash_amount = monthly_transaction_amount_by(operation: :debit, category: category)
-        @monthly_cash_transactions_total += monthly_cash_amount
+        monthly_cash_amount = category == :child_care ? __send__("#{category}_cash") : monthly_cash_by_category(category)
+        @monthly_cash_transactions_total += monthly_cash_amount unless category == :rent_or_mortgage
 
         attrs[:"#{category}_bank"] = __send__("#{category}_bank")
         attrs[:"#{category}_cash"] = monthly_cash_amount
         attrs[:"#{category}_all_sources"] = attrs[:"#{category}_bank"] + attrs[:"#{category}_cash"]
       end
+    end
+
+    def monthly_cash_by_category(category)
+      monthly_transaction_amount_by(operation: :debit, category: category)
     end
 
     def default_attrs

--- a/app/services/collators/disposable_income_collator.rb
+++ b/app/services/collators/disposable_income_collator.rb
@@ -22,18 +22,14 @@ module Collators
 
     def call
       attrs = {}
-      populate_attrs_v3 attrs if assessment_v3?
+      populate_attrs_v3 attrs if assessment.v3?
 
-      attrs.update(default_attrs)
+      attrs = attrs.merge(default_attrs)
 
       disposable_income_summary.update!(attrs)
     end
 
     private
-
-    def assessment_v3?
-      assessment.version == CFEConstants::LATEST_ASSESSMENT_VERSION
-    end
 
     def populate_attrs_v3(attrs)
       OUTGOING_CATEGORIES.each do |category|

--- a/app/services/collators/gross_income_collator.rb
+++ b/app/services/collators/gross_income_collator.rb
@@ -1,5 +1,7 @@
 module Collators
   class GrossIncomeCollator < BaseWorkflowService
+    include Transactions
+
     INCOME_CATEGORIES = CFEConstants::VALID_INCOME_CATEGORIES.map(&:to_sym)
 
     def call
@@ -25,7 +27,7 @@ module Collators
     def populate_attrs_v3(attrs)
       INCOME_CATEGORIES.each do |category|
         attrs[:"#{category}_bank"] = category == :benefits ? monthly_state_benefits : categorised_income[category].to_d
-        attrs[:"#{category}_cash"] = monthly_transaction_amount_by(category: category)
+        attrs[:"#{category}_cash"] = monthly_transaction_amount_by(operation: :credit, category: category)
         attrs[:"#{category}_all_sources"] = attrs[:"#{category}_bank"] + attrs[:"#{category}_cash"]
         attrs[:total_gross_income] += attrs[:"#{category}_all_sources"]
       end
@@ -41,13 +43,6 @@ module Collators
         monthly_other_income: categorised_income[:total],
         monthly_state_benefits: monthly_state_benefits
       }
-    end
-
-    def monthly_transaction_amount_by(category:)
-      transactions = assessment.cash_transaction_categories.credits_by_category(category)
-      return 0.0 if transactions.empty?
-
-      transactions.average(:amount).round(2)
     end
 
     def upper_threshold

--- a/app/services/collators/gross_income_collator.rb
+++ b/app/services/collators/gross_income_collator.rb
@@ -7,12 +7,7 @@ module Collators
     def call
       attrs = default_attrs
 
-      case assessment.version
-      when CFEConstants::LATEST_ASSESSMENT_VERSION
-        populate_attrs_v3 attrs
-      else
-        populate_attrs_v2 attrs
-      end
+      assessment.v3? ? populate_attrs_v3(attrs) : populate_attrs_v2(attrs)
 
       gross_income_summary.update!(attrs)
     end

--- a/app/services/collators/housing_costs_collator.rb
+++ b/app/services/collators/housing_costs_collator.rb
@@ -5,6 +5,7 @@ module Collators
       disposable_income_summary.update!(
         housing_benefit: housing_calculator.monthly_housing_benefit,
         gross_housing_costs: housing_calculator.gross_housing_costs,
+        rent_or_mortgage_bank: housing_calculator.gross_housing_costs,
         net_housing_costs: housing_calculator.net_housing_costs
       )
     end

--- a/app/services/collators/housing_costs_collator.rb
+++ b/app/services/collators/housing_costs_collator.rb
@@ -5,7 +5,6 @@ module Collators
       disposable_income_summary.update!(
         housing_benefit: housing_calculator.monthly_housing_benefit,
         gross_housing_costs: housing_calculator.gross_housing_costs,
-        rent_or_mortgage_bank: housing_calculator.gross_housing_costs,
         net_housing_costs: housing_calculator.net_housing_costs
       )
     end

--- a/app/services/concerns/exemptable.rb
+++ b/app/services/concerns/exemptable.rb
@@ -8,6 +8,6 @@ module Exemptable
   end
 
   def childcare_disallowed?
-    @assessment.disposable_income_summary.childcare.zero?
+    @assessment.disposable_income_summary.child_care_bank.zero?
   end
 end

--- a/app/services/concerns/transactions.rb
+++ b/app/services/concerns/transactions.rb
@@ -18,7 +18,7 @@ module Transactions
   end
 
   def monthly_transaction_amount_by(operation:, category:)
-    transactions = @assessment.cash_transaction_categories.__send__("#{operation}s_by_category", category)
+    transactions = CashTransaction.by_operation_and_category(@assessment, operation, category)
     return 0.0 if transactions.empty?
 
     transactions.average(:amount).round(2)

--- a/app/services/concerns/transactions.rb
+++ b/app/services/concerns/transactions.rb
@@ -1,0 +1,26 @@
+module Transactions
+  def all_transaction_types
+    {
+      bank_transactions: transactions_by(transaction_type: :bank),
+      cash_transactions: transactions_by(transaction_type: :cash),
+      all_sources: transactions_by(transaction_type: :all_sources)
+    }
+  end
+
+  def transactions_by(transaction_type:)
+    transactions = {}
+
+    @categories.each do |category|
+      transactions[category] = @record["#{category}_#{transaction_type}"]
+    end
+
+    transactions
+  end
+
+  def monthly_transaction_amount_by(operation:, category:)
+    transactions = @assessment.cash_transaction_categories.__send__("#{operation}s_by_category", category)
+    return 0.0 if transactions.empty?
+
+    transactions.average(:amount).round(2)
+  end
+end

--- a/app/services/decorators/disposable_income_summary_decorator.rb
+++ b/app/services/decorators/disposable_income_summary_decorator.rb
@@ -6,11 +6,20 @@ module Decorators
       @record = record
     end
 
-    def as_json # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+    def as_json
       return nil if record.nil?
 
+      attrs = {}
+      monthly_equivalents_key = assessment_v3? ? :monthly_equivalents : :monthly_outgoing_equivalents
+      attrs[monthly_equivalents_key] = MonthlyOutgoingEquivalentDecorator.new(record).as_json
+
+      attrs.update(default_attrs)
+    end
+
+    private
+
+    def default_attrs # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
       {
-        monthly_equivalents: MonthlyOutgoingEquivalentDecorator.new(record).as_json,
         childcare_allowance: record.childcare,
         deductions: DeductionsDecorator.new(record).as_json,
         dependant_allowance: record.dependant_allowance,
@@ -25,6 +34,10 @@ module Decorators
         assessment_result: record.assessment_result,
         income_contribution: record.income_contribution
       }
+    end
+
+    def assessment_v3?
+      record.version == CFEConstants::LATEST_ASSESSMENT_VERSION
     end
   end
 end

--- a/app/services/decorators/disposable_income_summary_decorator.rb
+++ b/app/services/decorators/disposable_income_summary_decorator.rb
@@ -1,29 +1,29 @@
 module Decorators
   class DisposableIncomeSummaryDecorator
-    attr_reader :assessment
+    attr_reader :record
 
     def initialize(record)
       @record = record
     end
 
     def as_json # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
-      return nil if @record.nil?
+      return nil if record.nil?
 
       {
-        monthly_outgoing_equivalents: MonthlyOutgoingEquivalentDecorator.new(@record).as_json,
-        childcare_allowance: @record.childcare,
-        deductions: DeductionsDecorator.new(@record).as_json,
-        dependant_allowance: @record.dependant_allowance,
-        maintenance_allowance: @record.maintenance,
-        gross_housing_costs: @record.gross_housing_costs,
-        housing_benefit: @record.housing_benefit,
-        net_housing_costs: @record.net_housing_costs,
-        total_outgoings_and_allowances: @record.total_outgoings_and_allowances,
-        total_disposable_income: @record.total_disposable_income,
-        lower_threshold: @record.lower_threshold,
-        upper_threshold: @record.upper_threshold,
-        assessment_result: @record.assessment_result,
-        income_contribution: @record.income_contribution
+        monthly_equivalents: MonthlyOutgoingEquivalentDecorator.new(record).as_json,
+        childcare_allowance: record.childcare,
+        deductions: DeductionsDecorator.new(record).as_json,
+        dependant_allowance: record.dependant_allowance,
+        maintenance_allowance: record.maintenance,
+        gross_housing_costs: record.gross_housing_costs,
+        housing_benefit: record.housing_benefit,
+        net_housing_costs: record.net_housing_costs,
+        total_outgoings_and_allowances: record.total_outgoings_and_allowances,
+        total_disposable_income: record.total_disposable_income,
+        lower_threshold: record.lower_threshold,
+        upper_threshold: record.upper_threshold,
+        assessment_result: record.assessment_result,
+        income_contribution: record.income_contribution
       }
     end
   end

--- a/app/services/decorators/disposable_income_summary_decorator.rb
+++ b/app/services/decorators/disposable_income_summary_decorator.rb
@@ -20,10 +20,10 @@ module Decorators
 
     def default_attrs # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
       {
-        childcare_allowance: record.childcare,
+        childcare_allowance: childcare_allowance,
         deductions: DeductionsDecorator.new(record).as_json,
         dependant_allowance: record.dependant_allowance,
-        maintenance_allowance: record.maintenance,
+        maintenance_allowance: maintenance_allowance,
         gross_housing_costs: record.gross_housing_costs,
         housing_benefit: record.housing_benefit,
         net_housing_costs: record.net_housing_costs,
@@ -34,6 +34,14 @@ module Decorators
         assessment_result: record.assessment_result,
         income_contribution: record.income_contribution
       }
+    end
+
+    def childcare_allowance
+      record.v3? ? record.child_care_all_sources : record.child_care_bank
+    end
+
+    def maintenance_allowance
+      record.v3? ? record.maintenance_out_all_sources : record.maintenance_out_bank
     end
   end
 end

--- a/app/services/decorators/disposable_income_summary_decorator.rb
+++ b/app/services/decorators/disposable_income_summary_decorator.rb
@@ -10,10 +10,10 @@ module Decorators
       return nil if record.nil?
 
       attrs = {}
-      monthly_equivalents_key = assessment_v3? ? :monthly_equivalents : :monthly_outgoing_equivalents
+      monthly_equivalents_key = record.v3? ? :monthly_equivalents : :monthly_outgoing_equivalents
       attrs[monthly_equivalents_key] = MonthlyOutgoingEquivalentDecorator.new(record).as_json
 
-      attrs.update(default_attrs)
+      attrs.merge(default_attrs)
     end
 
     private
@@ -34,10 +34,6 @@ module Decorators
         assessment_result: record.assessment_result,
         income_contribution: record.income_contribution
       }
-    end
-
-    def assessment_v3?
-      record.version == CFEConstants::LATEST_ASSESSMENT_VERSION
     end
   end
 end

--- a/app/services/decorators/gross_income_summary_decorator.rb
+++ b/app/services/decorators/gross_income_summary_decorator.rb
@@ -27,20 +27,27 @@ module Decorators
         assessment_result: record.assessment_result,
         monthly_income_equivalents: MonthlyIncomeEquivalentDecorator.new(record).as_json,
         monthly_outgoing_equivalents: MonthlyOutgoingEquivalentDecorator.new(disposable_income_summary).as_json,
-        state_benefits: record.state_benefits.map { |sb| StateBenefitDecorator.new(sb).as_json },
+        state_benefits: record.state_benefits.map { |sb| StateBenefitDecorator.new(record, sb).as_json },
         other_income: record.other_income_sources.map { |oi| OtherIncomeSourceDecorator.new(oi).as_json },
         irregular_income: IrregularIncomePaymentsDecorator.new(record.irregular_income_payments).as_json
       }
     end
 
-    def payload_v3
+    def payload_v3 # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
       {
         summary: {
           total_gross_income: record.total_gross_income,
           upper_threshold: record.upper_threshold,
           assessment_result: record.assessment_result
         },
-        student_loan: { monthly_equivalents: record.monthly_student_loan },
+        irregular_income: {
+          monthly_equivalents: {
+            student_loan: record.monthly_student_loan
+          }
+        },
+        state_benefits: {
+          monthly_equivalents: record.state_benefits.map { |sb| StateBenefitDecorator.new(record, sb).as_json }
+        },
         other_income: OtherIncomeSourceDecorator.new(record).as_json
       }
     end

--- a/app/services/decorators/gross_income_summary_decorator.rb
+++ b/app/services/decorators/gross_income_summary_decorator.rb
@@ -12,12 +12,7 @@ module Decorators
     def as_json
       return nil if record.nil?
 
-      case record.version
-      when CFEConstants::LATEST_ASSESSMENT_VERSION
-        payload_v3
-      else
-        payload_v2
-      end
+      record.v3? ? payload_v3 : payload_v2
     end
 
     private

--- a/app/services/decorators/monthly_outgoing_equivalent_decorator.rb
+++ b/app/services/decorators/monthly_outgoing_equivalent_decorator.rb
@@ -10,27 +10,13 @@ module Decorators
     end
 
     def as_json
-      case record.version
-      when CFEConstants::LATEST_ASSESSMENT_VERSION
-        payload_v3
-      else
-        payload_v2
-      end
+      assessment_v3? ? all_transaction_types : all_transaction_types[:bank_transactions]
     end
 
     private
 
-    def payload_v2
-      {
-        child_care: record.child_care_bank,
-        maintenance_out: record.maintenance_out_bank,
-        rent_or_mortgage: record.rent_or_mortgage_bank,
-        legal_aid: record.legal_aid_bank
-      }
-    end
-
-    def payload_v3
-      all_transaction_types
+    def assessment_v3?
+      record.version == CFEConstants::LATEST_ASSESSMENT_VERSION
     end
   end
 end

--- a/app/services/decorators/monthly_outgoing_equivalent_decorator.rb
+++ b/app/services/decorators/monthly_outgoing_equivalent_decorator.rb
@@ -10,13 +10,7 @@ module Decorators
     end
 
     def as_json
-      assessment_v3? ? all_transaction_types : all_transaction_types[:bank_transactions]
-    end
-
-    private
-
-    def assessment_v3?
-      record.version == CFEConstants::LATEST_ASSESSMENT_VERSION
+      record.v3? ? all_transaction_types : all_transaction_types[:bank_transactions]
     end
   end
 end

--- a/app/services/decorators/monthly_outgoing_equivalent_decorator.rb
+++ b/app/services/decorators/monthly_outgoing_equivalent_decorator.rb
@@ -1,16 +1,36 @@
 module Decorators
   class MonthlyOutgoingEquivalentDecorator
+    include Transactions
+
+    attr_reader :record, :categories
+
     def initialize(disposable_income_summary)
       @record = disposable_income_summary
+      @categories = CFEConstants::VALID_OUTGOING_CATEGORIES.map(&:to_sym)
     end
 
     def as_json
+      case record.version
+      when CFEConstants::LATEST_ASSESSMENT_VERSION
+        payload_v3
+      else
+        payload_v2
+      end
+    end
+
+    private
+
+    def payload_v2
       {
-        child_care: @record.childcare,
-        maintenance_out: @record.maintenance,
-        rent_or_mortgage: @record.gross_housing_costs,
-        legal_aid: @record.legal_aid
+        child_care: record.child_care_bank,
+        maintenance_out: record.maintenance_out_bank,
+        rent_or_mortgage: record.rent_or_mortgage_bank,
+        legal_aid: record.legal_aid_bank
       }
+    end
+
+    def payload_v3
+      all_transaction_types
     end
   end
 end

--- a/app/services/decorators/other_income_source_decorator.rb
+++ b/app/services/decorators/other_income_source_decorator.rb
@@ -1,13 +1,16 @@
 module Decorators
   class OtherIncomeSourceDecorator
-    INCOME_CATEGORIES = CFEConstants::VALID_INCOME_CATEGORIES.map(&:to_sym)
+    include Transactions
+
+    attr_reader :record, :categories
 
     def initialize(record)
       @record = record
+      @categories = CFEConstants::VALID_INCOME_CATEGORIES.map(&:to_sym)
     end
 
     def as_json
-      case @record.version
+      case record.version
       when CFEConstants::LATEST_ASSESSMENT_VERSION
         payload_v3
       else
@@ -19,34 +22,20 @@ module Decorators
 
     def payload_v2
       {
-        name: @record.name,
-        monthly_income: @record.monthly_income,
+        name: record.name,
+        monthly_income: record.monthly_income,
         payments: payments
       }
     end
 
     def payload_v3
       {
-        monthly_equivalents: {
-          bank_transactions: income_transactions(transaction_type: :bank),
-          cash_transactions: income_transactions(transaction_type: :cash),
-          all_sources: income_transactions(transaction_type: :all_sources)
-        }
+        monthly_equivalents: all_transaction_types
       }
     end
 
-    def income_transactions(transaction_type:)
-      income_transactions = {}
-
-      INCOME_CATEGORIES.each do |category|
-        income_transactions[category] = @record["#{category}_#{transaction_type}"]
-      end
-
-      income_transactions
-    end
-
     def payments
-      @record.other_income_payments.map do |payment|
+      record.other_income_payments.map do |payment|
         PaymentDecorator.new(payment).as_json
       end
     end

--- a/app/services/decorators/other_income_source_decorator.rb
+++ b/app/services/decorators/other_income_source_decorator.rb
@@ -6,7 +6,7 @@ module Decorators
 
     def initialize(record)
       @record = record
-      @categories = CFEConstants::VALID_INCOME_CATEGORIES.map(&:to_sym)
+      @categories = income_categories_excluding_benefits
     end
 
     def as_json
@@ -27,6 +27,10 @@ module Decorators
       {
         monthly_equivalents: all_transaction_types
       }
+    end
+
+    def income_categories_excluding_benefits
+      CFEConstants::VALID_INCOME_CATEGORIES.map(&:to_sym) - [:benefits]
     end
 
     def payments

--- a/app/services/decorators/other_income_source_decorator.rb
+++ b/app/services/decorators/other_income_source_decorator.rb
@@ -10,12 +10,7 @@ module Decorators
     end
 
     def as_json
-      case record.version
-      when CFEConstants::LATEST_ASSESSMENT_VERSION
-        payload_v3
-      else
-        payload_v2
-      end
+      record.v3? ? payload_v3 : payload_v2
     end
 
     private

--- a/app/services/decorators/state_benefit_decorator.rb
+++ b/app/services/decorators/state_benefit_decorator.rb
@@ -1,10 +1,22 @@
 module Decorators
   class StateBenefitDecorator
-    def initialize(state_benefit)
+    include Transactions
+
+    attr_reader :record, :categories
+
+    def initialize(record, state_benefit)
+      @record = record
       @state_benefit = state_benefit
+      @categories = %i[benefits]
     end
 
     def as_json
+      record.v3? ? payload_v3 : payload_v2
+    end
+
+    private
+
+    def payload_v2
       {
         name: @state_benefit.state_benefit_name,
         monthly_value: @state_benefit.monthly_value,
@@ -13,7 +25,19 @@ module Decorators
       }
     end
 
-    private
+    def payload_v3
+      {
+        name: @state_benefit.state_benefit_name,
+        all_sources: all_benefit_transactions[:all_sources][:benefits],
+        cash_transactions: all_benefit_transactions[:cash_transactions][:benefits],
+        bank_transactions: @state_benefit.monthly_value,
+        excluded_from_income_assessment: @state_benefit.exclude_from_gross_income
+      }
+    end
+
+    def all_benefit_transactions
+      @all_benefit_transactions ||= all_transaction_types
+    end
 
     def payments
       @state_benefit.state_benefit_payments.map do |payment|

--- a/db/migrate/20210128181623_add_bank_cash_transactions_to_disposable_income_summary.rb
+++ b/db/migrate/20210128181623_add_bank_cash_transactions_to_disposable_income_summary.rb
@@ -1,0 +1,20 @@
+class AddBankCashTransactionsToDisposableIncomeSummary < ActiveRecord::Migration[6.1]
+  def change
+    change_table :disposable_income_summaries, bulk: true do |t|
+      t.decimal :child_care_all_sources, default: 0.0
+      t.decimal :maintenance_out_all_sources, default: 0.0
+      t.decimal :rent_or_mortgage_all_sources, default: 0.0
+      t.decimal :legal_aid_all_sources, default: 0.0
+
+      t.decimal :child_care_bank, default: 0.0
+      t.decimal :maintenance_out_bank, default: 0.0
+      t.decimal :rent_or_mortgage_bank, default: 0.0
+      t.decimal :legal_aid_bank, default: 0.0
+
+      t.decimal :child_care_cash, default: 0.0
+      t.decimal :maintenance_out_cash, default: 0.0
+      t.decimal :rent_or_mortgage_cash, default: 0.0
+      t.decimal :legal_aid_cash, default: 0.0
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_01_22_165708) do
+ActiveRecord::Schema.define(version: 2021_01_28_181623) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -132,6 +132,18 @@ ActiveRecord::Schema.define(version: 2021_01_22_165708) do
     t.decimal "housing_benefit", default: "0.0"
     t.decimal "income_contribution", default: "0.0"
     t.decimal "legal_aid", default: "0.0", null: false
+    t.decimal "child_care_all_sources", default: "0.0"
+    t.decimal "maintenance_out_all_sources", default: "0.0"
+    t.decimal "rent_or_mortgage_all_sources", default: "0.0"
+    t.decimal "legal_aid_all_sources", default: "0.0"
+    t.decimal "child_care_bank", default: "0.0"
+    t.decimal "maintenance_out_bank", default: "0.0"
+    t.decimal "rent_or_mortgage_bank", default: "0.0"
+    t.decimal "legal_aid_bank", default: "0.0"
+    t.decimal "child_care_cash", default: "0.0"
+    t.decimal "maintenance_out_cash", default: "0.0"
+    t.decimal "rent_or_mortgage_cash", default: "0.0"
+    t.decimal "legal_aid_cash", default: "0.0"
     t.index ["assessment_id"], name: "index_disposable_income_summaries_on_assessment_id"
   end
 

--- a/spec/factories/assessment_factory.rb
+++ b/spec/factories/assessment_factory.rb
@@ -7,6 +7,7 @@ FactoryBot.define do
     version { '2' }
 
     trait :with_v3 do
+      with_gross_income_summary_and_records
       version { '3' }
     end
 

--- a/spec/factories/cash_transaction_factory.rb
+++ b/spec/factories/cash_transaction_factory.rb
@@ -2,7 +2,7 @@ FactoryBot.define do
   factory :cash_transaction do
     cash_transaction_category
     date { Date.current }
-    amount { Faker::Number.decimal(l_digits: 3, r_digits: 2) }
+    amount { Faker::Number.decimal(l_digits: 2, r_digits: 2) }
     client_id { Faker::Internet.uuid }
   end
 end

--- a/spec/factories/disposable_income_summary_factory.rb
+++ b/spec/factories/disposable_income_summary_factory.rb
@@ -15,6 +15,10 @@ FactoryBot.define do
     upper_threshold { 0.0 }
     assessment_result { 'pending' }
 
+    trait :with_v3 do
+      assessment { create :assessment, :with_v3 }
+    end
+
     trait :with_everything do
       after(:create) do |rec|
         [Date.current, 1.month.ago, 2.months.ago].each do |date|

--- a/spec/factories/disposable_income_summary_factory.rb
+++ b/spec/factories/disposable_income_summary_factory.rb
@@ -1,11 +1,12 @@
 FactoryBot.define do
   factory :disposable_income_summary do
     assessment
-    childcare { 0.0 }
-    maintenance { 0.0 }
-    legal_aid { 0.0 }
+    child_care_bank { 0.0 }
+    maintenance_out_bank { 0.0 }
+    legal_aid_bank { 0.0 }
     dependant_allowance { 0.0 }
     gross_housing_costs { 0.0 }
+    rent_or_mortgage_bank { 0.0 }
     net_housing_costs { 0.0 }
     housing_benefit { 0.0 }
     total_outgoings_and_allowances { 0.0 }

--- a/spec/factories/gross_income_summary_factory.rb
+++ b/spec/factories/gross_income_summary_factory.rb
@@ -36,12 +36,34 @@ FactoryBot.define do
 
     trait :with_all_records do
       after(:create) do |gross_income_summary|
+        benefits_in_cash = create :cash_transaction_category, name: 'benefits', operation: 'credit', gross_income_summary: gross_income_summary
+        friends_or_family_in_cash = create :cash_transaction_category, name: 'friends_or_family', operation: 'credit', gross_income_summary: gross_income_summary
+        maintenance_in_cash = create :cash_transaction_category, name: 'maintenance_in', operation: 'credit', gross_income_summary: gross_income_summary
+        property_or_lodger_in_cash = create :cash_transaction_category, name: 'property_or_lodger', operation: 'credit', gross_income_summary: gross_income_summary
+        pension_in_cash = create :cash_transaction_category, name: 'pension', operation: 'credit', gross_income_summary: gross_income_summary
+        child_care_in_cash = create :cash_transaction_category, name: 'child_care', operation: 'debit', gross_income_summary: gross_income_summary
+        maintenance_out_in_cash = create :cash_transaction_category, name: 'maintenance_out', operation: 'debit', gross_income_summary: gross_income_summary
+        rent_or_mortgage_in_cash = create :cash_transaction_category, name: 'rent_or_mortgage', operation: 'debit', gross_income_summary: gross_income_summary
+        legal_aid_in_cash = create :cash_transaction_category, name: 'legal_aid', operation: 'debit', gross_income_summary: gross_income_summary
+
         create :state_benefit, :with_monthly_payments, gross_income_summary: gross_income_summary
         create :other_income_source, :with_monthly_payments, gross_income_summary: gross_income_summary, name: 'friends_or_family', monthly_income: 100
         create :other_income_source, :with_monthly_payments, gross_income_summary: gross_income_summary, name: 'maintenance_in', monthly_income: 200
         create :other_income_source, :with_monthly_payments, gross_income_summary: gross_income_summary, name: 'property_or_lodger', monthly_income: 300
         create :other_income_source, :with_monthly_payments, gross_income_summary: gross_income_summary, name: 'pension', monthly_income: 400
         create :irregular_income_payment, gross_income_summary: gross_income_summary
+
+        3.times do
+          create :cash_transaction, cash_transaction_category: benefits_in_cash
+          create :cash_transaction, cash_transaction_category: friends_or_family_in_cash
+          create :cash_transaction, cash_transaction_category: maintenance_in_cash
+          create :cash_transaction, cash_transaction_category: property_or_lodger_in_cash
+          create :cash_transaction, cash_transaction_category: pension_in_cash
+          create :cash_transaction, cash_transaction_category: child_care_in_cash
+          create :cash_transaction, cash_transaction_category: maintenance_out_in_cash
+          create :cash_transaction, cash_transaction_category: rent_or_mortgage_in_cash
+          create :cash_transaction, cash_transaction_category: legal_aid_in_cash
+        end
       end
     end
 

--- a/spec/models/cash_transaction_spec.rb
+++ b/spec/models/cash_transaction_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+describe CashTransaction do
+  let(:assessment1) { create :assessment, :with_v3 }
+  let(:assessment2) { create :assessment, :with_v3 }
+  let(:benefits_category1) { assessment1.cash_transaction_categories.detect { |cat| cat.name == 'benefits' } }
+  let(:benefits_category2) { assessment2.cash_transaction_categories.detect { |cat| cat.name == 'benefits' } }
+  let!(:benefits_transactions1) { benefits_category1.cash_transactions.order(:date) }
+  let!(:benefits_transactions2) { benefits_category2.cash_transactions.order(:date) }
+
+  describe 'by_operation_and_category' do
+    it 'display all the cash transactions for benefits 1' do
+      expect(CashTransaction.by_operation_and_category(assessment1, :credit, :benefits)).to eq benefits_transactions1
+    end
+
+    it 'display all the cash transactions for benefits 2' do
+      expect(CashTransaction.by_operation_and_category(assessment2, :credit, :benefits)).to eq benefits_transactions2
+    end
+  end
+end

--- a/spec/services/calculators/housing_costs_calculator_spec.rb
+++ b/spec/services/calculators/housing_costs_calculator_spec.rb
@@ -282,6 +282,293 @@ module Calculators
       end
     end
 
+    context 'version 3 including cash payments' do
+      let(:assessment) { create :assessment, :with_v3, :with_disposable_income_summary, with_child_dependants: children }
+      let(:rent_or_mortgage_category) { assessment.cash_transaction_categories.detect { |cat| cat.name == 'rent_or_mortgage' } }
+      let(:rent_or_mortgage_transactions) { rent_or_mortgage_category.cash_transactions.order(:date) }
+      let(:monthly_cash_housing) { rent_or_mortgage_transactions.average(:amount).round(2).to_d }
+
+      before do
+        subject
+        assessment.disposable_income_summary.reload
+        @assessment = assessment
+      end
+
+      context 'when applicant has no dependants' do
+        let(:housing_cost_amount) { 1200.00 }
+
+        context 'and does not receive housing benefit' do
+          context 'board and lodging' do
+            let(:housing_cost_type) { 'board_and_lodging' }
+            let(:housing_cost_amount) { 1500.00 }
+
+            it 'should cap the return' do
+              expect(calculator.gross_housing_costs).to eq 750.00.to_d + monthly_cash_housing
+              expect(calculator.monthly_housing_benefit).to eq 0.0
+              expect(calculator.net_housing_costs).to eq 545.00 # Cap applied
+            end
+
+            context 'when 50% of monthly bank outgoings are below the cap but overall above it when including cash payments' do
+              let(:housing_cost_amount) { 1088.00 }
+
+              it 'should return the gross cost as net' do
+                expect(calculator.gross_housing_costs).to eq 544.00.to_d + monthly_cash_housing
+                expect(calculator.monthly_housing_benefit).to eq 0.0
+                expect(calculator.net_housing_costs).to eq 545.00 # Cap applied
+              end
+            end
+
+            context 'when 50% of monthly bank and cash outgoings are below the cap' do
+              let(:housing_cost_amount) { 888.0 }
+
+              it 'should return the gross cost as net' do
+                expect(calculator.gross_housing_costs).to eq 444.0.to_d + monthly_cash_housing
+                expect(calculator.monthly_housing_benefit).to eq 0.0
+                expect(calculator.net_housing_costs).to eq 444.0.to_d + monthly_cash_housing
+              end
+            end
+          end
+
+          context 'rent' do
+            let(:housing_cost_type) { 'rent' }
+
+            it 'should cap the return' do
+              expect(calculator.gross_housing_costs).to eq 1200.00.to_d + monthly_cash_housing
+              expect(calculator.monthly_housing_benefit).to eq 0.0
+              expect(calculator.net_housing_costs).to eq 545.00 # Cap applied
+            end
+
+            context 'when net cost is below housing cap' do
+              let(:housing_cost_amount) { 420.00 }
+
+              it 'should return the net cost' do
+                expect(calculator.gross_housing_costs).to eq 420.00.to_d + monthly_cash_housing
+                expect(calculator.monthly_housing_benefit).to eq 0.0
+                expect(calculator.net_housing_costs).to eq 420.00 + monthly_cash_housing
+              end
+            end
+          end
+
+          context 'mortgage' do
+            let(:housing_cost_type) { 'mortgage' }
+
+            it 'should cap the return' do
+              expect(calculator.gross_housing_costs).to eq 1200.00.to_d + monthly_cash_housing
+              expect(calculator.monthly_housing_benefit).to eq 0.0
+              expect(calculator.net_housing_costs).to eq 545.00 # Cap applied
+            end
+
+            context 'when net cost is below housing cap' do
+              let(:housing_cost_amount) { 420.00 }
+
+              it 'should return the net cost' do
+                expect(calculator.gross_housing_costs).to eq 420.00.to_d + monthly_cash_housing
+                expect(calculator.monthly_housing_benefit).to eq 0.0
+                expect(calculator.net_housing_costs).to eq 420.00.to_d + monthly_cash_housing
+              end
+            end
+          end
+        end
+
+        context 'and receives housing benefit' do
+          let(:housing_benefit_amount) { 500.00 }
+          before { create_benefit_payments(housing_benefit_amount) }
+
+          context 'and pays board and lodging' do
+            let(:housing_cost_type) { 'board_and_lodging' }
+            let(:housing_cost_amount) { 1500.00 }
+            let(:housing_benefit_amount) { 100.00 }
+
+            it 'should cap the return' do
+              expect(calculator.gross_housing_costs).to eq 750.00.to_d + monthly_cash_housing
+              expect(calculator.monthly_housing_benefit).to eq 100.00
+              expect(calculator.net_housing_costs).to eq 545.00 # Cap applied
+            end
+          end
+
+          context 'rent' do
+            let(:housing_cost_type) { 'rent' }
+
+            it 'should cap the return' do
+              expect(calculator.gross_housing_costs).to eq 1200.00.to_d + monthly_cash_housing
+              expect(calculator.monthly_housing_benefit).to eq 500.0
+              expect(calculator.net_housing_costs).to eq 545.00 # Cap applied
+            end
+
+            context 'when net amount will be below the cap' do
+              let(:housing_cost_amount) { 1200.00 }
+              let(:housing_benefit_amount) { 500.00 }
+
+              it 'should cap the return' do
+                expect(calculator.gross_housing_costs).to eq 1200.00.to_d + monthly_cash_housing
+                expect(calculator.monthly_housing_benefit).to eq 500.0
+                expect(calculator.net_housing_costs).to eq 545.00 # Cap applied
+              end
+            end
+          end
+
+          context 'mortgage' do
+            let(:housing_cost_type) { 'mortgage' }
+
+            it 'should cap the return' do
+              expect(calculator.gross_housing_costs).to eq 1200.00.to_d + monthly_cash_housing
+              expect(calculator.monthly_housing_benefit).to eq 500.00
+              expect(calculator.net_housing_costs).to eq 545.00 # Cap applied
+            end
+
+            context 'when net amount will be below the cap' do
+              let(:housing_cost_amount) { 600.00 }
+              let(:housing_benefit_amount) { 200.00 }
+
+              it 'should return net as gross_cost minus housing_benefit' do
+                expect(calculator.gross_housing_costs).to eq 600.00.to_d + monthly_cash_housing
+                expect(calculator.monthly_housing_benefit).to eq 200.0
+                expect(calculator.net_housing_costs).to eq 400.00.to_d + monthly_cash_housing
+              end
+            end
+          end
+        end
+      end
+
+      context 'when applicant has dependants' do
+        let(:housing_cost_amount) { 1200.00 }
+        let(:children) { 1 }
+
+        context 'no housing benefit' do
+          context 'board and lodging' do
+            let(:housing_cost_type) { 'board_and_lodging' }
+            let(:housing_cost_amount) { 1500.00 }
+
+            it 'should record half the monthly housing cost' do
+              expect(calculator.gross_housing_costs).to eq 750.00.to_d + monthly_cash_housing
+              expect(calculator.monthly_housing_benefit).to eq 0.0
+              expect(calculator.net_housing_costs).to eq 750.00.to_d + monthly_cash_housing
+            end
+
+            context 'when net cost is below housing cap' do
+              let(:housing_cost_amount) { 900.00 }
+
+              it 'should return half the monthly housing cost' do
+                expect(calculator.gross_housing_costs).to eq 450.00.to_d + monthly_cash_housing
+                expect(calculator.monthly_housing_benefit).to eq 0.0
+                expect(calculator.net_housing_costs).to eq 450.00.to_d + monthly_cash_housing
+              end
+            end
+          end
+
+          context 'rent' do
+            let(:housing_cost_type) { 'rent' }
+
+            it 'should record the full monthly housing costs' do
+              expect(calculator.gross_housing_costs).to eq 1200.00.to_d + monthly_cash_housing
+              expect(calculator.monthly_housing_benefit).to eq 0.0
+              expect(calculator.net_housing_costs).to eq 1200.00.to_d + monthly_cash_housing
+            end
+
+            context 'when net cost is below housing cap' do
+              let(:housing_cost_amount) { 520.00 }
+
+              it 'should return the net cost' do
+                expect(calculator.gross_housing_costs).to eq 520.00.to_d + monthly_cash_housing
+                expect(calculator.monthly_housing_benefit).to eq 0.0
+                expect(calculator.net_housing_costs).to eq 520.00.to_d + monthly_cash_housing
+              end
+            end
+          end
+
+          context 'mortgage' do
+            let(:housing_cost_type) { 'mortgage' }
+            it 'should record the full monthly housing costs' do
+              expect(calculator.gross_housing_costs).to eq 1200.00.to_d + monthly_cash_housing
+              expect(calculator.monthly_housing_benefit).to eq 0.0
+              expect(calculator.net_housing_costs).to eq 1200.00.to_d + monthly_cash_housing
+            end
+
+            context 'when net cost is below housing cap' do
+              let(:housing_cost_amount) { 520.00 }
+
+              it 'should return the gross cost as net' do
+                expect(calculator.gross_housing_costs).to eq 520.00.to_d + monthly_cash_housing
+                expect(calculator.monthly_housing_benefit).to eq 0.0
+                expect(calculator.net_housing_costs).to eq 520.00.to_d + monthly_cash_housing
+              end
+            end
+          end
+        end
+
+        context 'housing benefit' do
+          let(:housing_benefit_amount) { 500.00 }
+          before { create_benefit_payments(housing_benefit_amount) }
+
+          context 'board and lodging' do
+            let(:housing_cost_type) { 'board_and_lodging' }
+            let(:housing_cost_amount) { 1200.00 }
+            let(:housing_benefit_amount) { 100.00 }
+
+            it 'should record half the monthly outgoing less the housing benefit' do
+              expect(calculator.gross_housing_costs).to eq 600.00.to_d + monthly_cash_housing
+              expect(calculator.monthly_housing_benefit).to eq 100.000
+              expect(calculator.net_housing_costs).to eq((housing_cost_amount.to_d + monthly_cash_housing - housing_benefit_amount.to_d) / 2)
+            end
+          end
+
+          context 'board and lodging different values' do
+            let(:housing_cost_type) { 'board_and_lodging' }
+            let(:housing_cost_amount) { 1500.00 }
+            let(:housing_benefit_amount) { 100.00 }
+
+            it 'should record half the housing cost less the housing benefit' do
+              expect(calculator.gross_housing_costs).to eq 750.00.to_d + monthly_cash_housing
+              expect(calculator.monthly_housing_benefit).to eq 100.00
+              expect(calculator.net_housing_costs).to eq((housing_cost_amount.to_d + monthly_cash_housing - housing_benefit_amount.to_d) / 2)
+            end
+          end
+
+          context 'rent' do
+            let(:housing_cost_type) { 'rent' }
+
+            it 'should record the full monthly housing costs' do
+              expect(calculator.gross_housing_costs).to eq 1200.00.to_d + monthly_cash_housing
+              expect(calculator.monthly_housing_benefit).to eq 500.00
+              expect(calculator.net_housing_costs).to eq 700.00.to_d + monthly_cash_housing
+            end
+
+            context 'when net cost is below housing cap' do
+              let(:housing_cost_amount) { 600.00 }
+              let(:housing_benefit_amount) { 200.00 }
+
+              it 'should return net as gross_cost minus housing_benefit' do
+                expect(calculator.gross_housing_costs).to eq 600.00.to_d + monthly_cash_housing
+                expect(calculator.monthly_housing_benefit).to eq 200.0
+                expect(calculator.net_housing_costs).to eq 400.00.to_d + monthly_cash_housing
+              end
+            end
+          end
+
+          context 'mortgage' do
+            let(:housing_cost_type) { 'mortgage' }
+
+            it 'should record the full housing costs less the housing benefit' do
+              expect(calculator.gross_housing_costs).to eq 1200.00.to_d + monthly_cash_housing
+              expect(calculator.monthly_housing_benefit).to eq 500.00
+              expect(calculator.net_housing_costs).to eq 700.00.to_d + monthly_cash_housing
+            end
+
+            context 'when net cost is below housing cap' do
+              let(:housing_cost_amount) { 600.00 }
+              let(:housing_benefit_amount) { 200.00 }
+
+              it 'should return net as gross_cost minus housing_benefit' do
+                expect(calculator.gross_housing_costs).to eq 600.00.to_d + monthly_cash_housing
+                expect(calculator.monthly_housing_benefit).to eq 200.0
+                expect(calculator.net_housing_costs).to eq 400.00.to_d + monthly_cash_housing
+              end
+            end
+          end
+        end
+      end
+    end
+
     def create_benefit_payments(amount)
       housing_benefit_type = create :state_benefit_type, label: 'housing_benefit'
       state_benefit = create :state_benefit, gross_income_summary: assessment.gross_income_summary, state_benefit_type: housing_benefit_type

--- a/spec/services/collators/childcare_collator_spec.rb
+++ b/spec/services/collators/childcare_collator_spec.rb
@@ -74,14 +74,14 @@ module Collators
 
             it 'updates the childcare value on the disposable income summary' do
               subject
-              expect(disposable_income_summary.childcare).to eq 155.63
+              expect(disposable_income_summary.child_care_bank).to eq 155.63
             end
           end
 
           context 'not in receipt of Student grant' do
             it 'updates the childcare value on the disposable income summary' do
               subject
-              expect(disposable_income_summary.childcare).to eq 155.63
+              expect(disposable_income_summary.child_care_bank).to eq 155.63
             end
           end
         end
@@ -91,7 +91,7 @@ module Collators
             before { create :irregular_income_payment, amount: 0.0, gross_income_summary: gross_income_summary }
             it 'updates the childcare value on the disposable income summary' do
               subject
-              expect(disposable_income_summary.childcare).to eq 155.63
+              expect(disposable_income_summary.child_care_bank).to eq 155.63
             end
           end
 
@@ -99,7 +99,7 @@ module Collators
             before { create :other_income_source, gross_income_summary: gross_income_summary, name: 'friends_or_family' }
             it 'does not update the childcare value on the disposable income summary' do
               subject
-              expect(disposable_income_summary.childcare).to eq 0.0
+              expect(disposable_income_summary.child_care_bank).to eq 0.0
             end
           end
         end

--- a/spec/services/collators/disposable_income_collator_spec.rb
+++ b/spec/services/collators/disposable_income_collator_spec.rb
@@ -74,6 +74,94 @@ module Collators
           end
         end
       end
+
+      context 'version 3' do
+        let(:disposable_income_summary) do
+          create :disposable_income_summary, :with_v3,
+                 child_care_bank: child_care_bank,
+                 maintenance_out_bank: maintenance_out_bank,
+                 gross_housing_costs: gross_housing,
+                 rent_or_mortgage_bank: gross_housing,
+                 legal_aid_bank: legal_aid_bank,
+                 housing_benefit: housing_benefit,
+                 net_housing_costs: net_housing,
+                 total_outgoings_and_allowances: 0.0,
+                 dependant_allowance: dependant_allowance,
+                 total_disposable_income: 0.0,
+                 lower_threshold: 0.0,
+                 upper_threshold: 0.0
+        end
+
+        let(:total_outgoings) do
+          disposable_income_summary.child_care_cash +
+            disposable_income_summary.maintenance_out_cash +
+            disposable_income_summary.rent_or_mortgage_cash +
+            disposable_income_summary.legal_aid_cash +
+            disposable_income_summary.child_care_bank +
+            disposable_income_summary.maintenance_out_bank +
+            disposable_income_summary.legal_aid_bank +
+            net_housing +
+            dependant_allowance
+        end
+
+        context 'total_monthly_outgoings' do
+          it 'sums childcare, legal_aid, maintenance and housing costs' do
+            subject
+            expect(disposable_income_summary.reload.total_outgoings_and_allowances).to eq total_outgoings
+          end
+        end
+
+        context 'total disposable income' do
+          before do
+            assessment.gross_income_summary.update!(total_gross_income: total_outgoings + 1500.0)
+          end
+          it 'is populated with result of gross income minus total outgoings and allowances' do
+            subject
+            result = assessment.gross_income_summary.total_gross_income - disposable_income_summary.reload.total_outgoings_and_allowances
+            expect(disposable_income_summary.total_disposable_income).to eq result
+          end
+        end
+
+        context 'lower threshold' do
+          it 'populates the lower threshold' do
+            subject
+            expect(disposable_income_summary.lower_threshold).to eq 315.0
+          end
+        end
+
+        context 'upper threshold' do
+          context 'domestic abuse' do
+            it 'populates it with infinity' do
+              subject
+              expect(disposable_income_summary.upper_threshold).to eq 999_999_999_999.0
+            end
+          end
+
+          context 'non_domestic_abuse' do
+            it 'populates it with the standard upper limit' do
+              expect(assessment).to receive(:matter_proceeding_type).and_return('housing')
+              subject
+              expect(disposable_income_summary.upper_threshold).to eq 733.0
+            end
+          end
+        end
+
+        context 'all transactions' do
+          it 'updates with totals for all categories based on bank and cash transactions' do
+            subject
+            disposable_income_summary.reload
+            child_care_total = disposable_income_summary.child_care_bank + disposable_income_summary.child_care_cash
+            maintenance_out_total = disposable_income_summary.maintenance_out_bank + disposable_income_summary.maintenance_out_cash
+            rent_or_mortgage_total = disposable_income_summary.rent_or_mortgage_bank + disposable_income_summary.rent_or_mortgage_cash
+            legal_aid_total = disposable_income_summary.legal_aid_bank + disposable_income_summary.legal_aid_cash
+
+            expect(disposable_income_summary.child_care_all_sources).to eq child_care_total
+            expect(disposable_income_summary.maintenance_out_all_sources).to eq maintenance_out_total
+            expect(disposable_income_summary.rent_or_mortgage_all_sources).to eq rent_or_mortgage_total
+            expect(disposable_income_summary.legal_aid_all_sources).to eq legal_aid_total
+          end
+        end
+      end
     end
   end
 end

--- a/spec/services/collators/disposable_income_collator_spec.rb
+++ b/spec/services/collators/disposable_income_collator_spec.rb
@@ -97,9 +97,9 @@ module Collators
             disposable_income_summary.maintenance_out_cash +
             disposable_income_summary.rent_or_mortgage_cash +
             disposable_income_summary.legal_aid_cash +
-            disposable_income_summary.child_care_bank +
-            disposable_income_summary.maintenance_out_bank +
-            disposable_income_summary.legal_aid_bank +
+            child_care_bank +
+            maintenance_out_bank +
+            legal_aid_bank +
             net_housing +
             dependant_allowance
         end

--- a/spec/services/collators/disposable_income_collator_spec.rb
+++ b/spec/services/collators/disposable_income_collator_spec.rb
@@ -3,22 +3,23 @@ require 'rails_helper'
 module Collators
   RSpec.describe DisposableIncomeCollator do
     let(:assessment)  { disposable_income_summary.assessment }
-    let(:childcare) { Faker::Number.decimal(l_digits: 3, r_digits: 2).to_d }
-    let(:maintenance) { Faker::Number.decimal(l_digits: 3, r_digits: 2).to_d }
+    let(:child_care_bank) { Faker::Number.decimal(l_digits: 3, r_digits: 2).to_d }
+    let(:maintenance_out_bank) { Faker::Number.decimal(l_digits: 3, r_digits: 2).to_d }
     let(:gross_housing) { Faker::Number.decimal(l_digits: 3, r_digits: 2).to_d }
-    let(:legal_aid) { Faker::Number.decimal(l_digits: 3, r_digits: 2).to_d }
+    let(:legal_aid_bank) { Faker::Number.decimal(l_digits: 3, r_digits: 2).to_d }
     let(:housing_benefit) { Faker::Number.between(from: 1.25, to: gross_housing / 2).round(2) }
     let(:net_housing) { gross_housing - housing_benefit }
-    let(:total_outgoings) { childcare + maintenance + net_housing + dependant_allowance + legal_aid }
+    let(:total_outgoings) { child_care_bank + maintenance_out_bank + net_housing + dependant_allowance + legal_aid_bank }
 
     let(:dependant_allowance) { 582.98 }
 
     let(:disposable_income_summary) do
       create :disposable_income_summary,
-             childcare: childcare,
-             maintenance: maintenance,
+             child_care_bank: child_care_bank,
+             maintenance_out_bank: maintenance_out_bank,
              gross_housing_costs: gross_housing,
-             legal_aid: legal_aid,
+             rent_or_mortgage_bank: gross_housing,
+             legal_aid_bank: legal_aid_bank,
              housing_benefit: housing_benefit,
              net_housing_costs: net_housing,
              total_outgoings_and_allowances: 0.0,

--- a/spec/services/collators/disposable_income_collator_spec.rb
+++ b/spec/services/collators/disposable_income_collator_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 module Collators
   RSpec.describe DisposableIncomeCollator do
-    let(:assessment)  { disposable_income_summary.assessment }
+    let(:assessment) { disposable_income_summary.assessment }
     let(:child_care_bank) { Faker::Number.decimal(l_digits: 3, r_digits: 2).to_d }
     let(:maintenance_out_bank) { Faker::Number.decimal(l_digits: 3, r_digits: 2).to_d }
     let(:gross_housing) { Faker::Number.decimal(l_digits: 3, r_digits: 2).to_d }

--- a/spec/services/collators/gross_income_collator_spec.rb
+++ b/spec/services/collators/gross_income_collator_spec.rb
@@ -130,21 +130,9 @@ module Collators
       end
 
       context 'version 3' do
-        let(:assessment) { create :assessment, :with_gross_income_summary_and_records, :with_applicant, :with_v3 }
-        let(:benefits_in_cash) { create :cash_transaction_category, name: 'benefits', operation: 'credit', gross_income_summary: gross_income_summary }
-        let(:friends_or_family_in_cash) { create :cash_transaction_category, name: 'friends_or_family', operation: 'credit', gross_income_summary: gross_income_summary }
-        let(:maintenance_in_cash) { create :cash_transaction_category, name: 'maintenance_in', operation: 'credit', gross_income_summary: gross_income_summary }
-        let(:property_or_lodger_in_cash) { create :cash_transaction_category, name: 'property_or_lodger', operation: 'credit', gross_income_summary: gross_income_summary }
-        let(:pension_in_cash) { create :cash_transaction_category, name: 'pension', operation: 'credit', gross_income_summary: gross_income_summary }
+        let(:assessment) { create :assessment, :with_applicant, :with_v3 }
 
         before do
-          3.times do
-            create :cash_transaction, cash_transaction_category: benefits_in_cash
-            create :cash_transaction, cash_transaction_category: friends_or_family_in_cash
-            create :cash_transaction, cash_transaction_category: maintenance_in_cash
-            create :cash_transaction, cash_transaction_category: property_or_lodger_in_cash
-            create :cash_transaction, cash_transaction_category: pension_in_cash
-          end
           subject
           gross_income_summary.reload
         end

--- a/spec/services/collators/legal_aid_collator_spec.rb
+++ b/spec/services/collators/legal_aid_collator_spec.rb
@@ -13,7 +13,7 @@ module Collators
       context 'when there are no legal_aid outgoings' do
         it 'leaves the monthly maintenance field on the disposable income summary as zero' do
           subject
-          expect(disposable_income_summary.reload.legal_aid).to be_zero
+          expect(disposable_income_summary.reload.legal_aid_bank).to be_zero
         end
       end
 
@@ -32,7 +32,7 @@ module Collators
 
         it 'calculates the monthly equivalent and updates the disposable income summary' do
           subject
-          expect(disposable_income_summary.reload.legal_aid).to eq 112.08
+          expect(disposable_income_summary.reload.legal_aid_bank).to eq 112.08
         end
       end
     end

--- a/spec/services/collators/maintenance_collator_spec.rb
+++ b/spec/services/collators/maintenance_collator_spec.rb
@@ -13,7 +13,7 @@ module Collators
       context 'when there are no maintenance outgoings' do
         it 'leaves the monthly maintenance field on the disposable income summary as zero' do
           subject
-          expect(disposable_income_summary.reload.maintenance).to be_zero
+          expect(disposable_income_summary.reload.maintenance_out_bank).to be_zero
         end
       end
 
@@ -32,7 +32,7 @@ module Collators
 
         it 'calculates the monthly equivalent and updates the disposable income summary' do
           subject
-          expect(disposable_income_summary.reload.maintenance).to eq 112.08
+          expect(disposable_income_summary.reload.maintenance_out_bank).to eq 112.08
         end
       end
     end

--- a/spec/services/decorators/disposable_income_summary_decorator_spec.rb
+++ b/spec/services/decorators/disposable_income_summary_decorator_spec.rb
@@ -17,7 +17,7 @@ module Decorators
         let!(:gross_income_summary) { create :gross_income_summary, assessment: disposable_income_summary.assessment }
         it 'has the expected keys in the response structure' do
           expected_keys = %i[
-            monthly_outgoing_equivalents
+            monthly_equivalents
             childcare_allowance
             deductions
             dependant_allowance
@@ -34,7 +34,7 @@ module Decorators
           ]
           expect(subject.keys).to eq expected_keys
           outgoings_keys = %i[child_care maintenance_out rent_or_mortgage legal_aid]
-          expect(subject[:monthly_outgoing_equivalents].keys).to eq outgoings_keys
+          expect(subject[:monthly_equivalents].keys).to eq outgoings_keys
         end
       end
     end

--- a/spec/services/decorators/disposable_income_summary_decorator_spec.rb
+++ b/spec/services/decorators/disposable_income_summary_decorator_spec.rb
@@ -37,6 +37,38 @@ module Decorators
           expect(subject[:monthly_outgoing_equivalents].keys).to eq outgoings_keys
         end
       end
+
+      context 'version 3' do
+        let(:disposable_income_summary) { create :disposable_income_summary, :with_everything, :with_v3 }
+        let!(:gross_income_summary) { create :gross_income_summary, assessment: disposable_income_summary.assessment }
+        it 'has the expected keys in the response structure' do
+          expected_keys = %i[
+            monthly_equivalents
+            childcare_allowance
+            deductions
+            dependant_allowance
+            maintenance_allowance
+            gross_housing_costs
+            housing_benefit
+            net_housing_costs
+            total_outgoings_and_allowances
+            total_disposable_income
+            lower_threshold
+            upper_threshold
+            assessment_result
+            income_contribution
+          ]
+          expect(subject.keys).to eq expected_keys
+          expect(subject[:monthly_equivalents].keys).to eq %i[bank_transactions cash_transactions all_sources]
+        end
+
+        it 'has transaction types which contain all transaction categories' do
+          outgoings_keys = CFEConstants::VALID_OUTGOING_CATEGORIES.map(&:to_sym)
+          expect(subject[:monthly_equivalents][:bank_transactions].keys).to eq outgoings_keys
+          expect(subject[:monthly_equivalents][:cash_transactions].keys).to eq outgoings_keys
+          expect(subject[:monthly_equivalents][:all_sources].keys).to eq outgoings_keys
+        end
+      end
     end
   end
 end

--- a/spec/services/decorators/disposable_income_summary_decorator_spec.rb
+++ b/spec/services/decorators/disposable_income_summary_decorator_spec.rb
@@ -17,7 +17,7 @@ module Decorators
         let!(:gross_income_summary) { create :gross_income_summary, assessment: disposable_income_summary.assessment }
         it 'has the expected keys in the response structure' do
           expected_keys = %i[
-            monthly_equivalents
+            monthly_outgoing_equivalents
             childcare_allowance
             deductions
             dependant_allowance
@@ -33,8 +33,8 @@ module Decorators
             income_contribution
           ]
           expect(subject.keys).to eq expected_keys
-          outgoings_keys = %i[child_care maintenance_out rent_or_mortgage legal_aid]
-          expect(subject[:monthly_equivalents].keys).to eq outgoings_keys
+          outgoings_keys = CFEConstants::VALID_OUTGOING_CATEGORIES.map(&:to_sym)
+          expect(subject[:monthly_outgoing_equivalents].keys).to eq outgoings_keys
         end
       end
     end

--- a/spec/services/decorators/gross_income_summary_decorator_spec.rb
+++ b/spec/services/decorators/gross_income_summary_decorator_spec.rb
@@ -66,7 +66,8 @@ module Decorators
 
           it 'returns a hash with the expected keys' do
             expected_keys = %i[summary
-                               student_loan
+                               irregular_income
+                               state_benefits
                                other_income]
             expect(subject.keys).to eq expected_keys
           end
@@ -79,8 +80,8 @@ module Decorators
           end
 
           it 'returns expected keys for student_loan' do
-            expected_keys = %i[monthly_equivalents]
-            expect(subject[:student_loan].keys).to match expected_keys
+            expected_keys = %i[student_loan]
+            expect(subject[:irregular_income][:monthly_equivalents].keys).to match expected_keys
           end
 
           it 'calls the OtherIncomeSourceDecorator once' do

--- a/spec/services/decorators/other_income_source_decorator_spec.rb
+++ b/spec/services/decorators/other_income_source_decorator_spec.rb
@@ -34,25 +34,22 @@ module Decorators
         subject { described_class.new(record).as_json }
 
         let(:record) { create :gross_income_summary, :with_everything, :with_all_transaction_types, :with_v3 }
-        it 'returns expected hash' do
+        it 'returns expected hash containing monthly transactions for all income types except benefits' do
           expected_hash = {
             monthly_equivalents: {
               bank_transactions: {
-                benefits: 34.16,
                 friends_or_family: 7.47,
                 maintenance_in: 115.04,
                 property_or_lodger: 483.47,
                 pension: 27.4
               },
               cash_transactions: {
-                benefits: 1038.07,
                 friends_or_family: 255.34,
                 maintenance_in: 1038.07,
                 property_or_lodger: 0.0,
                 pension: 0.0
               },
               all_sources: {
-                benefits: 1072.23,
                 friends_or_family: 262.81,
                 maintenance_in: 1153.11,
                 property_or_lodger: 483.47,

--- a/spec/services/decorators/state_benefit_decorator_spec.rb
+++ b/spec/services/decorators/state_benefit_decorator_spec.rb
@@ -3,24 +3,45 @@ require 'rails_helper'
 module Decorators
   RSpec.describe StateBenefitDecorator do
     describe '#as_json' do
-      let(:record) { create :state_benefit, :with_monthly_payments, name: 'Childcare allowance' }
-      let(:excluded) { record.state_benefit_type.exclude_from_gross_income }
+      before { create :disposable_income_summary, :with_everything, assessment: gross_income_summary.assessment }
 
-      subject { described_class.new(record).as_json }
+      let(:state_benefit) { create :state_benefit, :with_monthly_payments, name: 'Childcare allowance' }
+      let(:excluded) { state_benefit.state_benefit_type.exclude_from_gross_income }
 
-      it 'returns the expected hash' do
-        expected_hash = {
-          name: 'Childcare allowance',
-          monthly_value: 88.3,
-          excluded_from_income_assessment: excluded,
-          state_benefit_payments:
-            [
-              { payment_date: Date.current, amount: 88.30 },
-              { payment_date: 1.month.ago.to_date, amount: 88.3 },
-              { payment_date: 2.months.ago.to_date, amount: 88.3 }
-            ]
-        }
-        expect(subject).to eq expected_hash
+      subject { described_class.new(gross_income_summary, state_benefit).as_json }
+
+      context 'v2' do
+        let!(:gross_income_summary) { create :gross_income_summary, :with_irregular_income_payments }
+
+        it 'returns the expected hash' do
+          expected_hash = {
+            name: 'Childcare allowance',
+            monthly_value: 88.3,
+            excluded_from_income_assessment: excluded,
+            state_benefit_payments:
+              [
+                { payment_date: Date.current, amount: 88.30 },
+                { payment_date: 1.month.ago.to_date, amount: 88.3 },
+                { payment_date: 2.months.ago.to_date, amount: 88.3 }
+              ]
+          }
+          expect(subject).to eq expected_hash
+        end
+      end
+
+      context 'v3' do
+        let!(:gross_income_summary) { create :gross_income_summary, :with_all_transaction_types, :with_v3 }
+
+        it 'returns the expected hash' do
+          expected_hash = {
+            name: 'Childcare allowance',
+            bank_transactions: 88.3,
+            cash_transactions: 1038.07,
+            all_sources: 1072.23,
+            excluded_from_income_assessment: excluded
+          }
+          expect(subject).to eq expected_hash
+        end
       end
     end
   end

--- a/spec/services/remark_generators/amount_variation_checker_spec.rb
+++ b/spec/services/remark_generators/amount_variation_checker_spec.rb
@@ -92,7 +92,7 @@ module RemarkGenerators
         end
 
         context 'if the childcare costs are allowed as an outgoing' do
-          before { disposable_income_summary.childcare = 1 }
+          before { disposable_income_summary.child_care_bank = 1 }
 
           it 'adds the remark' do
             expect_any_instance_of(Remarks).to receive(:add).with(:outgoings_childcare, :amount_variation, collection.map(&:client_id))

--- a/spec/services/remark_generators/frequency_checker_spec.rb
+++ b/spec/services/remark_generators/frequency_checker_spec.rb
@@ -85,7 +85,7 @@ module RemarkGenerators
             ]
           end
           context 'if the childcare costs are allowed as an outgoing' do
-            before { disposable_income_summary.childcare = 1 }
+            before { disposable_income_summary.child_care_bank = 1 }
 
             it 'adds the remark' do
               expect_any_instance_of(Remarks).to receive(:add).with(:outgoings_childcare, :unknown_frequency, collection.map(&:client_id))


### PR DESCRIPTION
## What

[AP-1983](https://dsdmoj.atlassian.net/browse/AP-1983)

Add new fields to disposable income summary table and ensure formatting correctly in json response for assessment version 3 only.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
