### PR TITLE
AP-2111 format error messages instead of crashing

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -9,7 +9,8 @@ class ApplicationController < ActionController::API
   end
 
   def render_unprocessable(message)
-    Raven.capture_message(message)
+    raven_message = message.is_a?(Array) ? message.join(', ') : message
+    Raven.capture_message(raven_message)
     render json: { success: false, errors: message }, status: :unprocessable_entity
   end
 


### PR DESCRIPTION
## format error messages instead of crashing

[Link to story](https://dsdmoj.atlassian.net/browse/AP-2111)

CFE is crashing instead of formatting a proper error message and sending it to Sentry.  This is the first fix that will format an array of error messages as a string so that Sentry can display it properly.  Then we will be able to see what the cause of the error is and fix that.

## Checklist

Before you ask people to review this PR:

- [ ] Tests and rubocop should be passing: `bundle exec rake`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [ ] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [ ] The PR description should say what you changed and why, with a link to the JIRA story.
- [ ] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
