### PR TITLE
Bug-fix: dependant-allowances

### DIFF
--- a/config/thresholds/28-Jan-2021.yml
+++ b/config/thresholds/28-Jan-2021.yml
@@ -33,10 +33,10 @@ vehicle_disregard: 15_000
 vehicle_out_of_scope_months: 36
 
 dependant_allowances:
-  child_under_15: 291.49
-  child_aged_15: 291.49
-  child_16_and_over: 291.49
-  adult: 291.49
+  child_under_15: 296.65
+  child_aged_15: 296.65
+  child_16_and_over: 296.65
+  adult: 296.65
   adult_capital_threshold: 8_000
 
 single_monthly_housing_costs_cap: 545


### PR DESCRIPTION
## What
The copy of rates was taken from a previous year
this caused a regression of the dependant_allowances

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
