### PR TITLE
Tech-debt: remove climate-control

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -82,7 +82,6 @@ group :development do
 end
 
 group :test do
-  gem 'climate_control' # Allows environment variables to be modified within specs
   gem 'database_cleaner'
   gem 'shoulda-matchers'
   gem 'simplecov', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -80,7 +80,6 @@ GEM
     byebug (11.1.3)
     case_transform (0.2)
       activesupport
-    climate_control (0.2.0)
     coderay (1.1.3)
     colorize (0.8.1)
     concurrent-ruby (1.1.8)
@@ -366,7 +365,6 @@ DEPENDENCIES
   bootsnap (>= 1.1.0)
   business (~> 2.2)
   byebug
-  climate_control
   colorize
   database_cleaner
   descriptive_statistics

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -96,9 +96,3 @@ end
 def json_schema_definitions
   File.read(Rails.root.join('public/schemas/assessment_request.json'))
 end
-
-# Modify ENV variables within a spec. See:
-#   https://github.com/thoughtbot/climate_control
-def with_modified_env(options, &block)
-  ClimateControl.modify(options, &block)
-end


### PR DESCRIPTION
## What

This is configured in rails helper but not actually used in the 
codebase (There are no uses of the `with_modified_env` method)
so, rather than update the gem we are removing it!

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
