### PR TITLE
AP-2057 Migrate to sentry-ruby from sentry-raven

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,6 @@ gem 'rails', '~> 6.1.3'
 gem 'pg', '>= 0.18', '< 2.0'
 # Use Puma as the app server
 gem 'puma', '~> 5.2'
-gem 'sentry-raven'
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
 # gem 'jbuilder', '~> 2.5'
 # Use Redis adapter to run Action Cable in production
@@ -20,6 +19,9 @@ gem 'sentry-raven'
 
 # Use ActiveStorage variant
 # gem 'mini_magick', '~> 4.8'
+
+gem 'sentry-rails'
+gem 'sentry-ruby'
 
 # Use Capistrano for deployment
 # gem 'capistrano-rails', group: :development

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -308,8 +308,16 @@ GEM
     rubyzip (2.3.0)
     secure_headers (6.3.2)
     semantic_range (2.3.0)
-    sentry-raven (3.1.2)
+    sentry-rails (4.3.3)
+      railties (>= 5.0)
+      sentry-ruby-core (~> 4.3.0)
+    sentry-ruby (4.3.1)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
       faraday (>= 1.0)
+      sentry-ruby-core (= 4.3.1)
+    sentry-ruby-core (4.3.1)
+      concurrent-ruby
+      faraday
     shellany (0.0.1)
     shoulda-matchers (4.5.1)
       activesupport (>= 4.2.0)
@@ -397,7 +405,8 @@ DEPENDENCIES
   rubocop-performance
   rubocop-rails
   secure_headers
-  sentry-raven
+  sentry-rails
+  sentry-ruby
   shoulda-matchers
   simplecov
   simplecov-rcov
@@ -413,4 +422,4 @@ RUBY VERSION
    ruby 2.7.2p137
 
 BUNDLED WITH
-   2.1.4
+   2.2.8

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,16 +1,16 @@
 class ApplicationController < ActionController::API
   rescue_from StandardError do |e|
-    Raven.capture_exception(e)
+    Sentry.capture_exception(e)
     render json: { success: false, errors: ["#{e.class}: #{e.message}"] }, status: :unprocessable_entity
   end
   rescue_from Apipie::ParamError do |e|
-    Raven.capture_exception(e)
+    Sentry.capture_exception(e)
     render json: { success: false, errors: [e.message] }, status: :unprocessable_entity
   end
 
   def render_unprocessable(message)
-    raven_message = message.is_a?(Array) ? message.join(', ') : message
-    Raven.capture_message(raven_message)
+    sentry_message = message.is_a?(Array) ? message.join(', ') : message
+    Sentry.capture_message(sentry_message)
     render json: { success: false, errors: message }, status: :unprocessable_entity
   end
 

--- a/app/controllers/assessments_controller.rb
+++ b/app/controllers/assessments_controller.rb
@@ -59,7 +59,7 @@ class AssessmentsController < ApplicationController
   def show
     determine_version_and_process
   rescue StandardError => err
-    Raven.capture_exception(err)
+    Sentry.capture_exception(err)
     render json: Decorators::ErrorDecorator.new(err).as_json, status: :unprocessable_entity
   end
 

--- a/config/initializers/raven.rb
+++ b/config/initializers/raven.rb
@@ -1,9 +1,0 @@
-require 'raven'
-
-if %w[production].include?(Rails.env) && ENV['SENTRY_DSN'].present?
-  Raven.configure do |config|
-    config.dsn = ENV['SENTRY_DSN']
-    config.environments = %w[production]
-    config.sanitize_fields = Rails.application.config.filter_parameters.map(&:to_s)
-  end
-end

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,0 +1,14 @@
+require 'sentry-ruby'
+require 'sentry-rails'
+
+if %w[production].include?(Rails.env) && ENV['SENTRY_DSN'].present?
+  Sentry.init do |config|
+    config.dsn = ENV['SENTRY_DSN']
+
+    filter = ActiveSupport::ParameterFilter.new(Rails.application.config.filter_parameters.map(&:to_s))
+
+    config.before_send = ->(event, _hint) do
+      filter.filter(event.to_hash)
+    end
+  end
+end

--- a/spec/requests/application_controller_spec.rb
+++ b/spec/requests/application_controller_spec.rb
@@ -45,8 +45,8 @@ RSpec.describe ApplicationController, type: :request do
       expect(parsed_response).to eq JSON.parse(expected_response, symbolize_names: true)
     end
 
-    it 'is captured by Raven' do
-      expect(Raven).to receive(:capture_exception).with(instance_of(ZeroDivisionError))
+    it 'is captured by Sentry' do
+      expect(Sentry).to receive(:capture_exception).with(instance_of(ZeroDivisionError))
       get '/my_test?raise_error=1'
     end
 
@@ -60,8 +60,8 @@ RSpec.describe ApplicationController, type: :request do
         expect(parsed_response).to eq JSON.parse(expected_response, symbolize_names: true)
       end
 
-      it 'is a captured message by Raven' do
-        expect(Raven).to receive(:capture_exception).with(instance_of(Apipie::ParamError))
+      it 'is a captured message by Sentry' do
+        expect(Sentry).to receive(:capture_exception).with(instance_of(Apipie::ParamError))
         get '/my_test?param_error=1'
       end
     end

--- a/spec/requests/assessments_spec.rb
+++ b/spec/requests/assessments_spec.rb
@@ -262,7 +262,7 @@ RSpec.describe AssessmentsController, type: :request do
       end
 
       it 'captures error' do
-        expect(Raven).to receive(:capture_exception).with(message_contains('Unsupported version specified in AcceptHeader'))
+        expect(Sentry).to receive(:capture_exception).with(message_contains('Unsupported version specified in AcceptHeader'))
         subject
       end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,7 +8,7 @@ SimpleCov.minimum_coverage 100 unless ENV['SKIP_COVERAGE']
 unless ENV['NOCOVERAGE']
   SimpleCov.start do
     add_filter 'spec/'
-    add_filter 'config/initializers/raven.rb'
+    add_filter 'config/initializers/sentry.rb'
     add_filter 'lib/integration_helpers'
   end
 


### PR DESCRIPTION
## AP-2057 Migrate to sentry-ruby from sentry-raven

[Link to story](https://dsdmoj.atlassian.net/browse/AP-2057)

This is becasue the old sentry-raven client has entered maintenance mode.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
