### PR TITLE
AP-2175 Threshold waiver by proceeding type

### DIFF
--- a/app/models/proceeding_type_threshold.rb
+++ b/app/models/proceeding_type_threshold.rb
@@ -1,0 +1,104 @@
+# This class returns the correct threshold for a specified proceeding type
+#
+class ProceedingTypeThreshold
+  WAIVABLE_THRESHOLDS = %i[capital_upper gross_income_upper disposable_income_upper].freeze
+
+  WAIVERS = {
+    DA001: {
+      capital_upper: true,
+      gross_income_upper: true,
+      disposable_income_upper: true
+    },
+    DA002: {
+      capital_upper: true,
+      gross_income_upper: true,
+      disposable_income_upper: true
+    },
+    DA003: {
+      capital_upper: true,
+      gross_income_upper: true,
+      disposable_income_upper: true
+    },
+    DA004: {
+      capital_upper: true,
+      gross_income_upper: true,
+      disposable_income_upper: true
+    },
+    DA005: {
+      capital_upper: true,
+      gross_income_upper: true,
+      disposable_income_upper: true
+    },
+    DA006: {
+      capital_upper: true,
+      gross_income_upper: true,
+      disposable_income_upper: true
+    },
+    DA007: {
+      capital_upper: true,
+      gross_income_upper: true,
+      disposable_income_upper: true
+    },
+    DA020: {
+      capital_upper: true,
+      gross_income_upper: true,
+      disposable_income_upper: true
+    },
+    SE003: {
+      capital_upper: false,
+      gross_income_upper: false,
+      disposable_income_upper: false
+    },
+    SE004: {
+      capital_upper: false,
+      gross_income_upper: false,
+      disposable_income_upper: false
+    },
+    SE013: {
+      capital_upper: false,
+      gross_income_upper: false,
+      disposable_income_upper: false
+    },
+    SE014: {
+      capital_upper: false,
+      gross_income_upper: false,
+      disposable_income_upper: false
+    }
+  }.freeze
+
+  def self.value_for(ccms_code, threshold, at)
+    new(ccms_code, threshold, at).value
+  end
+
+  def initialize(ccms_code, threshold, at)
+    @ccms_code = ccms_code
+    @threshold = threshold
+    @at = at
+  end
+
+  def value
+    waivable_threshold? ? waivable_value : standard_value
+  end
+
+  private
+
+  def waivable_threshold?
+    @threshold.in?(WAIVABLE_THRESHOLDS)
+  end
+
+  def standard_value
+    Threshold.value_for(@threshold, at: @at)
+  end
+
+  def waivable_value
+    waived? ? waived_value : standard_value
+  end
+
+  def waived_value
+    Threshold.value_for(:infinite_gross_income_upper, at: @at)
+  end
+
+  def waived?
+    WAIVERS.fetch(@ccms_code).fetch(@threshold)
+  end
+end

--- a/spec/models/proceeding_type_threshold_spec.rb
+++ b/spec/models/proceeding_type_threshold_spec.rb
@@ -1,0 +1,74 @@
+require 'rails_helper'
+
+RSpec.describe ProceedingTypeThreshold do
+  let(:date) { Date.new(2021, 4, 9) }
+  let(:waivable_codes) { %i[DA001 DA002 DA003 DA004 DA005 DA006 DA007 DA020] }
+  let(:unwaivable_codes) { %i[SE003 SE004 SE013 SE014] }
+  let(:all_codes) { waivable_codes + unwaivable_codes }
+
+  subject { described_class.value_for(ccms_code, threshold, date) }
+
+  describe '.value_for' do
+    let(:ccms_code) { all_codes.sample }
+    let(:threshold) { :capital_lower }
+
+    context 'not a waivable threshold' do
+      it 'forwards the request on to Threshold' do
+        expect(Threshold).to receive(:value_for).with(threshold, at: date)
+        subject
+      end
+
+      it 'gets standard value' do
+        expect(subject).to eq 3_000
+      end
+    end
+
+    context 'waivable threshold' do
+      let(:threshold) { described_class::WAIVABLE_THRESHOLDS.sample }
+      context 'waived ccms_code' do
+        let(:ccms_code) { waivable_codes.sample }
+
+        it 'gets the infinite_gross_income_upper from Threshold' do
+          expect(Threshold).to receive(:value_for).with(:infinite_gross_income_upper, at: date)
+          subject
+        end
+
+        it 'returns the infinite upper value' do
+          expect(subject).to eq 999_999_999_999
+        end
+      end
+
+      context 'un-waived ccms code' do
+        let(:ccms_code) { unwaivable_codes.sample }
+        it 'gets passes the call to Threshold' do
+          expect(Threshold).to receive(:value_for).with(threshold, at: date)
+          subject
+        end
+
+        it 'returns the threshold value' do
+          expect(subject).to eq Threshold.value_for(threshold, at: date)
+        end
+      end
+
+      context 'invalid ccms_code' do
+        let(:ccms_code) { :XX999 }
+        it 'raises' do
+          expect { subject }.to raise_error KeyError, 'key not found: :XX999'
+        end
+      end
+
+      context 'invalid threshold' do
+        let(:threshold) { :minimum_wage }
+        let(:ccms_code) { waivable_codes.sample }
+        it 'passes the call to Threshold' do
+          expect(Threshold).to receive(:value_for).with(threshold, at: date)
+          subject
+        end
+
+        it 'returns the value that Threshold returned: nil' do
+          expect(subject).to be_nil
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Once we switch to V4 of the API, we will need to know whether certain thresholds are waived for a particular proceeding type.

This PR provides the `ProceedingTypeThreshold` class to do that.

If it is one of the thresholds which are subject to a waiver, and if the proceeding type is one where that threshold is waived, then the infinite upper limit of 999,999,999,999 is returned, otherwise Threshold is called to get the normal value.

Call like:
 ```
    ProceedingTypeThreshold.value_for(:DA004, :capital_upper, calculation_date)
```


## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-XXX)

Describe what you did and why.

## Checklist

Before you ask people to review this PR:

- [ ] Tests and rubocop should be passing: `bundle exec rake`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [ ] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [ ] The PR description should say what you changed and why, with a link to the JIRA story.
- [ ] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
