### PR TITLE
Bug fix, revert mortgage allowance to unlimited

### DIFF
--- a/config/thresholds/12-Apr-2021.yml
+++ b/config/thresholds/12-Apr-2021.yml
@@ -25,7 +25,7 @@ pensioner_capital_disregard:
     [226.0, 315.99]: 10_000
     [316.0]: 0
 property_notional_sale_costs_percentage: 3.0
-property_maximum_mortgage_allowance: 100_000
+property_maximum_mortgage_allowance: 999_999_999_999
 property_disregard:
   main_home: 100_000
   additional_property: 0.0

--- a/lib/integration_helpers/test_case/result.rb
+++ b/lib/integration_helpers/test_case/result.rb
@@ -36,7 +36,7 @@ module TestCase
 
     def print_error_result(key)
       @overall_result = false
-      print_result(key, :blue)
+      print_result(key, :red)
     end
 
     def expected_value(key)


### PR DESCRIPTION
## Revert change to mortgage allowance

The mortgage allowance has been accidentally reverted from unlimited to 100,000.  This fixes that



Describe what you did and why.

## Checklist

Before you ask people to review this PR:

- [ ] Tests and rubocop should be passing: `bundle exec rake`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [ ] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [ ] The PR description should say what you changed and why, with a link to the JIRA story.
- [ ] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
