### PR TITLE
AP-2174 Allow version 4 to be specified on POST /assessments

### DIFF
--- a/app/constants/cfe_constants.rb
+++ b/app/constants/cfe_constants.rb
@@ -2,7 +2,7 @@ module CFEConstants
   # Versions
   #
   DEFAULT_ASSESSMENT_VERSION = '3'.freeze
-  VALID_ASSESSMENT_VERSIONS = [DEFAULT_ASSESSMENT_VERSION].freeze
+  VALID_ASSESSMENT_VERSIONS = [DEFAULT_ASSESSMENT_VERSION, '4'].freeze
 
   # Income categories
   #

--- a/app/models/assessment.rb
+++ b/app/models/assessment.rb
@@ -2,10 +2,16 @@ class Assessment < ApplicationRecord
   extend EnumHash
 
   serialize :remarks
+  serialize :proceeding_type_codes, Array
 
   validates :remote_ip,
             :submission_date,
-            :matter_proceeding_type, presence: true
+            presence: true
+  validates :matter_proceeding_type, presence: true, if: :matter_proceeding_type_required?
+  validates :proceeding_type_codes, presence: true, if: :proceeding_types_codes_required?
+  validates :version, inclusion: { in: CFEConstants::VALID_ASSESSMENT_VERSIONS, message: 'not valid in Accept header' }
+
+  validate :proceeding_type_codes_validations
 
   has_one :applicant, dependent: :destroy
   has_one :capital_summary, dependent: :destroy
@@ -24,12 +30,28 @@ class Assessment < ApplicationRecord
   delegate :determine_result!, to: :capital_summary
   delegate :cash_transaction_categories, to: :gross_income_summary
 
-  attr_accessor :version
-
   # Always instantiate a new Remarks object from a nil value
   def remarks
     attributes['remarks'] || Remarks.new(id)
   rescue StandardError
     Remarks.new(id)
+  end
+
+  private
+
+  def matter_proceeding_type_required?
+    version == '3'
+  end
+
+  def proceeding_type_codes_validations
+    return if version == '3'
+
+    proceeding_type_codes.each do |code|
+      errors.add(:proceeding_type_codes, "invalid: #{code}") unless code.to_sym.in?(ProceedingTypeThreshold.valid_ccms_codes)
+    end
+  end
+
+  def proceeding_types_codes_required?
+    version != '3'
   end
 end

--- a/app/models/proceeding_type_threshold.rb
+++ b/app/models/proceeding_type_threshold.rb
@@ -80,6 +80,10 @@ class ProceedingTypeThreshold
     waivable_threshold? ? waivable_value : standard_value
   end
 
+  def self.valid_ccms_codes
+    WAIVERS.keys
+  end
+
   private
 
   def waivable_threshold?

--- a/db/migrate/20210412102115_add_version_proceeding_type_codes.rb
+++ b/db/migrate/20210412102115_add_version_proceeding_type_codes.rb
@@ -1,0 +1,17 @@
+class AddVersionProceedingTypeCodes < ActiveRecord::Migration[6.1]
+  # rubocop:disable Rails/BulkChangeTable
+  def up
+    add_column :assessments, :version, :string
+    add_column :assessments, :proceeding_type_codes, :string
+    change_column :assessments, :matter_proceeding_type, :string, null: true
+
+    execute 'UPDATE assessments SET version = 3'
+  end
+
+  def down
+    remove_column :assessments, :version
+    remove_column :assessments, :proceeding_type_codes
+    change_column :assessments, :matter_proceeding_type, :string, null: false
+  end
+  # rubocop:enable Rails/BulkChangeTable
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_01_28_181623) do
+ActiveRecord::Schema.define(version: 2021_04_12_102115) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -42,9 +42,11 @@ ActiveRecord::Schema.define(version: 2021_01_28_181623) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.date "submission_date", null: false
-    t.string "matter_proceeding_type", null: false
+    t.string "matter_proceeding_type"
     t.string "assessment_result", default: "pending", null: false
     t.text "remarks"
+    t.string "version"
+    t.string "proceeding_type_codes"
     t.index ["client_reference_id"], name: "index_assessments_on_client_reference_id"
   end
 

--- a/spec/models/assessment_spec.rb
+++ b/spec/models/assessment_spec.rb
@@ -4,14 +4,87 @@ require Rails.root.join('spec/fixtures/assessment_request_fixture.rb')
 RSpec.describe Assessment, type: :model do
   let(:payload) { AssessmentRequestFixture.json }
 
+  context 'version 3' do
+    context 'missing matter proceeding type' do
+      let(:param_hash) do
+        {
+          client_reference_id: 'client-ref-1',
+          submission_date: Date.current,
+          remote_ip: '127.0.0.1',
+          version: '3'
+        }
+      end
+
+      it 'errors' do
+        assessment = Assessment.create param_hash
+        expect(assessment.valid?).to be false
+        expect(assessment.errors.full_messages).to include("Matter proceeding type can't be blank")
+      end
+    end
+  end
+
+  context 'version 4' do
+    let(:param_hash) do
+      {
+        client_reference_id: 'client-ref-1',
+        submission_date: Date.current,
+        proceeding_type_codes: ccms_codes,
+        remote_ip: '127.0.0.1',
+        version: '4'
+      }
+    end
+
+    context 'missing matter proceeding type codes' do
+      let(:ccms_codes) { nil }
+
+      it 'errors' do
+        param_hash.delete(:proceeding_type_codes)
+        assessment = Assessment.create param_hash
+        expect(assessment.valid?).to be false
+        expect(assessment.errors.full_messages).to include("Proceeding type codes can't be blank")
+      end
+    end
+
+    context 'no proceeding types specified' do
+      let(:ccms_codes) { [] }
+
+      it 'errors' do
+        assessment = Assessment.create param_hash
+        expect(assessment.valid?).to be false
+        expect(assessment.errors.full_messages).to include("Proceeding type codes can't be blank")
+      end
+    end
+
+    context 'invalid proceeding type codes' do
+      let(:ccms_codes) { %w[DA005 SE014 XX999 SE003] }
+
+      it 'errors' do
+        assessment = Assessment.create param_hash
+        expect(assessment.valid?).to be false
+        expect(assessment.errors.full_messages).to include('Proceeding type codes invalid: XX999')
+      end
+    end
+
+    context 'valid params' do
+      let(:ccms_codes) { %w[DA005 SE014 SE003 DA020] }
+
+      it 'writes a valid record' do
+        assessment = Assessment.create param_hash
+        expect(assessment).to be_valid
+      end
+    end
+  end
+
   context 'missing ip address' do
     let(:param_hash) do
       {
         client_reference_id: 'client-ref-1',
         submission_date: Date.current,
-        matter_proceeding_type: 'domestic_abuse'
+        matter_proceeding_type: 'domestic_abuse',
+        version: '3'
       }
     end
+
     it 'errors' do
       assessment = Assessment.create param_hash
       expect(assessment.valid?).to be false

--- a/spec/services/calculators/housing_costs_calculator_spec.rb
+++ b/spec/services/calculators/housing_costs_calculator_spec.rb
@@ -53,9 +53,9 @@ module Calculators
             let(:housing_cost_amount) { 888.0 }
 
             it 'should return the gross cost as net' do
-              expect(calculator.gross_housing_costs).to eq 444.0.to_d + monthly_cash_housing
+              expect(calculator.gross_housing_costs).to eq 444.0.to_d + monthly_cash_housing.to_d
               expect(calculator.monthly_housing_benefit).to eq 0.0
-              expect(calculator.net_housing_costs).to eq 444.0.to_d + monthly_cash_housing
+              expect(calculator.net_housing_costs).to eq 444.0.to_d + monthly_cash_housing.to_d
             end
           end
         end

--- a/spec/services/creators/assessment_creator_spec.rb
+++ b/spec/services/creators/assessment_creator_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 module Creators
   RSpec.describe AssessmentCreator do
     let(:remote_ip) { '127.0.0.1' }
-    let(:raw_post) do
+    let(:raw_post_v3) do
       {
         client_reference_id: 'psr-123',
         submission_date: '2019-06-06',
@@ -11,78 +11,176 @@ module Creators
       }.to_json
     end
 
-    subject { described_class.call(remote_ip: remote_ip, raw_post: raw_post) }
+    let(:raw_post_v4) do
+      {
+        client_reference_id: 'psr-123',
+        submission_date: '2019-06-06',
+        proceeding_types: {
+          ccms_codes: %w[DA005 SE003 SE014]
+        }
+      }.to_json
+    end
+
+    subject { described_class.call(remote_ip: remote_ip, raw_post: raw_post, version: version) }
 
     before { stub_call_to_json_schema }
 
-    context 'valid request' do
-      it 'is successful' do
-        expect(subject.success?).to eq true
-      end
-
-      it 'creates an Assessment record' do
-        expect { subject.success? }.to change { Assessment.count }.by(1)
-      end
-
-      it 'creates a CapitalSummary record' do
-        expect { subject.success? }.to change { CapitalSummary.count }.by(1)
-      end
-
-      context 'capital summary record' do
-        before { subject.success? }
-        let(:capital_summary) { CapitalSummary.first }
-
-        it 'creates a pending Result record' do
-          expect(capital_summary.assessment_result).to eq 'pending'
+    context 'version 3' do
+      let(:raw_post) { raw_post_v3 }
+      let(:version) { '3' }
+      context 'valid request' do
+        it 'is successful' do
+          expect(subject.success?).to eq true
         end
 
-        it 'creates all fields as zero' do
-          expect(capital_summary.total_liquid).to eq 0.0
-          expect(capital_summary.total_non_liquid).to eq 0.0
-          expect(capital_summary.total_vehicle).to eq 0.0
-          expect(capital_summary.total_property).to eq 0.0
-          expect(capital_summary.total_mortgage_allowance).to eq 0.0
-          expect(capital_summary.pensioner_capital_disregard).to eq 0.0
-          expect(capital_summary.assessed_capital).to eq 0.0
-          expect(capital_summary.capital_contribution).to eq 0.0
-          expect(capital_summary.total_capital).to eq 0.0
-          expect(capital_summary.pensioner_capital_disregard).to eq 0.0
-          expect(capital_summary.lower_threshold).to eq 0.0
-          expect(capital_summary.assessed_capital).to eq 0.0
-          expect(capital_summary.upper_threshold).to eq 0.0
+        it 'creates an Assessment record' do
+          expect { subject.success? }.to change { Assessment.count }.by(1)
+        end
+
+        it 'creates a CapitalSummary record' do
+          expect { subject.success? }.to change { CapitalSummary.count }.by(1)
+        end
+
+        context 'capital summary record' do
+          before { subject.success? }
+          let(:capital_summary) { CapitalSummary.first }
+
+          it 'creates a pending Result record' do
+            expect(capital_summary.assessment_result).to eq 'pending'
+          end
+
+          it 'creates all fields as zero' do
+            expect(capital_summary.total_liquid).to eq 0.0
+            expect(capital_summary.total_non_liquid).to eq 0.0
+            expect(capital_summary.total_vehicle).to eq 0.0
+            expect(capital_summary.total_property).to eq 0.0
+            expect(capital_summary.total_mortgage_allowance).to eq 0.0
+            expect(capital_summary.pensioner_capital_disregard).to eq 0.0
+            expect(capital_summary.assessed_capital).to eq 0.0
+            expect(capital_summary.capital_contribution).to eq 0.0
+            expect(capital_summary.total_capital).to eq 0.0
+            expect(capital_summary.pensioner_capital_disregard).to eq 0.0
+            expect(capital_summary.lower_threshold).to eq 0.0
+            expect(capital_summary.assessed_capital).to eq 0.0
+            expect(capital_summary.upper_threshold).to eq 0.0
+          end
+        end
+
+        it 'has no errors' do
+          expect(subject.errors).to be_empty
+        end
+
+        describe '#as_json' do
+          it 'returns a successful json struct including the assessment it has created' do
+            subject.success?
+            expected_response = {
+              success: true,
+              assessment_id: Assessment.last.id,
+              errors: []
+            }
+            expect(subject.as_json).to eq expected_response
+          end
         end
       end
 
-      it 'has no errors' do
-        expect(subject.errors).to be_empty
-      end
+      context 'invalid request' do
+        let(:remote_ip) { nil }
 
-      describe '#as_json' do
-        it 'returns a successful json struct including the assessment it has created' do
-          subject.success?
-          expected_response = {
-            success: true,
-            assessment_id: Assessment.last.id,
-            errors: []
-          }
-          expect(subject.as_json).to eq expected_response
+        it 'is not successful' do
+          expect(subject.success?).to be false
+        end
+
+        it 'does not create an Assessment record' do
+          expect { subject.success? }.not_to change { Assessment.count }
+        end
+
+        it 'has  errors' do
+          expect(subject.errors).to eq ["Remote ip can't be blank"]
         end
       end
     end
 
-    context 'invalid request' do
-      let(:remote_ip) { nil }
+    context 'version 4' do
+      let(:raw_post) { raw_post_v4 }
+      let(:version) { '4' }
+      context 'valid request' do
+        it 'is successful' do
+          expect(subject.success?).to eq true
+        end
 
-      it 'is not successful' do
-        expect(subject.success?).to be false
+        it 'creates an Assessment record' do
+          expect { subject.success? }.to change { Assessment.count }.by(1)
+        end
+
+        it 'populates the assessment record with expected values' do
+          subject.success?
+          assessment = Assessment.first
+          expect(assessment.version).to eq '4'
+          expect(assessment.remote_ip).to eq '127.0.0.1'
+          expect(assessment.matter_proceeding_type).to be_nil
+          expect(assessment.proceeding_type_codes).to eq %w[DA005 SE003 SE014]
+        end
+
+        it 'creates a CapitalSummary record' do
+          expect { subject.success? }.to change { CapitalSummary.count }.by(1)
+        end
+
+        context 'capital summary record' do
+          before { subject.success? }
+          let(:capital_summary) { CapitalSummary.first }
+
+          it 'creates a pending Result record' do
+            expect(capital_summary.assessment_result).to eq 'pending'
+          end
+
+          it 'creates all fields as zero' do
+            expect(capital_summary.total_liquid).to eq 0.0
+            expect(capital_summary.total_non_liquid).to eq 0.0
+            expect(capital_summary.total_vehicle).to eq 0.0
+            expect(capital_summary.total_property).to eq 0.0
+            expect(capital_summary.total_mortgage_allowance).to eq 0.0
+            expect(capital_summary.pensioner_capital_disregard).to eq 0.0
+            expect(capital_summary.assessed_capital).to eq 0.0
+            expect(capital_summary.capital_contribution).to eq 0.0
+            expect(capital_summary.total_capital).to eq 0.0
+            expect(capital_summary.pensioner_capital_disregard).to eq 0.0
+            expect(capital_summary.lower_threshold).to eq 0.0
+            expect(capital_summary.assessed_capital).to eq 0.0
+            expect(capital_summary.upper_threshold).to eq 0.0
+          end
+        end
+
+        it 'has no errors' do
+          expect(subject.errors).to be_empty
+        end
+
+        describe '#as_json' do
+          it 'returns a successful json struct including the assessment it has created' do
+            subject.success?
+            expected_response = {
+              success: true,
+              assessment_id: Assessment.last.id,
+              errors: []
+            }
+            expect(subject.as_json).to eq expected_response
+          end
+        end
       end
 
-      it 'does not create an Assessment record' do
-        expect { subject.success? }.not_to change { Assessment.count }
-      end
+      context 'invalid request' do
+        let(:remote_ip) { nil }
 
-      it 'has  errors' do
-        expect(subject.errors).to eq ["Remote ip can't be blank"]
+        it 'is not successful' do
+          expect(subject.success?).to be false
+        end
+
+        it 'does not create an Assessment record' do
+          expect { subject.success? }.not_to change { Assessment.count }
+        end
+
+        it 'has  errors' do
+          expect(subject.errors).to eq ["Remote ip can't be blank"]
+        end
       end
     end
   end


### PR DESCRIPTION
## Allow version 4 to be specified on POST /assessments

[Link to story](https://dsdmoj.atlassian.net/browse/AP-2174)

- Added 4 to the list of valid versions
- Expect version to be specified on the first call (to `POST /assessments`).  If not specified, version 3 is assumed.
- Expect payload to have proceeding type ccms codes instead of matter type codes if version 4
- Added version and proceeding type codes to `assessments` table
- Validate the version number, and the new fields on the `Assessment` model

## Checklist

Before you ask people to review this PR:

- [ ] Tests and rubocop should be passing: `bundle exec rake`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [ ] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [ ] The PR description should say what you changed and why, with a link to the JIRA story.
- [ ] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
