### PR TITLE
TESTFIX - fix dates on tests 

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -65,6 +65,7 @@ RSpec.configure do |config|
   # https://github.com/thoughtbot/factory_bot/blob/master/GETTING_STARTED.md#rspec
   config.include FactoryBot::Syntax::Methods
   config.include RequestHelpers, type: :request
+  config.include ActiveSupport::Testing::TimeHelpers
 
   # Allow apipie recording for API documentation
   config.filter_run show_in_doc: true if ENV['APIPIE_RECORD']

--- a/spec/services/collators/childcare_collator_spec.rb
+++ b/spec/services/collators/childcare_collator_spec.rb
@@ -6,15 +6,19 @@ module Collators
       let(:assessment) { create :assessment, :with_disposable_income_summary, :with_gross_income_summary }
       let(:disposable_income_summary) { assessment.disposable_income_summary }
       let(:gross_income_summary) { assessment.gross_income_summary }
+      let(:target_time) { Date.current }
 
       subject { described_class.call(assessment) }
 
       before do
+        travel_to target_time
         create :bank_holiday
         create :childcare_outgoing, disposable_income_summary: disposable_income_summary, payment_date: Date.yesterday, amount: 155.63
         create :childcare_outgoing, disposable_income_summary: disposable_income_summary, payment_date: 1.month.ago, amount: 155.63
         create :childcare_outgoing, disposable_income_summary: disposable_income_summary, payment_date: 2.months.ago, amount: 155.63
       end
+
+      after { travel_back }
 
       context 'No dependants under 15' do
         before do
@@ -62,10 +66,13 @@ module Collators
       end
 
       context 'a dependant under 15' do
+        let(:target_time) { Time.zone.local(2021, 4, 11) }
         before do
           create :dependant, assessment: assessment, date_of_birth: 16.years.ago
           create :dependant, assessment: assessment, date_of_birth: 14.years.ago
         end
+
+        after { travel_back }
 
         context 'Employed' do
           before { allow_any_instance_of(described_class).to receive(:applicant_employed?).and_return(true) }


### PR DESCRIPTION
## Fix tests on dates.

Some unit tests have been written using today's dates, and expecting the values to be caluclated according to the current values in the config files.  When the thresholds and values change, we have to change the expected values in the dates.

This fixes the date for the test so that we don't have to do that every time there is a change to he means test.




## Checklist

Before you ask people to review this PR:

- [ ] Tests and rubocop should be passing: `bundle exec rake`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [ ] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [ ] The PR description should say what you changed and why, with a link to the JIRA story.
- [ ] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
