### PR TITLE
Bug-fix: Update test action

### DIFF
--- a/.github/workflows/manual-integration-tests.yml
+++ b/.github/workflows/manual-integration-tests.yml
@@ -28,9 +28,7 @@ jobs:
         run: echo Run started by ${{ github.event.client_payload.user }}
       - uses: actions/checkout@v2
       - name: Set up Ruby 2.7
-        uses: actions/setup-ruby@v1
-        with:
-          ruby-version: 2.7.x
+        uses: ruby/setup-ruby@v1
       - uses: actions/cache@v2
         with:
           path: vendor/bundle


### PR DESCRIPTION
## What 
The new ruby runner should read the value from
.ruby-version rather than guessing the latest
ruby version

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
