### PR TITLE
Revert "Bump bootsnap from 1.7.3 to 1.7.4"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -73,7 +73,7 @@ GEM
     awesome_print (1.9.2)
     binding_of_caller (1.0.0)
       debug_inspector (>= 0.0.1)
-    bootsnap (1.7.4)
+    bootsnap (1.7.3)
       msgpack (~> 1.0)
     builder (3.2.4)
     business (2.2.1)


### PR DESCRIPTION
Reverts ministryofjustice/check-financial-eligibility#486