### PR TITLE
Bug fix/monthly period analyser february

### DIFF
--- a/app/services/utilities/calendar_monthly_period_analyser.rb
+++ b/app/services/utilities/calendar_monthly_period_analyser.rb
@@ -43,7 +43,6 @@ module Utilities
     end
 
     def calendar_month_intervals?
-      first_payment_date = @dates.first
       result = true
       @dates.each_with_index do |date, iteration_count|
         next if iteration_count.zero?
@@ -51,10 +50,23 @@ module Utilities
         expected_date = first_payment_date + iteration_count.months
         next if date == expected_date
 
+        next if end_of_feb_check_needed?(date, iteration_count)
+
         result = false unless bank_holiday_adjustment?(date, expected_date)
         break if result == false
       end
       result
+    end
+
+    def first_payment_date
+      @first_payment_date ||= @dates.first
+    end
+
+    def end_of_feb_check_needed?(date, iteration_count)
+      return unless first_payment_date.month.eql?(2) && first_payment_date.day > 27
+
+      expected_date = date - iteration_count.months
+      first_payment_date == expected_date
     end
 
     def bank_holiday_adjustment?(actual_date, expected_date)

--- a/spec/services/utilities/calendar_monthly_period_analyser_spec.rb
+++ b/spec/services/utilities/calendar_monthly_period_analyser_spec.rb
@@ -177,6 +177,26 @@ module Utilities
         end
       end
 
+      context 'longer months after shorter months' do
+        context 'where February is included' do
+          let(:dates) { make_dates(%w[2021-02-28 2021-03-29 2021-04-29]) }
+
+          it { is_expected.to be true }
+        end
+
+        context 'where February is in the middle' do
+          let(:dates) { make_dates(%w[2021-01-31 2021-02-28 2021-03-31]) }
+
+          it { is_expected.to be true }
+        end
+
+        context 'not including February' do
+          let(:dates) { make_dates(%w[2021-03-31 2021-04-30 2021-05-31]) }
+
+          it { is_expected.to be true }
+        end
+      end
+
       def make_dates(array_of_string_dates)
         array_of_string_dates.map { |x| Date.parse(x) }
       end


### PR DESCRIPTION
## What

Update the date handling inside CalendarMonthlyPeriodAnalyser

Allow February dates to be handled when the date falls at the end of subsequent months

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
