### PR TITLE
Bug-Fix: Update test that failed a match

### DIFF
--- a/spec/models/gross_income_summary_spec.rb
+++ b/spec/models/gross_income_summary_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe GrossIncomeSummary do
         housing_benefit = create :state_benefit, state_benefit_type: housing_benefit_type, gross_income_summary: gross_income_summary
         housing_benefit_payments = create_list :state_benefit_payment, 3, state_benefit: housing_benefit
 
-        expect(gross_income_summary.housing_benefit_payments).to eq housing_benefit_payments
+        expect(gross_income_summary.housing_benefit_payments).to match_array housing_benefit_payments
       end
     end
   end


### PR DESCRIPTION
## What

When run with `bundle exec rspec  --seed 53801` this test would
consistently fail becuase the arrays were slighltly out of sequence
e.g. [a, b, c] == [b, a, c]

Changing to match_array ensures the contents are right and
ignores the sequence

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
