### PR TITLE
AP-2452 Ensure capital summary gets created with eligibilities

### DIFF
--- a/app/controllers/assessments_controller.rb
+++ b/app/controllers/assessments_controller.rb
@@ -62,6 +62,13 @@ class AssessmentsController < ApplicationController
   def show
     perform_assessment
   rescue StandardError => err
+    puts ">>>>>>>>>  #{__FILE__}:#{__LINE__} <<<<<<<<<<".yellow if ENV["DEBUG_VERBOSE"] == '1'
+    puts err.class if ENV["DEBUG_VERBOSE"] == '1'
+    puts err.message if ENV["DEBUG_VERBOSE"] == '1'
+    ap assessment if ENV["DEBUG_VERBOSE"] == '1'
+    if ENV["DEBUG_VERBOSE"] == '1'
+      binding.pry
+    end
     Sentry.capture_exception(err)
     render json: Decorators::ErrorDecorator.new(err).as_json, status: :unprocessable_entity
   end

--- a/app/controllers/assessments_controller.rb
+++ b/app/controllers/assessments_controller.rb
@@ -62,13 +62,6 @@ class AssessmentsController < ApplicationController
   def show
     perform_assessment
   rescue StandardError => err
-    puts ">>>>>>>>>  #{__FILE__}:#{__LINE__} <<<<<<<<<<".yellow if ENV["DEBUG_VERBOSE"] == '1'
-    puts err.class if ENV["DEBUG_VERBOSE"] == '1'
-    puts err.message if ENV["DEBUG_VERBOSE"] == '1'
-    ap assessment if ENV["DEBUG_VERBOSE"] == '1'
-    if ENV["DEBUG_VERBOSE"] == '1'
-      binding.pry
-    end
     Sentry.capture_exception(err)
     render json: Decorators::ErrorDecorator.new(err).as_json, status: :unprocessable_entity
   end

--- a/spec/factories/assessment_factory.rb
+++ b/spec/factories/assessment_factory.rb
@@ -94,7 +94,7 @@ FactoryBot.define do
     trait :passported do
       with_passported_applicant
       after(:create) do |assessment|
-        create :capital_summary, :with_everything, assessment: assessment
+        create :capital_summary, :with_everything, :with_eligibilities, assessment: assessment
       end
     end
 


### PR DESCRIPTION
## Ensure capital summary gets created with eligibilities

[Link to story](https://dsdmoj.atlassian.net/browse/AP-2452)

This hopefully will cure a flickering spec failure on the assessment request spec

The failures were (shown below) were caused by the capital summary record  **sometimes** not having any eligibility records associated with it, so that the first was nil.   This fix should ensure that eligibility records are always created

```Failures:

  1) AssessmentsController GET /assessments/:id no version specified passported has defaulted to using version 3
     Failure/Error: expect(parsed_response[:version]).to eq '3'
     
       expected: "3"
            got: nil
     
       (compared using ==)
     # ./spec/requests/assessments_spec.rb:161:in `block (5 levels) in <top (required)>'

  2) AssessmentsController GET /assessments/:id no version specified passported returns capital summary data as json
     Failure/Error: expect(parsed_response).to eq(JSON.parse(expected_response, symbolize_names: true))
     
       expected: {:assessment=>{:applicant=>{:date_of_birth=>"1973-06-11", :has_partner_opponent=>false, :involvement_...bmission_date=>"2021-08-18"}, :success=>true, :timestamp=>"2021-08-18T12:07:44.696Z", :version=>"3"}
            got: {:errors=>["NoMethodError: undefined method `lower_threshold' for nil:NilClass\n[\"/home/circleci/pro...oject/vendor/bundle/ruby/3.0.0/gems/rspec-core-3.10.1/exe/rspec:4:in `<main>'\"]"], :success=>false}
     
       (compared using ==)
     
       Diff:
       @@ -1,5 +1,3 @@
       -:assessment => {:applicant=>{:date_of_birth=>"1973-06-11", :has_partner_opponent=>false, :involvement_type=>"applicant", :receives_qualifying_benefit=>false, :self_employed=>false}, :assessment_result=>"pending", :capital=>{:assessed_capital=>"0.0", :assessment_result=>"pending", :capital_contribution=>"0.0", :capital_items=>{:liquid=>[{:description=>"Magni laborum eum impedit.", :value=>"2937.33"}], :non_liquid=>[{:description=>"Asperiores accusantium sint repudiandae.", :value=>"9285.13"}], :properties=>{:additional_properties=>[{:allowable_outstanding_mortgage=>"0.0", :assessed_equity=>"0.0", :main_home=>false, :main_home_equity_disregard=>"0.0", :net_equity=>"0.0", :net_value=>"0.0", :outstanding_mortgage=>"6268.08", :percentage_owned=>"0.42", :shared_with_housing_assoc=>true, :transaction_allowance=>"0.0", :value=>"7011.25"}], :main_home=>{:allowable_outstanding_mortgage=>"0.0", :assessed_equity=>"0.0", :main_home=>true, :main_home_equity_disregard=>"0.0", :net_equity=>"0.0", :net_value=>"0.0", :outstanding_mortgage=>"4528.72", :percentage_owned=>"6.62", :shared_with_housing_assoc=>false, :transaction_allowance=>"0.0", :value=>"7677.39"}}, :vehicles=>[{:assessed_value=>"0.0", :date_of_purchase=>"2019-01-29", :in_regular_use=>false, :included_in_assessment=>false, :loan_amount_outstanding=>"6837.68", :value=>"9856.82"}]}, :lower_threshold=>"3000.0", :pensioner_capital_disregard=>"0.0", :total_capital=>"0.0", :total_liquid=>"0.0", :total_mortgage_allowance=>"0.0", :total_non_liquid=>"0.0", :total_property=>"0.0", :total_vehicle=>"0.0", :upper_threshold=>"999999999999.0"}, :client_reference_id=>"CLIENT-REF-0450", :disposable_income=>{:assessment_result=>"eligible", :childcare_allowance=>"0.0", :deductions=>{:dependants_allowance=>"0.0", :disregarded_state_benefits=>0.0}, :dependant_allowance=>"0.0", :gross_housing_costs=>"125.0", :housing_benefit=>"0.0", :income_contribution=>"0.0", :lower_threshold=>"315.0", :maintenance_allowance=>"50.0", :monthly_equivalents=>{:all_sources=>{:child_care=>"0.0", :legal_aid=>"363.0", :maintenance_out=>"50.0", :rent_or_mortgage=>"125.0"}, :bank_transactions=>{:child_care=>"0.0", :legal_aid=>"363.0", :maintenance_out=>"50.0", :rent_or_mortgage=>"125.0"}, :cash_transactions=>{:child_care=>"0.0", :legal_aid=>"0.0", :maintenance_out=>"0.0", :rent_or_mortgage=>"0.0"}}, :net_housing_costs=>"125.0", :total_disposable_income=>"0.0", :total_outgoings_and_allowances=>"538.0", :upper_threshold=>"999999999999.0"}, :gross_income=>{:irregular_income=>{:monthly_equivalents=>{:student_loan=>"0.0"}}, :other_income=>{:monthly_equivalents=>{:all_sources=>{:friends_or_family=>"75.0", :maintenance_in=>"0.0", :pension=>"0.0", :property_or_lodger=>"0.0"}, :bank_transactions=>{:friends_or_family=>"75.0", :maintenance_in=>"0.0", :pension=>"0.0", :property_or_lodger=>"0.0"}, :cash_transactions=>{:friends_or_family=>"0.0", :maintenance_in=>"0.0", :pension=>"0.0", :property_or_lodger=>"0.0"}}}, :state_benefits=>{:monthly_equivalents=>{:all_sources=>"88.3", :bank_transactions=>[{:excluded_from_income_assessment=>false, :monthly_value=>"88.3", :name=>"benefit_type_29"}], :cash_transactions=>"0.0"}}, :summary=>{:assessment_result=>"eligible", :total_gross_income=>"163.3", :upper_threshold=>"999999999999.0"}}, :id=>"0216581a-0a27-47d8-8a0a-46af756742db", :matter_proceeding_type=>"domestic_abuse", :remarks=>{}, :submission_date=>"2021-08-18"},
       -:success => true,
       -:timestamp => "2021-08-18T12:07:44.696Z",
       -:version => "3",
       +:errors => ["NoMethodError: undefined method `lower_threshold' for nil:NilClass\n[\"/home/circleci/project/app/services/remark_generators/residual_balance_checker.rb:35:in `lower_capital_threshold'\", \"/home/circleci/project/app/services/remark_generators/residual_balance_checker.rb:24:in `capital_exceeds_lower_threshold?'\", \"/home/circleci/project/app/services/remark_generators/residual_balance_checker.rb:20:in `residual_balance?'\", \"/home/circleci/project/app/services/remark_generators/residual_balance_checker.rb:12:in `call'\", \"/home/circleci/project/app/services/remark_generators/residual_balance_checker.rb:4:in `call'\", \"/home/circleci/project/app/services/remark_generators/orchestrator.rb:61:in `check_residual_balances'\", \"/home/circleci/project/app/services/remark_generators/orchestrator.rb:24:in `call'\", \"/home/circleci/project/app/services/remark_generators/orchestrator.rb:12:in `call'\", \"/home/circleci/project/app/services/workflows/main_workflow.rb:9:in `call'\", \"/home/circleci/project/app/services/base_workflow_service.rb:21:in `call'\", \"/home/circleci/project/app/controllers/assessments_controller.rb:72:in `perform_assessment'\", \"/home/circleci/project/app/controllers/assessments_controller.rb:63:in `show'\", \"/home/circleci/project/vendor/bundle/ruby/3.0.0/gems/apipie-rails-0.5.19/lib/apipie/dsl_definition.rb:286:in `call'\", \"/home/circleci/project/vendor/bundle/ruby/3.0.0/gems/apipie-rails-0.5.19/lib/apipie/dsl_definition.rb:286:in `block in _apipie_define_validators'\", \"/home/circleci/project/vendor/bundle/ruby/3.0.0/gems/actionpack-6.1.4/lib/action_controller/metal/basic_implicit_render.rb:6:in `send_action'\", \"/home/circleci/project/vendor/bundle/ruby/3.0.0/gems/actionpack-6.1.4/lib/abstract_controller/base.rb:228:in `process_action'\", \"/home/circleci/project/vendor/bundle/ruby/3.0.0/gems/actionpack-6.1.4/lib/action_controller/metal/rendering.rb:30:in `process_action'\", \"/home/circleci/project/vendor/bundle/ruby/3.0.0/gems/actionpack-6.1.4/lib/abstract_controller/callbacks.rb:42:in `block in process_action'\", \"/home/circleci/project/vendor/bundle/ruby/3.0.0/gems/activesupport-6.1.4/lib/active_support/callbacks.rb:106:in `run_callbacks'\", \"/home/circleci/project/vendor/bundle/ruby/3.0.0/gems/actionpack-6.1.4/lib/abstract_controller/callbacks.rb:41:in `process_action'\", \"/home/circleci/project/vendor/bundle/ruby/3.0.0/gems/actionpack-6.1.4/lib/action_controller/metal/rescue.rb:22:in `process_action'\", \"/home/circleci/project/vendor/bundle/ruby/3.0.0/gems/actionpack-6.1.4/lib/action_controller/metal/instrumentation.rb:34:in `block in process_action'\", \"/home/circleci/project/vendor/bundle/ruby/3.0.0/gems/activesupport-6.1.4/lib/active_support/notifications.rb:203:in `block in instrument'\", \"/home/circleci/project/vendor/bundle/ruby/3.0.0/gems/activesupport-6.1.4/lib/active_support/notifications/instrumenter.rb:24:in `instrument'\", \"/home/circleci/project/vendor/bundle/ruby/3.0.0/gems/activesupport-6.1.4/lib/active_support/notifications.rb:203:in `instrument'\", \"/home/circleci/project/vendor/bundle/ruby/3.0.0/gems/actionpack-6.1.4/lib/action_controller/metal/instrumentation.rb:33:in `process_action'\", \"/home/circleci/project/vendor/bundle/ruby/3.0.0/gems/actionpack-6.1.4/lib/action_controller/metal/params_wrapper.rb:249:in `process_action'\", \"/home/circleci/project/vendor/bundle/ruby/3.0.0/gems/activerecord-6.1.4/lib/active_record/railties/controller_runtime.rb:27:in `process_action'\", \"/home/circleci/project/vendor/bundle/ruby/3.0.0/gems/actionpack-6.1.4/lib/abstract_controller/base.rb:165:in `process'\", \"/home/circleci/project/vendor/bundle/ruby/3.0.0/gems/actionpack-6.1.4/lib/action_controller/metal.rb:190:in `dispatch'\", \"/home/circleci/project/vendor/bundle/ruby/3.0.0/gems/actionpack-6.1.4/lib/action_controller/metal.rb:254:in `dispatch'\", \"/home/circleci/project/vendor/bundle/ruby/3.0.0/gems/actionpack-6.1.4/lib/action_dispatch/routing/route_set.rb:50:in `dispatch'\", \"/home/circleci/project/vendor/bundle/ruby/3.0.0/gems/actionpack-6.1.4/lib/action_dispatch/routing/route_set.rb:33:in `serve'\", \"/home/circleci/project/vendor/bundle/ruby/3.0.0/gems/actionpack-6.1.4/lib/action_dispatch/journey/router.rb:50:in `block in serve'\", \"/home/circleci/project/vendor/bundle/ruby/3.0.0/gems/actionpack-6.1.4/lib/action_dispatch/journey/router.rb:32:in `each'\", \"/home/circleci/project/vendor/bundle/ruby/3.0.0/gems/actionpack-6.1.4/lib/action_dispatch/journey/router.rb:32:in `serve'\", \"/home/circleci/project/vendor/bundle/ruby/3.0.0/gems/actionpack-6.1.4/lib/action_dispatch/routing/route_set.rb:842:in `call'\", \"/home/circleci/project/vendor/bundle/ruby/3.0.0/gems/apipie-rails-0.5.19/lib/apipie/static_dispatcher.rb:66:in `call'\", \"/home/circleci/project/vendor/bundle/ruby/3.0.0/gems/apipie-rails-0.5.19/lib/apipie/extractor/recorder.rb:137:in `call'\", \"/home/circleci/project/vendor/bundle/ruby/3.0.0/gems/sentry-rails-4.6.5/lib/sentry/rails/rescued_exception_interceptor.rb:9:in `call'\", \"/home/circleci/project/vendor/bundle/ruby/3.0.0/gems/rack-2.2.3/lib/rack/etag.rb:27:in `call'\", \"/home/circleci/project/vendor/bundle/ruby/3.0.0/gems/rack-2.2.3/lib/rack/conditional_get.rb:27:in `call'\", \"/home/circleci/project/vendor/bundle/ruby/3.0.0/gems/rack-2.2.3/lib/rack/head.rb:12:in `call'\", \"/home/circleci/project/vendor/bundle/ruby/3.0.0/gems/actionpack-6.1.4/lib/action_dispatch/middleware/callbacks.rb:27:in `block in call'\", \"/home/circleci/project/vendor/bundle/ruby/3.0.0/gems/activesupport-6.1.4/lib/active_support/callbacks.rb:98:in `run_callbacks'\", \"/home/circleci/project/vendor/bundle/ruby/3.0.0/gems/actionpack-6.1.4/lib/action_dispatch/middleware/callbacks.rb:26:in `call'\", \"/home/circleci/project/vendor/bundle/ruby/3.0.0/gems/actionpack-6.1.4/lib/action_dispatch/middleware/actionable_exceptions.rb:18:in `call'\", \"/home/circleci/project/vendor/bundle/ruby/3.0.0/gems/actionpack-6.1.4/lib/action_dispatch/middleware/debug_exceptions.rb:29:in `call'\", \"/home/circleci/project/vendor/bundle/ruby/3.0.0/gems/actionpack-6.1.4/lib/action_dispatch/middleware/show_exceptions.rb:33:in `call'\", \"/home/circleci/project/vendor/bundle/ruby/3.0.0/gems/railties-6.1.4/lib/rails/rack/logger.rb:37:in `call_app'\", \"/home/circleci/project/vendor/bundle/ruby/3.0.0/gems/railties-6.1.4/lib/rails/rack/logger.rb:26:in `block in call'\", \"/home/circleci/project/vendor/bundle/ruby/3.0.0/gems/activesupport-6.1.4/lib/active_support/tagged_logging.rb:99:in `block in tagged'\", \"/home/circleci/project/vendor/bundle/ruby/3.0.0/gems/activesupport-6.1.4/lib/active_support/tagged_logging.rb:37:in `tagged'\", \"/home/circleci/project/vendor/bundle/ruby/3.0.0/gems/activesupport-6.1.4/lib/active_support/tagged_logging.rb:99:in `tagged'\", \"/home/circleci/project/vendor/bundle/ruby/3.0.0/gems/railties-6.1.4/lib/rails/rack/logger.rb:26:in `call'\", \"/home/circleci/project/vendor/bundle/ruby/3.0.0/gems/actionpack-6.1.4/lib/action_dispatch/middleware/remote_ip.rb:81:in `call'\", \"/home/circleci/project/vendor/bundle/ruby/3.0.0/gems/actionpack-6.1.4/lib/action_dispatch/middleware/request_id.rb:26:in `call'\", \"/home/circleci/project/vendor/bundle/ruby/3.0.0/gems/rack-2.2.3/lib/rack/runtime.rb:22:in `call'\", \"/home/circleci/project/vendor/bundle/ruby/3.0.0/gems/activesupport-6.1.4/lib/active_support/cache/strategy/local_cache_middleware.rb:29:in `call'\", \"/home/circleci/project/vendor/bundle/ruby/3.0.0/gems/sentry-ruby-core-4.6.5/lib/sentry/rack/capture_exceptions.rb:9:in `call'\", \"/home/circleci/project/vendor/bundle/ruby/3.0.0/gems/actionpack-6.1.4/lib/action_dispatch/middleware/executor.rb:14:in `call'\", \"/home/circleci/project/vendor/bundle/ruby/3.0.0/gems/actionpack-6.1.4/lib/action_dispatch/middleware/static.rb:24:in `call'\", \"/home/circleci/project/vendor/bundle/ruby/3.0.0/gems/rack-2.2.3/lib/rack/sendfile.rb:110:in `call'\", \"/home/circleci/project/vendor/bundle/ruby/3.0.0/gems/actionpack-6.1.4/lib/action_dispatch/middleware/host_authorization.rb:92:in `call'\", \"/home/circleci/project/vendor/bundle/ruby/3.0.0/gems/secure_headers-6.3.2/lib/secure_headers/middleware.rb:11:in `call'\", \"/home/circleci/project/vendor/bundle/ruby/3.0.0/gems/railties-6.1.4/lib/rails/engine.rb:539:in `call'\", \"/home/circleci/project/vendor/bundle/ruby/3.0.0/gems/rack-test-1.1.0/lib/rack/mock_session.rb:29:in `request'\", \"/home/circleci/project/vendor/bundle/ruby/3.0.0/gems/rack-test-1.1.0/lib/rack/test.rb:266:in `process_request'\", \"/home/circleci/project/vendor/bundle/ruby/3.0.0/gems/rack-test-1.1.0/lib/rack/test.rb:119:in `request'\", \"/home/circleci/project/vendor/bundle/ruby/3.0.0/gems/actionpack-6.1.4/lib/action_dispatch/testing/integration.rb:279:in `process'\", \"/home/circleci/project/vendor/bundle/ruby/3.0.0/gems/actionpack-6.1.4/lib/action_dispatch/testing/integration.rb:16:in `get'\", \"/home/circleci/project/vendor/bundle/ruby/3.0.0/gems/actionpack-6.1.4/lib/action_dispatch/testing/integration.rb:372:in `get'\", \"/home/circleci/project/spec/requests/assessments_spec.rb:131:in `block (3 levels) in <top (required)>'\", \"/home/circleci/project/vendor/bundle/ruby/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/memoized_helpers.rb:317:in `block (2 levels) in let'\", \"/home/circleci/project/vendor/bundle/ruby/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/memoized_helpers.rb:157:in `block (3 levels) in fetch_or_store'\", \"/home/circleci/project/vendor/bundle/ruby/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/memoized_helpers.rb:157:in `fetch'\", \"/home/circleci/project/vendor/bundle/ruby/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/memoized_helpers.rb:157:in `block (2 levels) in fetch_or_store'\", \"/home/circleci/project/vendor/bundle/ruby/3.0.0/gems/rspec-support-3.10.2/lib/rspec/support/reentrant_mutex.rb:23:in `synchronize'\", \"/home/circleci/project/vendor/bundle/ruby/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/memoized_helpers.rb:156:in `block in fetch_or_store'\", \"/home/circleci/project/vendor/bundle/ruby/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/memoized_helpers.rb:155:in `fetch'\", \"/home/circleci/project/vendor/bundle/ruby/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/memoized_helpers.rb:155:in `fetch_or_store'\", \"/home/circleci/project/vendor/bundle/ruby/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/memoized_helpers.rb:317:in `block in let'\", \"/home/circleci/project/spec/requests/assessments_spec.rb:146:in `block (6 levels) in <top (required)>'\", \"/home/circleci/project/vendor/bundle/ruby/3.0.0/gems/timecop-0.9.4/lib/timecop/timecop.rb:201:in `travel'\", \"/home/circleci/project/vendor/bundle/ruby/3.0.0/gems/timecop-0.9.4/lib/timecop/timecop.rb:129:in `send_travel'\", \"/home/circleci/project/vendor/bundle/ruby/3.0.0/gems/timecop-0.9.4/lib/timecop/timecop.rb:50:in `freeze'\", \"/home/circleci/project/spec/requests/assessments_spec.rb:145:in `block (5 levels) in <top (required)>'\", \"/home/circleci/project/vendor/bundle/ruby/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/example.rb:262:in `instance_exec'\", \"/home/circleci/project/vendor/bundle/ruby/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/example.rb:262:in `block in run'\", \"/home/circleci/project/vendor/bundle/ruby/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/example.rb:508:in `block in with_around_and_singleton_context_hooks'\", \"/home/circleci/project/vendor/bundle/ruby/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/example.rb:465:in `block in with_around_example_hooks'\", \"/home/circleci/project/vendor/bundle/ruby/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/hooks.rb:486:in `block in run'\", \"/home/circleci/project/vendor/bundle/ruby/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/hooks.rb:626:in `block in run_around_example_hooks_for'\", \"/home/circleci/project/vendor/bundle/ruby/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/example.rb:350:in `call'\", \"/home/circleci/project/vendor/bundle/ruby/3.0.0/gems/rspec-rails-5.0.2/lib/rspec/rails/adapters.rb:75:in `block (2 levels) in <module:MinitestLifecycleAdapter>'\", \"/home/circleci/project/vendor/bundle/ruby/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/example.rb:455:in `instance_exec'\", \"/home/circleci/project/vendor/bundle/ruby/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/example.rb:455:in `instance_exec'\", \"/home/circleci/project/vendor/bundle/ruby/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/hooks.rb:390:in `execute_with'\", \"/home/circleci/project/vendor/bundle/ruby/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/hooks.rb:628:in `block (2 levels) in run_around_example_hooks_for'\", \"/home/circleci/project/vendor/bundle/ruby/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/example.rb:350:in `call'\", \"/home/circleci/project/vendor/bundle/ruby/3.0.0/gems/webmock-3.14.0/lib/webmock/rspec.rb:37:in `block (2 levels) in <top (required)>'\", \"/home/circleci/project/vendor/bundle/ruby/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/example.rb:455:in `instance_exec'\", \"/home/circleci/project/vendor/bundle/ruby/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/example.rb:455:in `instance_exec'\", \"/home/circleci/project/vendor/bundle/ruby/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/hooks.rb:390:in `execute_with'\", \"/home/circleci/project/vendor/bundle/ruby/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/hooks.rb:628:in `block (2 levels) in run_around_example_hooks_for'\", \"/home/circleci/project/vendor/bundle/ruby/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/example.rb:350:in `call'\", \"/home/circleci/project/vendor/bundle/ruby/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/hooks.rb:629:in `run_around_example_hooks_for'\", \"/home/circleci/project/vendor/bundle/ruby/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/hooks.rb:486:in `run'\", \"/home/circleci/project/vendor/bundle/ruby/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/example.rb:465:in `with_around_example_hooks'\", \"/home/circleci/project/vendor/bundle/ruby/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/example.rb:508:in `with_around_and_singleton_context_hooks'\", \"/home/circleci/project/vendor/bundle/ruby/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/example.rb:259:in `run'\", \"/home/circleci/project/vendor/bundle/ruby/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/example_group.rb:644:in `block in run_examples'\", \"/home/circleci/project/vendor/bundle/ruby/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/example_group.rb:640:in `map'\", \"/home/circleci/project/vendor/bundle/ruby/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/example_group.rb:640:in `run_examples'\", \"/home/circleci/project/vendor/bundle/ruby/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/example_group.rb:606:in `run'\", \"/home/circleci/project/vendor/bundle/ruby/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/example_group.rb:607:in `block in run'\", \"/home/circleci/project/vendor/bundle/ruby/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/example_group.rb:607:in `map'\", \"/home/circleci/project/vendor/bundle/ruby/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/example_group.rb:607:in `run'\", \"/home/circleci/project/vendor/bundle/ruby/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/example_group.rb:607:in `block in run'\", \"/home/circleci/project/vendor/bundle/ruby/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/example_group.rb:607:in `map'\", \"/home/circleci/project/vendor/bundle/ruby/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/example_group.rb:607:in `run'\", \"/home/circleci/project/vendor/bundle/ruby/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/example_group.rb:607:in `block in run'\", \"/home/circleci/project/vendor/bundle/ruby/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/example_group.rb:607:in `map'\", \"/home/circleci/project/vendor/bundle/ruby/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/example_group.rb:607:in `run'\", \"/home/circleci/project/vendor/bundle/ruby/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/runner.rb:121:in `block (3 levels) in run_specs'\", \"/home/circleci/project/vendor/bundle/ruby/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/runner.rb:121:in `map'\", \"/home/circleci/project/vendor/bundle/ruby/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/runner.rb:121:in `block (2 levels) in run_specs'\", \"/home/circleci/project/vendor/bundle/ruby/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/configuration.rb:2067:in `with_suite_hooks'\", \"/home/circleci/project/vendor/bundle/ruby/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/runner.rb:116:in `block in run_specs'\", \"/home/circleci/project/vendor/bundle/ruby/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/reporter.rb:74:in `report'\", \"/home/circleci/project/vendor/bundle/ruby/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/runner.rb:115:in `run_specs'\", \"/home/circleci/project/vendor/bundle/ruby/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/runner.rb:89:in `run'\", \"/home/circleci/project/vendor/bundle/ruby/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/runner.rb:71:in `run'\", \"/home/circleci/project/vendor/bundle/ruby/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/runner.rb:45:in `invoke'\", \"/home/circleci/project/vendor/bundle/ruby/3.0.0/gems/rspec-core-3.10.1/exe/rspec:4:in `<main>'\"]"],
       +:success => false,
       
     # ./spec/requests/assessments_spec.rb:149:in `block (6 levels) in <top (required)>'
     # ./spec/requests/assessments_spec.rb:145:in `block (5 levels) in <top (required)>'

  3) AssessmentsController GET /assessments/:id no version specified passported returns http success
     Failure/Error: expect(response).to have_http_status(:success)
       expected the response to have a success status code (2xx) but it was 422
     # ./spec/requests/assessments_spec.rb:141:in `block (5 levels) in <top (required)>'

Finished in 39.1 seconds (files took 3 seconds to load)
814 examples, 3 failures

Failed examples:

rspec ./spec/requests/assessments_spec.rb:159 # AssessmentsController GET /assessments/:id no version specified passported has defaulted to using version 3
rspec ./spec/requests/assessments_spec.rb:144 # AssessmentsController GET /assessments/:id no version specified passported returns capital summary data as json
rspec ./spec/requests/assessments_spec.rb:139 # AssessmentsController GET /assessments/:id no version specified passported returns http success

Randomized with seed 16313

```

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase master`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
