### PR TITLE
update-dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,3 +12,11 @@ updates:
   - dependency-name: sentry-raven
     versions:
     - 3.1.2
+- package-ecosystem: npm
+  directory: "/"
+  schedule:
+    interval: weekly
+    day: wednesday
+    time: "03:30"
+    timezone: Europe/London
+  open-pull-requests-limit: 10


### PR DESCRIPTION
We had to add Webpacker to the service but are not auto updating the packages

**Note**: I only realised that it wasn't running when webpacker was updated in bundler, but not in yarn!