### PR TITLE
Tech-Debt: Flickering decimal tests

### DIFF
--- a/spec/services/calculators/housing_costs_calculator_spec.rb
+++ b/spec/services/calculators/housing_costs_calculator_spec.rb
@@ -53,9 +53,9 @@ module Calculators
             let(:housing_cost_amount) { 888.0 }
 
             it 'should return the gross cost as net' do
-              expect(calculator.gross_housing_costs.to_f).to eq 444.0 + monthly_cash_housing
+              expect(calculator.gross_housing_costs).to eq 444.0.to_d + monthly_cash_housing # all variables are always decimals
               expect(calculator.monthly_housing_benefit).to eq 0.0
-              expect(calculator.net_housing_costs.to_f).to eq 444.0 + monthly_cash_housing
+              expect(calculator.net_housing_costs).to eq (444.0.to_d + monthly_cash_housing).to_f # net_housing_costs is always a float
             end
           end
         end
@@ -93,9 +93,9 @@ module Calculators
             let(:housing_cost_amount) { 420.00 }
 
             it 'should return the net cost' do
-              expect(calculator.gross_housing_costs).to eq 420.00.to_d + monthly_cash_housing
+              expect(calculator.gross_housing_costs).to eq 420.00.to_d + monthly_cash_housing # all variables are always decimals
               expect(calculator.monthly_housing_benefit).to eq 0.0
-              expect(calculator.net_housing_costs).to eq 420.00.to_d + monthly_cash_housing
+              expect(calculator.net_housing_costs).to eq (420.00.to_d + monthly_cash_housing).to_f # net_housing_costs is always a float
             end
           end
         end

--- a/spec/services/collators/disposable_income_collator_spec.rb
+++ b/spec/services/collators/disposable_income_collator_spec.rb
@@ -3,10 +3,10 @@ require 'rails_helper'
 module Collators
   RSpec.describe DisposableIncomeCollator do
     let(:assessment) { disposable_income_summary.assessment }
-    let(:child_care_bank) { Faker::Number.decimal(l_digits: 3, r_digits: 2).to_d }
-    let(:maintenance_out_bank) { Faker::Number.decimal(l_digits: 3, r_digits: 2).to_d }
-    let(:gross_housing) { Faker::Number.decimal(l_digits: 3, r_digits: 2).to_d }
-    let(:legal_aid_bank) { Faker::Number.decimal(l_digits: 3, r_digits: 2).to_d }
+    let(:child_care_bank) { Faker::Number.decimal(l_digits: 3, r_digits: 2).to_d(Float::DIG) }
+    let(:maintenance_out_bank) { Faker::Number.decimal(l_digits: 3, r_digits: 2).to_d(Float::DIG) }
+    let(:gross_housing) { Faker::Number.decimal(l_digits: 3, r_digits: 2).to_d(Float::DIG) }
+    let(:legal_aid_bank) { Faker::Number.decimal(l_digits: 3, r_digits: 2).to_d(Float::DIG) }
     let(:housing_benefit) { Faker::Number.between(from: 1.25, to: gross_housing / 2).round(2) }
     let(:net_housing) { gross_housing - housing_benefit }
     let(:total_outgoings) { child_care_bank + maintenance_out_bank + net_housing + dependant_allowance + legal_aid_bank }


### PR DESCRIPTION
## What

There have been some more flickers of decimal creation and testing and this PR fixes the latest one and attempts to identify and correct any others that may occur in the tests

This issue in `housing_costs_calculator_spec.rb` seems to be caused by changing one side of the equation, the occasional decimal flicker would cause issues with the float comparison.  After running multiple tests, ensuring all values are either comparing decimals with decimals or floats with floats seems to resolve it 🤞 

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase master`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
