### PR TITLE
AP-2497A remove Faraday header from webmock spec

### DIFF
--- a/spec/services/legal_framework_api/query_service_spec.rb
+++ b/spec/services/legal_framework_api/query_service_spec.rb
@@ -100,11 +100,12 @@ module LegalFrameworkAPI
     end
 
     def headers
+      # The headers also include the Faraday version, but because that changes over time, we
+      # don't specify that.  It just matches the headers we specify here
       {
         'Accept' => '*/*',
         'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
-        'Content-Type' => 'application/json',
-        'User-Agent' => 'Faraday v1.7.2'
+        'Content-Type' => 'application/json'
       }
     end
   end


### PR DESCRIPTION
Remove Faraday header from webmock spec

[Link to story](https://dsdmoj.atlassian.net/browse/AP-2497)

AP-2497 failed unit tests when merged with main because the version of Faraday didn't match that specified in the specs using webmock.  This change removes the Faraday header from the stubbed response, so that when the Faraday version changes, we don't get failed tests
## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase master`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
