### PR TITLE
Add CodeClimate to circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -161,8 +161,21 @@ jobs:
       - *setup_database
       - *install_js_packages
       - run:
+          name: Setup Code Climate test-reporter
+          command: |
+            curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./tmp/cc-test-reporter
+            chmod +x ./tmp/cc-test-reporter
+      - run:
           name: Run ruby tests
-          command: bin/rails spec
+          command: |
+            ./tmp/cc-test-reporter before-build
+            bundle exec rspec --format progress --format RspecJunitFormatter -o /tmp/test-results/rspec/rspec.xml
+            ./tmp/cc-test-reporter format-coverage -t simplecov -o tmp/coverage/codeclimate.json
+            ./tmp/cc-test-reporter upload-coverage -i tmp/coverage/codeclimate.json
+      - store_test_results:
+          path: /tmp/test-results/rspec
+      - store_artifacts:
+          path: ./coverage            
   build_and_push:
     executor: basic-executor
     steps:

--- a/Gemfile
+++ b/Gemfile
@@ -67,6 +67,7 @@ group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: %i[mri mingw x64_mingw]
   gem 'pry-byebug'
+  gem 'rspec_junit_formatter'
   gem 'rspec-rails', '~> 5.0'
   gem 'rubocop', require: false
   gem 'rubocop-performance'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -302,6 +302,8 @@ GEM
       rspec-mocks (~> 3.10)
       rspec-support (~> 3.10)
     rspec-support (3.10.3)
+    rspec_junit_formatter (0.4.1)
+      rspec-core (>= 2, < 4, != 2.12.0)
     rubocop (1.23.0)
       parallel (~> 1.10)
       parser (>= 3.0.0.0)
@@ -420,6 +422,7 @@ DEPENDENCIES
   rails (~> 6.1.4)
   roo (~> 2.8.3)
   rspec-rails (~> 5.0)
+  rspec_junit_formatter
   rubocop
   rubocop-performance
   rubocop-rails


### PR DESCRIPTION
## What

Test coverage stats aren't being sent to CircleCI so we have a badge that looks like this
![image](https://user-images.githubusercontent.com/28729201/142662303-3714eccc-12d7-424a-819d-8e2394e653b2.png)


To fix this, while running the unit_tests job, configure the code climate test reporter and prepare and upload the results. This required storing the CodeClimate test API key in a CircleCI environment variable named `CC_TEST_REPORTER_ID`


## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase master`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
