### PR TITLE
AP-2644: Update CircleCI Docker images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ executors:
           GITHUB_TEAM_NAME_SLUG: laa-apply-for-legal-aid
   linting-executor:
     docker:
-      - image: circleci/ruby:3.0.2-node-browsers
+      - image: cimg/ruby:3.0.2-node
         environment:
           - RAILS_ENV=test
           - TZ: "Europe/London"
@@ -25,14 +25,14 @@ executors:
     resource_class: small
   test-executor:
     docker:
-      - image: circleci/ruby:3.0.2-node-browsers
+      - image: cimg/ruby:3.0.2-node
         environment:
           - RAILS_ENV=test
           - PGHOST=localhost
           - PGUSER=user
           - TZ: "Europe/London"
           - ALLOW_FUTURE_SUBMISSION_DATE: true
-      - image: postgres:10.5
+      - image: cimg/postgres:10.18
         environment:
           - POSTGRES_USER=user
           - POSTGRES_DB=check_financial_eligibility_test


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-2644)

Update references to outdated `circleci/` prefixed docker images

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase master`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
