### PR TITLE
Bump CircleCI Slack Orb to v4.5.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  slack: circleci/slack@4.5.1
+  slack: circleci/slack@4.5.2
 executors:
   basic-executor:
     docker:
@@ -163,7 +163,7 @@ jobs:
       - store_test_results:
           path: /tmp/test-results/rspec
       - store_artifacts:
-          path: ./coverage            
+          path: ./coverage
   build_and_push:
     executor: basic-executor
     steps:


### PR DESCRIPTION
## What

v4.5.1 of the CircleCI Slack Orb is rendering new line symbols (`\n`) in slack message templates. 

![image](https://user-images.githubusercontent.com/28729201/148772728-ff96bc7b-c825-49b2-ab06-20152b7a0762.png)

This updates to v4.5.2 which resolves this.
 
## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase master`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
