### PR TITLE
AP-2820 Parse employment data

### DIFF
--- a/bin/ispec
+++ b/bin/ispec
@@ -25,6 +25,7 @@ class Ispec
     display_help if @help
 
     command = "#{verbosity} #{freshness} #{target} bundle exec rspec spec/integration/test_runner_spec.rb"
+    puts command
     system command
   end
 

--- a/lib/integration_helpers/test_case/employment_collection.rb
+++ b/lib/integration_helpers/test_case/employment_collection.rb
@@ -1,0 +1,93 @@
+module TestCase
+  class EmploymentCollection
+    def initialize(rows)
+      @employment_earnings = {}
+      populate_employments(rows)
+    end
+
+    def url_method
+      :assessment_employments_path
+    end
+
+    def payload
+      {
+        employment_income: employment_payload
+      }
+    end
+
+    def empty?
+      @employment_earnings.empty?
+    end
+
+    private
+
+    def employment_payload
+      payload = []
+      @employment_earnings.each do |job_name, payment_hash|
+        payload << employments_hash_to_payload(job_name, payment_hash)
+      end
+      payload
+    end
+
+    def employments_hash_to_payload(job_name, payments_array)
+      {
+        name: job_name,
+        payments: payments_array
+      }
+    end
+
+    def populate_employments(rows)
+      employment_rows = extract_employment_rows(rows)
+
+      while employment_rows.any?
+        payment_data = employment_rows.shift(5)
+        job_name = payment_data.first[1] if payment_data.first[1].present?
+        add_employment_earnings(job_name, payment_data)
+
+      end
+    end
+
+    def extract_employment_rows(rows)
+      row_index = rows.index { |r| r.first.present? && r.first != 'employment_income' }
+      rows.shift(row_index)
+    end
+
+    def add_employment_earnings(job_name, data_rows)
+      raise 'No job name specified in column B for employment data' if job_name.blank?
+
+      @employment_earnings[job_name] = [] unless @employment_earnings.key?(job_name)
+
+      @employment_earnings[job_name] << employment_payment(data_rows)
+    end
+
+    def employment_payment(data_rows)
+      payment_hash = {}
+      data_rows.each do |row|
+        transform_row_to_hash(row, payment_hash)
+      end
+      payment_hash[:net_employment_income] = calculate_net(payment_hash)
+      payment_hash
+    end
+
+    def transform_row_to_hash(row, payment_hash) # rubocop:disable Metrics/MethodLength
+      case row[2].strip
+      when 'date'
+        payment_hash[:date] = row[3].strftime('%F')
+      when 'gross pay'
+        payment_hash[:gross] = row[3]
+      when 'benefits in kind'
+        payment_hash[:benefits_in_kind] = row[3]
+      when 'tax'
+        payment_hash[:tax] = row[3]
+      when 'national insurance'
+        payment_hash[:national_insurance] = row[3]
+      else
+        raise "Unexpected key '#{row[2]}' in column C of employment data"
+      end
+    end
+
+    def calculate_net(payment_hash)
+      payment_hash[:gross] + payment_hash[:benefits_in_kind] + payment_hash[:tax] + payment_hash[:national_insurance]
+    end
+  end
+end

--- a/lib/integration_helpers/test_case/worksheet.rb
+++ b/lib/integration_helpers/test_case/worksheet.rb
@@ -5,6 +5,7 @@ module TestCase
                 :capitals,
                 :cash_transactions,
                 :dependants,
+                :employment_income,
                 :expected_results,
                 :irregular_income,
                 :other_incomes,
@@ -21,6 +22,7 @@ module TestCase
       capitals
       cash_transactions
       dependants
+      employment_income
       irregular_income
       other_incomes
       outgoings
@@ -90,6 +92,10 @@ module TestCase
 
     def populate_dependants
       @dependants = TestCase::DependantCollection.new(@rows)
+    end
+
+    def populate_employment_income
+      @employment_income = TestCase::EmploymentCollection.new(@rows)
     end
 
     def populate_other_incomes

--- a/spec/integration_helpers/test_case/employment_collection_spec.rb
+++ b/spec/integration_helpers/test_case/employment_collection_spec.rb
@@ -1,0 +1,213 @@
+require 'rails_helper'
+require Rails.root.join('lib/integration_helpers/test_case/employment_collection.rb')
+
+module TestCase
+  RSpec.describe EmploymentCollection do
+    let(:dec) { Date.new(2021, 12, 20) }
+    let(:nov) { Date.new(2021, 11, 30) }
+    let(:oct) { Date.new(2021, 10, 30) }
+    let(:early_dec) { Date.new(2021, 12, 7) }
+    let(:mid_dec) { Date.new(2021, 12, 15) }
+
+    subject { described_class.new(rows).payload }
+
+    context 'well formed spreadsheet' do
+      context 'single job' do
+        let(:rows) { single_job_rows }
+        it 'returns expected payload' do
+          expect(subject).to eq expected_single_job_payload
+        end
+      end
+
+      context 'multiple jobs' do
+        let(:rows) { multi_job_rows }
+        it 'returns expected payload' do
+          expect(subject).to eq expected_multi_job_payload
+        end
+      end
+    end
+
+    context 'malformed_spreadsheet' do
+      context 'no job name specified on first row' do
+        let(:rows) { missing_job_name_rows }
+        it 'raises' do
+          expect { subject }.to raise_error RuntimeError, 'No job name specified in column B for employment data'
+        end
+      end
+
+      context 'unknown key in column C of spreadsheet' do
+        let(:rows) { unknown_key_rows }
+        it 'raises' do
+          expect { subject }.to raise_error RuntimeError, "Unexpected key 'XXX-YYY-ZZZ' in column C of employment data"
+        end
+      end
+    end
+
+    def single_job_rows
+      [
+        ['employment_income', 'Job 1', 'date', dec, 'date as xx/xx/xx'],
+        ['', '', 'gross pay', 2550.33],
+        ['', '', 'benefits in kind', 0.0],
+        ['', '', 'tax', -745.31, 'Enter as negative value unless refund'],
+        ['', '', 'national insurance', -144.06, 'enter as negative figure for NIC deduction, positive for refund'],
+        ['', '', 'date', nov, 'date as xx/xx/xx'],
+        ['', '', 'gross pay', 2550.33],
+        ['', '', 'benefits in kind', 0.0],
+        ['', '', 'tax', -745.31, 'Enter as negative value unless refund'],
+        ['', '', 'national insurance', -144.06, 'enter as negative figure for NIC deduction, positive for refund'],
+        ['', '', 'date', oct, 'date as xx/xx/xx'],
+        ['', '', 'gross pay', 2550.33],
+        ['', '', 'benefits in kind', 0.0],
+        ['', '', 'tax', -745.31, 'Enter as negative value unless refund'],
+        ['', '', 'national insurance', -144.06, 'enter as negative figure for NIC deduction, positive for refund'],
+        ['some other section']
+      ]
+    end
+
+    def multi_job_rows
+      [
+        ['employment_income', 'Job 1', 'date', dec, 'date as xx/xx/xx'],
+        ['', '', 'gross pay', 2550.33],
+        ['', '', 'benefits in kind', 0.0],
+        ['', '', 'tax', -745.31, 'Enter as negative value unless refund'],
+        ['', '', 'national insurance', -144.06, 'enter as negative figure for NIC deduction, positive for refund'],
+        ['', '', 'date', nov, 'date as xx/xx/xx'],
+        ['', '', 'gross pay', 2550.33],
+        ['', '', 'benefits in kind', 0.0],
+        ['', '', 'tax', -745.31, 'Enter as negative value unless refund'],
+        ['', '', 'national insurance', -144.06, 'enter as negative figure for NIC deduction, positive for refund'],
+        ['', '', 'date', oct, 'date as xx/xx/xx'],
+        ['', '', 'gross pay', 2550.33],
+        ['', '', 'benefits in kind', 0.0],
+        ['', '', 'tax', -745.31, 'Enter as negative value unless refund'],
+        ['', '', 'national insurance', -144.06, 'enter as negative figure for NIC deduction, positive for refund'],
+        ['', 'Job 2', 'date', early_dec, 'date as xx/xx/xx'],
+        ['', '', 'gross pay', 350.20],
+        ['', '', 'benefits in kind', 0.0],
+        ['', '', 'tax', -98, 44, 'Enter as negative value unless refund'],
+        ['', '', 'national insurance', 0, 'enter as negative figure for NIC deduction, positive for refund'],
+        ['', '', 'date', mid_dec, 'date as xx/xx/xx'],
+        ['', '', 'gross pay', 390],
+        ['', '', 'benefits in kind', 0.0],
+        ['', '', 'tax', -45.87, 'Enter as negative value unless refund'],
+        ['', '', 'national insurance', 0, 'enter as negative figure for NIC deduction, positive for refund'],
+        ['some other section']
+      ]
+    end
+
+    def missing_job_name_rows
+      [
+        ['employment_income', '', 'date', dec, 'date as xx/xx/xx'],
+        ['', '', 'gross pay', 2550.33],
+        ['', '', 'benefits in kind', 0.0],
+        ['', '', 'tax', -745.31, 'Enter as negative value unless refund'],
+        ['', '', 'national insurance', -144.06, 'enter as negative figure for NIC deduction, positive for refund'],
+        ['some other section']
+      ]
+    end
+
+    def unknown_key_rows
+      [
+        ['employment_income', 'Job 1', 'date', dec, 'date as xx/xx/xx'],
+        ['', '', 'gross pay', 2550.33],
+        ['', '', 'XXX-YYY-ZZZ', 0.0],
+        ['', '', 'tax', -745.31, 'Enter as negative value unless refund'],
+        ['', '', 'national insurance', -144.06, 'enter as negative figure for NIC deduction, positive for refund'],
+        ['some other section']
+      ]
+    end
+
+    def expected_single_job_payload
+      {
+        employment_income: [
+          {
+            name: 'Job 1',
+            payments: [
+              {
+                date: '2021-12-20',
+                gross: 2550.33,
+                benefits_in_kind: 0.0,
+                tax: -745.31,
+                national_insurance: -144.06,
+                net_employment_income: 1660.96
+              },
+              {
+                date: '2021-11-30',
+                gross: 2550.33,
+                benefits_in_kind: 0.0,
+                tax: -745.31,
+                national_insurance: -144.06,
+                net_employment_income: 1660.96
+              },
+              {
+                date: '2021-10-30',
+                gross: 2550.33,
+                benefits_in_kind: 0.0,
+                tax: -745.31,
+                national_insurance: -144.06,
+                net_employment_income: 1660.96
+              }
+            ]
+          }
+        ]
+      }
+    end
+
+    def expected_multi_job_payload
+      {
+        employment_income: [
+          {
+            name: 'Job 1',
+            payments: [
+              {
+                date: '2021-12-20',
+                gross: 2550.33,
+                benefits_in_kind: 0.0,
+                tax: -745.31,
+                national_insurance: -144.06,
+                net_employment_income: 1660.96
+              },
+              {
+                date: '2021-11-30',
+                gross: 2550.33,
+                benefits_in_kind: 0.0,
+                tax: -745.31,
+                national_insurance: -144.06,
+                net_employment_income: 1660.96
+              },
+              {
+                date: '2021-10-30',
+                gross: 2550.33,
+                benefits_in_kind: 0.0,
+                tax: -745.31,
+                national_insurance: -144.06,
+                net_employment_income: 1660.96
+              }
+            ]
+          },
+          {
+            name: 'Job 2',
+            payments: [
+              {
+                date: '2021-12-07',
+                gross: 350.2,
+                benefits_in_kind: 0.0,
+                tax: -98,
+                national_insurance: 0,
+                net_employment_income: 252.2
+              },
+              {
+                date: '2021-12-15',
+                gross: 390,
+                benefits_in_kind: 0.0,
+                tax: -45.87,
+                national_insurance: 0,
+                net_employment_income: 344.13
+              }
+            ]
+          }
+        ]
+      }
+    end
+  end
+end


### PR DESCRIPTION
## Parse employment data for integration tests

[Link to story](https://dsdmoj.atlassian.net/browse/AP-2820)

Integration tests are run by parsing spreadsheets and submitting the data to CFE and comparing the results with the expected results on the spreadsheet.

The spreadsheets have been expanded to include employment income data, and the PR parses that new data if present and submits it to CFE.  The spreadsheets have not yet been updated to include employment data in the expected results, and this PR does not implement the changes required to parse the extra data in the expected results, which will be done as separate tickets.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase master`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
