### PR TITLE
Change master to main in PR template

### DIFF
--- a/docs/pull_request_template.md
+++ b/docs/pull_request_template.md
@@ -10,8 +10,8 @@ Describe what you did and why.
 Before you ask people to review this PR:
 
 - Tests and rubocop should be passing: `bundle exec rake`
-- Github should not be reporting conflicts; you should have recently run `git rebase master`.
+- Github should not be reporting conflicts; you should have recently run `git rebase main`.
 - There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
 - The PR description should say what you changed and why, with a link to the JIRA story.
-- You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
+- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
 - You should have checked that the commit messages say why the change was made.


### PR DESCRIPTION
## What

Changes outdated references to the `master` branch in the PR template to `main`.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase master`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
