### PR TITLE
AP-2820 Compare new employment figures in actual and expected results

### DIFF
--- a/lib/integration_helpers/test_case/v4/result_comparer.rb
+++ b/lib/integration_helpers/test_case/v4/result_comparer.rb
@@ -105,6 +105,11 @@ module TestCase
         compare_and_print("monthly other income", actual_gross_other_income, expected_gi_other_income)
         compare_and_print("monthly state benefits", actual_gross_state_benefits, expected_gi_state_benefits)
         compare_and_print("monthly student loan", actual_student_loan, expected_gi_student_loan)
+        compare_and_print("employment_income_gross", actual_employment_income[:gross_income], expected_employment_income_gross)
+        compare_and_print("employment_income_benefits_in_kind", actual_employment_income[:benefits_in_kind], expected_employment_income_benefits_in_kind)
+        compare_and_print("employment_income_tax",  actual_employment_income[:tax], expected_employment_income_tax)
+        compare_and_print("employment_income_nic",  actual_employment_income[:national_insurance], expected_employment_income_nic)
+        compare_and_print("fixed_employment_allowance", actual_employment_income[:fixed_employment_deduction], expected_fixed_employment_allowance)
         compare_and_print("total gross income", actual_total_gross_income, expected_total_gross_income)
       end
 
@@ -250,6 +255,10 @@ module TestCase
         @actual[:result_summary][:capital]
       end
 
+      def actual_employment_income
+        disposable_income_result[:employment_income]
+      end
+
       def expected_assessment
         @expected[:assessment]
       end
@@ -300,6 +309,26 @@ module TestCase
 
       def expected_capital
         @expected[:capital]
+      end
+
+      def expected_employment_income_gross
+        expected_gross_income[:employment_income_gross]
+      end
+
+      def expected_employment_income_benefits_in_kind
+        expected_gross_income[:employment_income_benefits_in_kind]
+      end
+
+      def expected_employment_income_tax
+        expected_gross_income[:employment_income_tax]
+      end
+
+      def expected_employment_income_nic
+        expected_gross_income[:employment_income_nic]
+      end
+
+      def expected_fixed_employment_allowance
+        expected_gross_income[:fixed_employment_allowance]
       end
     end
   end

--- a/spec/lib/integration_helpers/test_case/v4/result_comparer_spec.rb
+++ b/spec/lib/integration_helpers/test_case/v4/result_comparer_spec.rb
@@ -83,9 +83,10 @@ module TestCase
           end
 
           it "highlights the line in error in red" do
-            expect(instance).to receive(:verbose).with("                                         net housing costs  1100.0                     1100.01", :red)
-            expect(instance).to receive(:verbose).with(instance_of(String), :green).at_least(1)
-            expect(instance).to receive(:verbose).with(instance_of(String)).at_least(1)
+            expect(instance).to receive(:verbose).with("                                         net housing costs  1100.0                     1100.01", :red).and_call_original
+            allow(instance).to receive(:verbose).with(instance_of(String), :green).at_least(1)
+            allow(instance).to receive(:verbose).with(instance_of(String)).at_least(1)
+            allow(instance).to receive(:verbose).with(instance_of(String), :blue).at_least(1)
             subject
           end
         end
@@ -135,6 +136,7 @@ module TestCase
             total_outgoings_and_allowances: 1288.0,
             total_disposable_income: 4788.0,
             income_contribution: 0.0,
+
           },
           capital: {
             total_liquid: 0.0,
@@ -218,6 +220,14 @@ module TestCase
               gross_housing_costs: "50.0",
               housing_benefit: "600.0",
               net_housing_costs: "1100.0",
+              employment_income: {
+                gross_income: 2717.0,
+                benefits_in_kind: 0.0,
+                tax: -798.64,
+                national_insurance: -144.06,
+                fixed_employment_deduction: -45.0,
+                net_employment_income: 1774.3,
+              },
               total_outgoings_and_allowances: "1288.0",
               income_contribution: "0.0",
               total_disposable_income: "4788.0",


### PR DESCRIPTION
## Compare new employment figures in actual and expected results

[Link to story](https://dsdmoj.atlassian.net/browse/AP-2820)

The CFE Integration spreadsheets holding test data have can now optionally contain employment income in the data and the expected results.

An earlier PR (also under AP-2820) parsed the data section of the spreadsheet and sent employment data to CFE.

This PR parses the results section of the spreadsheet, and compares the expected employment figures therein with the data returned from CFE.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
