### PR TITLE
Remove unnecessary 2nd call to MainAsssessor

### DIFF
--- a/app/controllers/assessments_controller.rb
+++ b/app/controllers/assessments_controller.rb
@@ -70,7 +70,7 @@ private
 
   def perform_assessment
     Workflows::MainWorkflow.call(assessment)
-    Assessors::MainAssessor.call(assessment)
+    # Assessors::MainAssessor.call(assessment)
     decorator_klass = assessment.version_3? ? Decorators::V3::AssessmentDecorator : Decorators::V4::AssessmentDecorator
     render json: decorator_klass.new(assessment).as_json
   end

--- a/app/controllers/assessments_controller.rb
+++ b/app/controllers/assessments_controller.rb
@@ -70,7 +70,6 @@ private
 
   def perform_assessment
     Workflows::MainWorkflow.call(assessment)
-    # Assessors::MainAssessor.call(assessment)
     decorator_klass = assessment.version_3? ? Decorators::V3::AssessmentDecorator : Decorators::V4::AssessmentDecorator
     render json: decorator_klass.new(assessment).as_json
   end


### PR DESCRIPTION
## Remove unnecessary 2nd call to MainAsssessor

The MainAssessor was being called twice - both from the MainWorkflow and the AssessmentsController.

This PR removes it from the AssessmentsController

Describe what you did and why.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
