### PR TITLE
ap-2933 fix display cfe results

### DIFF
--- a/app/services/collators/disposable_income_collator.rb
+++ b/app/services/collators/disposable_income_collator.rb
@@ -17,7 +17,8 @@ module Collators
              :legal_aid_bank,
              :legal_aid_cash, to: :disposable_income_summary
 
-    delegate :total_gross_income, to: :gross_income_summary
+    delegate :total_gross_income,
+             :gross_employment_income, to: :gross_income_summary
 
     def initialize(assessment)
       super(assessment)
@@ -66,11 +67,11 @@ module Collators
 
     def total_outgoings_and_allowances
       net_housing_costs + dependant_allowance + child_care_bank + maintenance_out_bank + legal_aid_bank\
-      + @monthly_cash_transactions_total + fixed_employment_allowance + employment_income_deductions
+      + @monthly_cash_transactions_total - fixed_employment_allowance - employment_income_deductions
     end
 
     def disposable_income
-      [0, total_gross_income - total_outgoings_and_allowances].max
+      [0, total_gross_income + gross_employment_income - total_outgoings_and_allowances].max
     end
   end
 end

--- a/app/services/collators/gross_income_collator.rb
+++ b/app/services/collators/gross_income_collator.rb
@@ -5,7 +5,10 @@ module Collators
     INCOME_CATEGORIES = CFEConstants::VALID_INCOME_CATEGORIES.map(&:to_sym)
 
     def call
-      Calculators::EmploymentIncomeCalculator.call(assessment) if assessment.employments.any?
+      if assessment.employments.any?
+        assessment.employments.each { |employment| Utilities::EmploymentIncomeMonthlyEquivalentCalculator.call(employment) }
+        Calculators::EmploymentIncomeCalculator.call(assessment)
+      end
       gross_income_summary.update!(populate_attrs)
     end
 

--- a/app/services/collators/gross_income_collator.rb
+++ b/app/services/collators/gross_income_collator.rb
@@ -17,7 +17,6 @@ module Collators
       INCOME_CATEGORIES.each do |category|
         populate_income_attrs(attrs, category)
       end
-      attrs[:total_gross_income] += gross_income_summary.gross_employment_income
 
       attrs
     end

--- a/spec/services/collators/disposable_income_collator_spec.rb
+++ b/spec/services/collators/disposable_income_collator_spec.rb
@@ -40,8 +40,8 @@ module Collators
         maintenance_out_bank +
         legal_aid_bank +
         net_housing +
-        dependant_allowance +
-        employment_income_deductions +
+        dependant_allowance -
+        employment_income_deductions -
         fixed_employment_allowance
     end
 
@@ -64,7 +64,7 @@ module Collators
 
         it "is populated with result of gross income minus total outgoings and allowances" do
           collator
-          result = assessment.gross_income_summary.total_gross_income - disposable_income_summary.reload.total_outgoings_and_allowances
+          result = assessment.gross_income_summary.total_gross_income + assessment.gross_income_summary.gross_employment_income - disposable_income_summary.reload.total_outgoings_and_allowances
           expect(disposable_income_summary.total_disposable_income).to eq result
         end
       end

--- a/spec/services/collators/gross_income_collator_spec.rb
+++ b/spec/services/collators/gross_income_collator_spec.rb
@@ -130,10 +130,6 @@ module Collators
             expect(gross_income_summary.gross_employment_income).to eq 1500
           end
 
-          it "updates total gross income" do
-            expect(gross_income_summary.total_gross_income).to eq 1500
-          end
-
           it "updates disposable income summary" do
             expect(displosable_income_summary.employment_income_deductions).to eq(-645)
             expect(displosable_income_summary.tax).to eq(-495)


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/jira/software/c/projects/AP/boards/233?modal=detail&selectedIssue=AP-2933)

Describe what you did and why.

This pr contains the CFE changes to fix display of CFE results with employment income. The apply changes are in pr https://github.com/ministryofjustice/laa-apply-for-legal-aid/pull/3523
It also fixes a bug where EmploymentIncomeMonthlyEquivalentCalculator was not being called.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
