### PR TITLE
Ap 2982 show actual disposable income

### DIFF
--- a/app/services/collators/disposable_income_collator.rb
+++ b/app/services/collators/disposable_income_collator.rb
@@ -71,7 +71,7 @@ module Collators
     end
 
     def disposable_income
-      [0, total_gross_income - total_outgoings_and_allowances].max
+      total_gross_income - total_outgoings_and_allowances
     end
   end
 end

--- a/config/thresholds/2018-04-08.yml
+++ b/config/thresholds/2018-04-08.yml
@@ -13,7 +13,7 @@ pensioner_capital_disregard:
   non_passported: 100_000
   # capital to disregard if monthly disposable income (excluding income derived from capital) is below these figures
   monthly_income_values:
-    [-999_999_999_999, 25.99]: 100_000
+    [-.inf, 25.99]: 100_000
     [26.0, 50.99]: 90_000
     [51.0, 75.99]: 80_000
     [76.0, 100.99]: 70_000
@@ -43,7 +43,7 @@ single_monthly_housing_costs_cap: 545
 
 disposable_income_contribution_bands:
   band_zero:
-    threshold: 0.0
+    threshold: -.inf
     disregard: 0.0
     percentage: 0.0
     base: 0.0

--- a/config/thresholds/2018-04-08.yml
+++ b/config/thresholds/2018-04-08.yml
@@ -13,7 +13,7 @@ pensioner_capital_disregard:
   non_passported: 100_000
   # capital to disregard if monthly disposable income (excluding income derived from capital) is below these figures
   monthly_income_values:
-    [0, 25.99]: 100_000
+    [-999_999_999_999, 25.99]: 100_000
     [26.0, 50.99]: 90_000
     [51.0, 75.99]: 80_000
     [76.0, 100.99]: 70_000

--- a/config/thresholds/2019-04-08.yml
+++ b/config/thresholds/2019-04-08.yml
@@ -13,7 +13,7 @@ pensioner_capital_disregard:
   non_passported: 100_000
   # capital to disregard if monthly disposable income (excluding income derived from capital) is below these figures
   monthly_income_values:
-    [-999_999_999_999, 25.99]: 100_000
+    [-.inf, 25.99]: 100_000
     [26.0, 50.99]: 90_000
     [51.0, 75.99]: 80_000
     [76.0, 100.99]: 70_000
@@ -43,7 +43,7 @@ single_monthly_housing_costs_cap: 545
 
 disposable_income_contribution_bands:
   band_zero:
-    threshold: 0.0
+    threshold: -.inf
     disregard: 0.0
     percentage: 0.0
     base: 0.0

--- a/config/thresholds/2019-04-08.yml
+++ b/config/thresholds/2019-04-08.yml
@@ -13,7 +13,7 @@ pensioner_capital_disregard:
   non_passported: 100_000
   # capital to disregard if monthly disposable income (excluding income derived from capital) is below these figures
   monthly_income_values:
-    [0, 25.99]: 100_000
+    [-999_999_999_999, 25.99]: 100_000
     [26.0, 50.99]: 90_000
     [51.0, 75.99]: 80_000
     [76.0, 100.99]: 70_000

--- a/config/thresholds/2020-04-06.yml
+++ b/config/thresholds/2020-04-06.yml
@@ -13,7 +13,7 @@ pensioner_capital_disregard:
   non_passported: 100_000
   # capital to disregard if monthly disposable income (excluding income derived from capital) is below these figures
   monthly_income_values:
-    [-999_999_999_999, 25.99]: 100_000
+    [-.inf, 25.99]: 100_000
     [26.0, 50.99]: 90_000
     [51.0, 75.99]: 80_000
     [76.0, 100.99]: 70_000
@@ -43,7 +43,7 @@ single_monthly_housing_costs_cap: 545
 
 disposable_income_contribution_bands:
   band_zero:
-    threshold: 0.0
+    threshold: -.inf
     disregard: 0.0
     percentage: 0.0
     base: 0.0

--- a/config/thresholds/2020-04-06.yml
+++ b/config/thresholds/2020-04-06.yml
@@ -13,7 +13,7 @@ pensioner_capital_disregard:
   non_passported: 100_000
   # capital to disregard if monthly disposable income (excluding income derived from capital) is below these figures
   monthly_income_values:
-    [0, 25.99]: 100_000
+    [-999_999_999_999, 25.99]: 100_000
     [26.0, 50.99]: 90_000
     [51.0, 75.99]: 80_000
     [76.0, 100.99]: 70_000

--- a/config/thresholds/2021-01-28.yml
+++ b/config/thresholds/2021-01-28.yml
@@ -13,7 +13,7 @@ pensioner_capital_disregard:
   non_passported: 100_000
   # capital to disregard if monthly disposable income (excluding income derived from capital) is below these figures
   monthly_income_values:
-    [-999_999_999_999, 25.99]: 100_000
+    [-.inf, 25.99]: 100_000
     [26.0, 50.99]: 90_000
     [51.0, 75.99]: 80_000
     [76.0, 100.99]: 70_000
@@ -43,7 +43,7 @@ single_monthly_housing_costs_cap: 545
 
 disposable_income_contribution_bands:
   band_zero:
-    threshold: 0.0
+    threshold: -.inf
     disregard: 0.0
     percentage: 0.0
     base: 0.0

--- a/config/thresholds/2021-01-28.yml
+++ b/config/thresholds/2021-01-28.yml
@@ -13,7 +13,7 @@ pensioner_capital_disregard:
   non_passported: 100_000
   # capital to disregard if monthly disposable income (excluding income derived from capital) is below these figures
   monthly_income_values:
-    [0, 25.99]: 100_000
+    [-999_999_999_999, 25.99]: 100_000
     [26.0, 50.99]: 90_000
     [51.0, 75.99]: 80_000
     [76.0, 100.99]: 70_000

--- a/config/thresholds/2021-04-12.yml
+++ b/config/thresholds/2021-04-12.yml
@@ -13,7 +13,7 @@ pensioner_capital_disregard:
   non_passported: 100_000
   # capital to disregard if monthly disposable income (excluding income derived from capital) is below these figures
   monthly_income_values:
-    [-999_999_999_999, 25.99]: 100_000
+    [-.inf, 25.99]: 100_000
     [26.0, 50.99]: 90_000
     [51.0, 75.99]: 80_000
     [76.0, 100.99]: 70_000
@@ -43,7 +43,7 @@ single_monthly_housing_costs_cap: 545
 
 disposable_income_contribution_bands:
   band_zero:
-    threshold: 0.0
+    threshold: -.inf
     disregard: 0.0
     percentage: 0.0
     base: 0.0

--- a/config/thresholds/2021-04-12.yml
+++ b/config/thresholds/2021-04-12.yml
@@ -13,7 +13,7 @@ pensioner_capital_disregard:
   non_passported: 100_000
   # capital to disregard if monthly disposable income (excluding income derived from capital) is below these figures
   monthly_income_values:
-    [0, 25.99]: 100_000
+    [-999_999_999_999, 25.99]: 100_000
     [26.0, 50.99]: 90_000
     [51.0, 75.99]: 80_000
     [76.0, 100.99]: 70_000

--- a/config/thresholds/test-jan.yml
+++ b/config/thresholds/test-jan.yml
@@ -14,7 +14,7 @@ pensioner_capital_disregard:
   non_passported: 100_000
   # capital to disregard if monthly disposable income (excluding income derived from capital) is below these figures
   monthly_income_values:
-    [-999_999_999_999, 25.99]: 100_000
+    [-.inf, 25.99]: 100_000
     [26.0, 50.99]: 90_000
     [51.0, 75.99]: 80_000
     [76.0, 100.99]: 70_000
@@ -44,7 +44,7 @@ single_monthly_housing_costs_cap: 545
 
 disposable_income_contribution_bands:
   band_zero:
-    threshold: 0.0
+    threshold: -.inf
     disregard: 0.0
     percentage: 0.0
     base: 0.0

--- a/config/thresholds/test-jan.yml
+++ b/config/thresholds/test-jan.yml
@@ -14,7 +14,7 @@ pensioner_capital_disregard:
   non_passported: 100_000
   # capital to disregard if monthly disposable income (excluding income derived from capital) is below these figures
   monthly_income_values:
-    [0, 25.99]: 100_000
+    [-999_999_999_999, 25.99]: 100_000
     [26.0, 50.99]: 90_000
     [51.0, 75.99]: 80_000
     [76.0, 100.99]: 70_000

--- a/spec/services/calculators/income_contribution_calculator_spec.rb
+++ b/spec/services/calculators/income_contribution_calculator_spec.rb
@@ -13,6 +13,14 @@ module Calculators
         end
       end
 
+      context "negative income" do
+        let(:income) { -100.0 }
+
+        it "returns zero" do
+          expect(calculator).to be_zero
+        end
+      end
+
       context "income in band a" do
         let(:income) { 340.0 }
         # (340 - 311) * 35% = 10.15

--- a/spec/services/calculators/pensioner_capital_disregard_calculator_spec.rb
+++ b/spec/services/calculators/pensioner_capital_disregard_calculator_spec.rb
@@ -30,6 +30,12 @@ module Calculators
               end
             end
 
+            context "with an income of -100" do
+              let(:disposable_income) { -100.0 }
+
+              it { is_expected.to eq 100_000.0 }
+            end
+
             context "with an income of 50.99" do
               let(:disposable_income) { 50.99 }
 

--- a/spec/services/collators/disposable_income_collator_spec.rb
+++ b/spec/services/collators/disposable_income_collator_spec.rb
@@ -69,6 +69,19 @@ module Collators
         end
       end
 
+      context "when total disposable income is negative" do
+        before do
+          assessment.gross_income_summary.update!(total_gross_income: total_outgoings - 1500.0)
+        end
+
+        it "returns the correct negative amount" do
+          collator
+          result = assessment.gross_income_summary.total_gross_income + assessment.gross_income_summary.gross_employment_income - disposable_income_summary.reload.total_outgoings_and_allowances
+          expect(disposable_income_summary.total_disposable_income).to eq result
+          expect(disposable_income_summary.total_disposable_income).to be_negative
+        end
+      end
+
       context "lower threshold" do
         it "populates the lower threshold" do
           collator


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-2982)

- Allow negative total disposable incomes
- Amend pensioner_capital_disregard monthly_income_values in threshold files to cater for negative values
- Amend disposable_income_contribution_bands band_zero on threshold files to allow negative values

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
