### PR TITLE
[AP-3025] get integration tests GGG_EMP_8/9 passing

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -95,6 +95,7 @@ group :test do
   gem "shoulda-matchers"
   gem "simplecov", require: false
   gem "simplecov-rcov"
+  gem "super_diff"
   gem "vcr"
   gem "webmock", ">= 3.13.0"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -76,6 +76,7 @@ GEM
     apipie-rails (0.5.20)
       rails (>= 4.1)
     ast (2.4.2)
+    attr_extras (6.2.5)
     awesome_print (1.9.2)
     binding_of_caller (1.0.0)
       debug_inspector (>= 0.0.1)
@@ -241,10 +242,13 @@ GEM
     notiffany (0.1.3)
       nenv (~> 0.1)
       shellany (~> 0.0)
+    optimist (3.0.1)
     os (1.1.4)
     parallel (1.22.1)
     parser (3.1.1.0)
       ast (~> 2.4.1)
+    patience_diff (1.2.0)
+      optimist (~> 3.0)
     pg (1.3.4)
     pry (0.13.1)
       coderay (~> 1.1)
@@ -390,6 +394,10 @@ GEM
     simplecov_json_formatter (0.1.4)
     spring (4.0.0)
     strscan (3.0.1)
+    super_diff (0.8.0)
+      attr_extras (>= 6.2.4)
+      diff-lcs
+      patience_diff
     thor (1.2.1)
     timecop (0.9.5)
     timeout (0.2.0)
@@ -462,6 +470,7 @@ DEPENDENCIES
   simplecov
   simplecov-rcov
   spring
+  super_diff
   timecop
   tzinfo-data
   vcr

--- a/app/models/employment.rb
+++ b/app/models/employment.rb
@@ -45,8 +45,8 @@ private
 
   def use_ni_tax_blunt_average
     update!(
-      monthly_national_insurance: blunt_average(:national_insurance),
-      monthly_tax: blunt_average(:tax),
+      monthly_national_insurance: blunt_average(:national_insurance_monthly_equiv),
+      monthly_tax: blunt_average(:tax_monthly_equiv),
     )
   end
 
@@ -54,8 +54,8 @@ private
     most_recent_payment = employment_payments.order(:date).last
 
     update!(
-      monthly_national_insurance: most_recent_payment.national_insurance,
-      monthly_tax: most_recent_payment.tax,
+      monthly_national_insurance: most_recent_payment.national_insurance_monthly_equiv,
+      monthly_tax: most_recent_payment.tax_monthly_equiv,
     )
   end
 

--- a/app/services/decorators/v4/gross_income_decorator.rb
+++ b/app/services/decorators/v4/gross_income_decorator.rb
@@ -39,7 +39,7 @@ module Decorators
       end
 
       def employment_payments(employment)
-        employment.employment_payments.map { |payment| employment_payment(payment) }
+        employment.employment_payments.order(date: :desc).map { |payment| employment_payment(payment) }
       end
 
       def employment_payment(payment)

--- a/app/services/utilities/employment_income_monthly_equivalent_calculator.rb
+++ b/app/services/utilities/employment_income_monthly_equivalent_calculator.rb
@@ -55,7 +55,11 @@ module Utilities
 
     def update_payments(calc_method)
       @employment.employment_payments.each do |payment|
-        payment.update(gross_income_monthly_equiv: __send__(calc_method, payment.gross_income))
+        payment.update(
+          gross_income_monthly_equiv: __send__(calc_method, payment.gross_income),
+          tax_monthly_equiv: __send__(calc_method, payment.tax),
+          national_insurance_monthly_equiv: __send__(calc_method, payment.national_insurance),
+        )
       end
     end
 

--- a/db/migrate/20220330103236_add_tax_monthly_equiv_to_employment_payment.rb
+++ b/db/migrate/20220330103236_add_tax_monthly_equiv_to_employment_payment.rb
@@ -1,0 +1,6 @@
+class AddTaxMonthlyEquivToEmploymentPayment < ActiveRecord::Migration[7.0]
+  change_table :employment_payments, bulk: true do |t|
+    t.decimal :tax_monthly_equiv, default: 0.0, null: false
+    t.decimal :national_insurance_monthly_equiv, default: 0.0, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_03_17_185108) do
+ActiveRecord::Schema[7.0].define(version: 2022_03_30_103236) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -175,6 +175,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_03_17_185108) do
     t.datetime "updated_at", null: false
     t.string "client_id", null: false
     t.decimal "gross_income_monthly_equiv", default: "0.0", null: false
+    t.decimal "tax_monthly_equiv", default: "0.0", null: false
+    t.decimal "national_insurance_monthly_equiv", default: "0.0", null: false
     t.index ["employment_id"], name: "index_employment_payments_on_employment_id"
   end
 

--- a/spec/factories/employment_factory.rb
+++ b/spec/factories/employment_factory.rb
@@ -7,7 +7,7 @@ FactoryBot.define do
 
   trait :with_monthly_payments do
     after(:create) do |record|
-      [Date.current, 1.month.ago, 2.months.ago].each do |date|
+      [Time.zone.today, 1.month.ago.to_date, 2.months.ago.to_date].each do |date|
         create :employment_payment, employment: record, date: date, gross_income: 1500, gross_income_monthly_equiv: 1500
       end
     end

--- a/spec/models/employment_spec.rb
+++ b/spec/models/employment_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe Employment do
       end
     end
 
-    describe ".calculate_monthly_ni_tax!" do
+    describe "#calculate_monthly_ni_tax!" do
       before { setup_ni_and_tax }
 
       context "when using the blunt average" do
@@ -139,7 +139,9 @@ RSpec.describe Employment do
              gross_income_monthly_equiv: gross,
              benefits_in_kind: bik,
              tax: tax_amounts[i],
-             national_insurance: ni_amounts[i]
+             tax_monthly_equiv: tax_amounts[i],
+             national_insurance: ni_amounts[i],
+             national_insurance_monthly_equiv: ni_amounts[i]
     end
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -6,6 +6,7 @@ require File.expand_path("../config/environment", __dir__)
 abort("The Rails environment is running in production mode!") if Rails.env.production?
 require "rspec/rails"
 require "pry-rescue/rspec" if Rails.env.development?
+require "super_diff/rspec-rails"
 
 # Add additional requires below this line. Rails is not loaded until this point!
 

--- a/spec/services/decorators/v4/gross_income_decorator_spec.rb
+++ b/spec/services/decorators/v4/gross_income_decorator_spec.rb
@@ -32,7 +32,7 @@ module Decorators
               name: employment1.name,
               payments: [
                 {
-                  date: Date.current.strftime("%Y-%m-%d"),
+                  date: Time.zone.today.strftime("%Y-%m-%d"),
                   benefits_in_kind: 0.0,
                   gross: 1500.0,
                   tax: -495.0,
@@ -40,7 +40,7 @@ module Decorators
                   net_employment_income: 855.0,
                 },
                 {
-                  date: 1.month.ago.strftime("%Y-%m-%d"),
+                  date: 1.month.ago.to_date.strftime("%Y-%m-%d"),
                   benefits_in_kind: 0.0,
                   gross: 1500.0,
                   tax: -495.0,
@@ -48,7 +48,7 @@ module Decorators
                   net_employment_income: 855.0,
                 },
                 {
-                  date: 2.months.ago.strftime("%Y-%m-%d"),
+                  date: 2.months.ago.to_date.strftime("%Y-%m-%d"),
                   benefits_in_kind: 0.0,
                   gross: 1500.0,
                   tax: -495.0,
@@ -61,7 +61,7 @@ module Decorators
               name: employment2.name,
               payments: [
                 {
-                  date: Date.current.strftime("%Y-%m-%d"),
+                  date: Time.zone.today.strftime("%Y-%m-%d"),
                   benefits_in_kind: 0.0,
                   gross: 1500.0,
                   tax: -495.0,
@@ -69,7 +69,7 @@ module Decorators
                   net_employment_income: 855.0,
                 },
                 {
-                  date: 1.month.ago.strftime("%Y-%m-%d"),
+                  date: 1.month.ago.to_date.strftime("%Y-%m-%d"),
                   benefits_in_kind: 0.0,
                   gross: 1500.0,
                   tax: -495.0,
@@ -77,7 +77,7 @@ module Decorators
                   net_employment_income: 855.0,
                 },
                 {
-                  date: 2.months.ago.strftime("%Y-%m-%d"),
+                  date: 2.months.ago.to_date.strftime("%Y-%m-%d"),
                   benefits_in_kind: 0.0,
                   gross: 1500.0,
                   tax: -495.0,

--- a/spec/services/decorators/v4/gross_income_decorator_spec.rb
+++ b/spec/services/decorators/v4/gross_income_decorator_spec.rb
@@ -4,6 +4,7 @@ module Decorators
   module V4
     RSpec.describe GrossIncomeDecorator do
       let(:assessment) { create :assessment }
+
       let(:summary) do
         create :gross_income_summary,
                assessment: assessment,
@@ -18,10 +19,12 @@ module Decorators
                property_or_lodger_all_sources: 250,
                property_or_lodger_bank: 250
       end
-      let(:employment1) { create :employment, :with_monthly_payments, assessment: assessment }
-      let(:employment2) { create :employment, :with_monthly_payments, assessment: assessment }
+
+      let!(:employment1) { create :employment, :with_monthly_payments, assessment: assessment }
+      let!(:employment2) { create :employment, :with_monthly_payments, assessment: assessment }
       let(:universal_credit) { create :state_benefit_type, :universal_credit }
       let(:child_benefit) { create :state_benefit_type, :child_benefit }
+
       let(:expected_results) do
         {
           employment_income: [
@@ -135,16 +138,14 @@ module Decorators
 
       describe "#as_json" do
         before do
-          create :state_benefit, state_benefit_type: universal_credit, gross_income_summary: summary, monthly_value: 979.33
-          create :state_benefit, state_benefit_type: child_benefit, gross_income_summary: summary, monthly_value: 343.27
+          create(:state_benefit, state_benefit_type: universal_credit, gross_income_summary: summary, monthly_value: 979.33)
+          create(:state_benefit, state_benefit_type: child_benefit, gross_income_summary: summary, monthly_value: 343.27)
         end
 
         subject(:decorator) { described_class.new(assessment).as_json }
 
         it "returns the expected structure" do
-          employment1
-          employment2
-          expect(decorator).to eq expected_results
+          expect(decorator).to match(expected_results)
         end
       end
     end


### PR DESCRIPTION











## WARNING: 
GGG_EMP_8/9  integration tests still fail due to negative disposable income issue - this is being worked on separately.

## What


[AP-3025](https://dsdmoj.atlassian.net/browse/AP-3025)

To get the [GGG_EMP_8](https://docs.google.com/spreadsheets/d/1fv0oNuQBIB_r2krsRCAM8lOVKdkaf8olbr6Wa-cVEE0/edit#gid=384253371) and [GGG_EMP_9](https://docs.google.com/spreadsheets/d/1fv0oNuQBIB_r2krsRCAM8lOVKdkaf8olbr6Wa-cVEE0/edit#gid=629957388) integration tests passing the `tax` and `national_insurance` for `employment_payments` needs to be converted to calendar monthly amounts. This is inline with the `gross_income` calculation.

- Add `monthly_equiv` columns for `tax` and `national_insurance`
- Update `tax_monthly_equiv` and `national_insurance_monthly_equiv` with values
  for calendar month


## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
