### PR TITLE
El-171 - Create crime assessment

### DIFF
--- a/app/models/assessment.rb
+++ b/app/models/assessment.rb
@@ -48,6 +48,10 @@ class Assessment < ApplicationRecord
     version == "3"
   end
 
+  def criminal?
+    assessment_type == "criminal"
+  end
+
 private
 
   def matter_proceeding_type_required?
@@ -55,7 +59,7 @@ private
   end
 
   def proceeding_type_codes_validations
-    return if version_3?
+    return if version_3? || criminal?
 
     proceeding_type_codes.each do |code|
       errors.add(:proceeding_type_codes, "invalid: #{code}") unless code.to_sym.in?(ProceedingTypeThreshold.valid_ccms_codes)
@@ -63,6 +67,6 @@ private
   end
 
   def proceeding_types_codes_required?
-    !version_3? && :assessment_type != "criminal"
+    !version_3? && !criminal?
   end
 end

--- a/app/models/assessment.rb
+++ b/app/models/assessment.rb
@@ -63,6 +63,6 @@ private
   end
 
   def proceeding_types_codes_required?
-    !version_3?
+    !version_3? && :assessment_type != "criminal"
   end
 end

--- a/app/services/creators/assessment_creator.rb
+++ b/app/services/creators/assessment_creator.rb
@@ -35,13 +35,18 @@ module Creators
         submission_date: Date.parse(@parsed_raw_post[:submission_date]),
         matter_proceeding_type: @parsed_raw_post[:matter_proceeding_type],
         proceeding_type_codes: ccms_codes_for_application,
+        assessment_type: assessment_type,
         version: @version,
         remote_ip: remote_ip,
       }
     end
 
+    def assessment_type
+      @parsed_raw_post[:assessment_type]
+    end
+
     def ccms_codes_for_application
-      @version == "3" ? dummy_code_for_domestic_abuse : codes_from_post
+      @version == "3" || assessment_type == "criminal" ? dummy_code_for_domestic_abuse : codes_from_post
     end
 
     # For version 3, which are all single_proceeding type (domestic abuse),

--- a/db/migrate/20220421085301_add_assessment_type_to_assessment.rb
+++ b/db/migrate/20220421085301_add_assessment_type_to_assessment.rb
@@ -1,0 +1,5 @@
+class AddAssessmentTypeToAssessment < ActiveRecord::Migration[7.0]
+  def change
+    add_column :assessments, :assessment_type, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_03_30_103236) do
+ActiveRecord::Schema[7.0].define(version: 2022_04_21_085301) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -46,6 +46,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_03_30_103236) do
     t.text "remarks"
     t.string "version"
     t.string "proceeding_type_codes"
+    t.string "assessment_type"
     t.index ["client_reference_id"], name: "index_assessments_on_client_reference_id"
   end
 

--- a/lib/integration_helpers/test_case/assessment.rb
+++ b/lib/integration_helpers/test_case/assessment.rb
@@ -31,6 +31,7 @@ module TestCase
         proceeding_types: {
           ccms_codes: @proceeding_type_codes,
         },
+        assessment_type: @assessment_type,
       }
     end
 
@@ -56,6 +57,8 @@ module TestCase
         @version = row[3].to_i.to_s
       when "proceeding_type_codes"
         @proceeding_type_codes = row[3].split(";")
+      when "assessment_type"
+        @assessment_type = row[3]
       end
     end
   end

--- a/public/schemas/assessment_request.json
+++ b/public/schemas/assessment_request.json
@@ -31,6 +31,11 @@
       "type": "string",
       "enum": ["domestic_abuse"]
     },
+    "assessment_type": {
+      "description": "The type of case the assessment relates to",
+      "type": "string",
+      "enum": ["civil", "criminal"]
+    },
     "applicant_involvement_type": {
       "description": "The type of involvement of the applicant in the case.",
       "type": "string",

--- a/spec/requests/assessments_controller_spec.rb
+++ b/spec/requests/assessments_controller_spec.rb
@@ -103,6 +103,30 @@ RSpec.describe AssessmentsController, type: :request do
       end
     end
 
+    context "criminal assessment" do
+      let(:headers) do
+        {
+          "CONTENT_TYPE" => "application/json",
+          "Accept" => "application/json; version=4",
+        }
+      end
+      let(:params) do
+        {
+          client_reference_id: "psr-123",
+          submission_date: "2019-06-06",
+          assessment_type: "criminal"
+        }
+      end
+
+      it "calls the assessment creator with version and params" do
+        expect(Creators::AssessmentCreator).to receive(:call).with(remote_ip: ipaddr, raw_post: params.to_json, version: "4").and_call_original
+        post assessments_path, params: params.to_json, headers: headers
+        expect(response).to have_http_status(:ok)
+        expect(parsed_response[:success]).to be true
+        expect(Assessment.first.assessment_type).to eq 'criminal'
+      end
+    end
+
     context "invalid version" do
       let(:headers) do
         {

--- a/spec/requests/assessments_controller_spec.rb
+++ b/spec/requests/assessments_controller_spec.rb
@@ -100,6 +100,7 @@ RSpec.describe AssessmentsController, type: :request do
         post assessments_path, params: params.to_json, headers: headers
         expect(response).to have_http_status(:ok)
         expect(parsed_response[:success]).to be true
+        expect(Assessment.first.assessment_type).to eq nil
       end
     end
 


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/EL-171)

Adds the `assessment_type` to `Assessment` model, and allows creation of it via creator and controller
Adds an integration test for this behaviour on the controller
Adds a check to an existing test to ensure `assessment_type` remains unset if not passed

Partially handles not passing `ccms_codes`, but not completely. That needs some work, but the code in its current state is useful for building other behaviours (POSTs to other endpoints that attach objects to an Assessment) on
