### PR TITLE
Dependants for crime assessment now accepted.

### DIFF
--- a/app/controllers/dependants_controller.rb
+++ b/app/controllers/dependants_controller.rb
@@ -3,7 +3,7 @@ class DependantsController < ApplicationController
   formats(%w[json])
   param :dependants, Array, required: true, desc: "An Array of Objects describing a dependant" do
     param :date_of_birth, Date, date_option: :today_or_older, required: true, desc: "The date of birth of the dependant"
-    param :in_full_time_education, :boolean, required: true, desc: "Whether or not the dependant is in full time education"
+    param :in_full_time_education, :boolean, required: false, allow_nil: true, desc: "Whether or not the dependant is in full time education"
     param :relationship, Dependant.relationships.values, required: true, desc: "What is the dependant's relationship to the applicant"
     param :monthly_income, :currency, required: false, desc: "What is the monthly income of the dependant"
     param :assets_value, :currency, required: false, desc: "What is the total assets value of the dependant"

--- a/app/services/creators/dependants_creator.rb
+++ b/app/services/creators/dependants_creator.rb
@@ -22,9 +22,17 @@ module Creators
     end
 
     def create_dependants
+      validate_in_full_time_education if assessment.assessment_type != "criminal"
+
       self.dependants = assessment.dependants.create!(dependants_attributes)
     rescue ActiveRecord::RecordInvalid => e
       raise CreationError, e.record.errors.full_messages
+    end
+
+    def validate_in_full_time_education
+      dependants_attributes.each do |dependant|
+        raise CreationError, ["in_full_time_education cannot be nil for a civil assessment"] if dependant[:in_full_time_education].nil?
+      end
     end
   end
 end

--- a/doc/apipie_examples.json
+++ b/doc/apipie_examples.json
@@ -559,42 +559,6 @@
     {
       "title": "Default",
       "verb": "POST",
-      "path": "/assessments/fc72540b-2c69-4997-87ac-0ab21e689c79/dependants",
-      "versions": [
-        "1.0"
-      ],
-      "query": null,
-      "request_data": {
-        "dependants": [
-          {
-            "date_of_birth": "1991-07-07",
-            "in_full_time_education": null,
-            "relationship": "adult_relative",
-            "monthly_income": "8732.52",
-            "assets_value": 0.0
-          },
-          {
-            "date_of_birth": "1962-04-10",
-            "in_full_time_education": null,
-            "relationship": "adult_relative",
-            "monthly_income": "3382.47",
-            "assets_value": 0.0
-          }
-        ]
-      },
-      "response_data": {
-        "success": false,
-        "errors": [
-          "Invalid parameter 'in_full_time_education' value nil: Must be one of: <code>true</code>, <code>false</code>, <code>1</code>, <code>0</code>."
-        ]
-      },
-      "code": 422,
-      "show_in_doc": 1,
-      "recorded": true
-    },
-    {
-      "title": "Default",
-      "verb": "POST",
       "path": "/assessments/c1a8cfe7-c46f-40fb-858e-d820f70b4698/dependants",
       "versions": [
         "1.0"

--- a/spec/factories/dependant_factory.rb
+++ b/spec/factories/dependant_factory.rb
@@ -7,6 +7,14 @@ FactoryBot.define do
     monthly_income { rand(1...10_000.0).round(2).to_d(Float::DIG) }
     assets_value { 0.0 }
 
+    trait :crime_dependant do
+      assessment { create :assessment, :criminal }
+      date_of_birth { Faker::Date.birthday }
+      in_full_time_education { nil }
+      monthly_income { 0.0 }
+      assets_value { 0.0 }
+    end
+
     trait :child_relative do
       relationship { :child_relative }
     end

--- a/spec/requests/dependants_controller_spec.rb
+++ b/spec/requests/dependants_controller_spec.rb
@@ -40,17 +40,6 @@ RSpec.describe DependantsController, type: :request do
       end
     end
 
-    context "invalid payload" do
-      let(:dependants_attributes) { attributes_for_list(:dependant, 2, in_full_time_education: nil) }
-
-      it "returns an error and is shown in apidocs", :show_in_doc do
-        expect(response).to have_http_status(:unprocessable_entity)
-      end
-
-      it_behaves_like "it fails with message",
-                      %(Invalid parameter 'in_full_time_education' value nil: Must be one of: <code>true</code>, <code>false</code>, <code>1</code>, <code>0</code>.)
-    end
-
     context "invalid assessment_id" do
       let(:assessment_id) { SecureRandom.uuid }
 
@@ -63,6 +52,21 @@ RSpec.describe DependantsController, type: :request do
       end
 
       it_behaves_like "it fails with message", "No such assessment id"
+    end
+
+    context "crime payload" do
+      let(:assessment) { create :assessment, :criminal }
+      let(:assessment_id) { assessment.id }
+      let(:dependants_attributes) { attributes_for_list(:dependant, 2, :crime_dependant, :under15) }
+
+      it "returns http success", :show_in_doc do
+        expect(response).to have_http_status(:success)
+      end
+
+      it "generates a valid response" do
+        expect(parsed_response[:success]).to eq(true)
+        expect(parsed_response[:errors]).to be_empty
+      end
     end
   end
 end


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/EL-139)

CFE can now accept dependants for a crime assessment.  

- The major change is the relaxing of the validation for `in_full_time_education` in the `DependantsController`.  Validation has instead moved to the model to validate parameter this for civil assessments only.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
