### PR TITLE
AP-2808 add delete script and step to circle config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,7 +80,6 @@ references:
         kubectl config set-credentials circleci --token=${K8S_TOKEN}
         kubectl config set-context ${K8S_CLUSTER_NAME} --cluster=${K8S_CLUSTER_NAME} --user=circleci --namespace=${K8S_NAMESPACE}
         kubectl config use-context ${K8S_CLUSTER_NAME}
-        kubectl config use-context ${K8S_CLUSTER_NAME}
   update_packages: &update_packages
     run:
       name: Update packages
@@ -234,6 +233,17 @@ jobs:
                         --values ./deploy/helm/values-production.yaml \
                         --set image.repository="$ECR_ENDPOINT/laa-apply-for-legal-aid/check-financial-eligibility-service" \
                         --set image.tag="${CIRCLE_SHA1}"
+  delete_dependabot_deployment:
+    executor: cloud-platform-executor
+    steps:
+      - checkout
+      - setup_remote_docker
+      - *authenticate_k8s
+      - run:
+          name: Delete dependabot deployment
+          command: |
+            ./bin/delete_dependabot_deployment
+
   clean_up_ecr:
     executor: linting-executor
     steps:
@@ -276,6 +286,15 @@ workflows:
             - lint_checks
             - unit_tests
             - build_and_push
+          <<: *generic-slack-fail-post-step
+      - delete_dependabot_deployment:
+          context: check-financial-eligibility-uat
+          filters:
+            branches:
+              only:
+                - /dependabot.*/
+          requires:
+            - deploy_uat
           <<: *generic-slack-fail-post-step
 
   merge_pr:

--- a/bin/delete_dependabot_deployment
+++ b/bin/delete_dependabot_deployment
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+RELEASE_BRANCH=$(echo $CIRCLE_BRANCH | tr '[:upper:]' '[:lower:]' | sed 's:^\w*\/::' | tr -s ' _/[]().' '-' | cut -c1-30 | sed 's/-$//')
+RELEASE_NAME="$RELEASE_BRANCH"
+echo "Attempting to delete CFE UAT dependabot release"
+echo "$RELEASE_NAME"
+
+
+UAT_RELEASES=$(helm list --namespace=${K8S_NAMESPACE} --all)
+echo "Current CFE UAT releases:"
+echo "$UAT_RELEASES"
+
+if [[ $UAT_RELEASES == *"$RELEASE_NAME"* ]]
+then
+  helm delete $RELEASE_NAME --namespace=${K8S_NAMESPACE}
+  echo "Deleted CFE UAT dependabot release $RELEASE_NAME"
+else
+  echo "UAT dependabot release $RELEASE_NAME was not found"
+fi

--- a/bin/uat_deploy
+++ b/bin/uat_deploy
@@ -10,7 +10,7 @@ deploy() {
 
   helm upgrade $RELEASE_NAME ./deploy/helm/. \
                 --install --wait \
-                --namespace=${K8S_NAMESPACE_UAT_LIVE} \
+                --namespace=${K8S_NAMESPACE} \
                 --values ./deploy/helm/values-uat.yaml \
                 --set deploy.host="$RELEASE_HOST" \
                 --set image.repository="$IMG_REPO" \


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-2808)

Add delete dependabot script
add section in circle config to call script on dependabot branches
Update uat_deploy to use contexts and the correct env_var, also updated the K8S_NAMESPACE env var in CFE UAT context as this was pointing at staging, now points to uat

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
