### PR TITLE
AP-3150 Make V4 the default version

### DIFF
--- a/app/constants/cfe_constants.rb
+++ b/app/constants/cfe_constants.rb
@@ -1,8 +1,8 @@
 module CFEConstants
   # Versions
   #
-  DEFAULT_ASSESSMENT_VERSION = "3".freeze
-  VALID_ASSESSMENT_VERSIONS = [DEFAULT_ASSESSMENT_VERSION, "4"].freeze
+  DEFAULT_ASSESSMENT_VERSION = "4".freeze
+  VALID_ASSESSMENT_VERSIONS = [DEFAULT_ASSESSMENT_VERSION, "3"].freeze
 
   # Income categories
   #

--- a/spec/integration/ap_1367_spec.rb
+++ b/spec/integration/ap_1367_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe "Full Assessment with remarks" do
   end
 
   def post_assessment
-    post assessments_path, params: assessment_params, headers: headers
+    post assessments_path, params: assessment_params, headers: v3_headers
     output_response(:post, :assessment)
     parsed_response[:assessment_id]
   end
@@ -102,7 +102,7 @@ RSpec.describe "Full Assessment with remarks" do
   end
 
   def v3_headers
-    { "Accept" => "application/json;version=3" }
+    { "CONTENT_TYPE" => "application/json", "Accept" => "application/json;version=3" }
   end
 
   def assessment_params

--- a/spec/integration/ap_2996_employment_remarks_spec.rb
+++ b/spec/integration/ap_2996_employment_remarks_spec.rb
@@ -190,11 +190,11 @@ RSpec.describe "Full Assessment with remarks" do
   end
 
   def post_headers
-    { "CONTENT_TYPE" => "application/json" }
+    { "CONTENT_TYPE" => "application/json", "Accept" => "application/json;version=3" }
   end
 
   def v4_headers
-    { "Accept" => "application/json;version=4" }
+    { "CONTENT_TYPE" => "application/json", "Accept" => "application/json;version=4" }
   end
 
   def assessment_params

--- a/spec/integration/policy_disregards_spec.rb
+++ b/spec/integration/policy_disregards_spec.rb
@@ -88,11 +88,11 @@ RSpec.describe "Eligible Full Assessment with policy disregard remarks" do
   end
 
   def headers
-    { "CONTENT_TYPE" => "application/json" }
+    v3_headers
   end
 
   def v3_headers
-    { "Accept" => "application/json;version=3" }
+    { "CONTENT_TYPE" => "application/json", "Accept" => "application/json;version=3" }
   end
 
   def assessment_params

--- a/spec/integration/remarks_spec.rb
+++ b/spec/integration/remarks_spec.rb
@@ -45,38 +45,38 @@ RSpec.describe "contribution_required Full Assessment with remarks" do
   end
 
   def post_assessment
-    post assessments_path, params: assessment_params, headers: headers
+    post assessments_path, params: assessment_params, headers: v3_headers
     output_response(:post, :assessment)
     parsed_response[:assessment_id]
   end
 
   def post_applicant(assessment_id)
-    post assessment_applicant_path(assessment_id), params: applicant_params, headers: headers
+    post assessment_applicant_path(assessment_id), params: applicant_params, headers: v3_headers
     output_response(:post, :applicant)
   end
 
   def post_capitals(assessment_id)
-    post assessment_capitals_path(assessment_id), params: capitals_params, headers: headers
+    post assessment_capitals_path(assessment_id), params: capitals_params, headers: v3_headers
     output_response(:post, :capitals)
   end
 
   def post_other_incomes(assessment_id)
-    post assessment_other_incomes_path(assessment_id), params: other_income_params, headers: headers
+    post assessment_other_incomes_path(assessment_id), params: other_income_params, headers: v3_headers
     output_response(:post, :other_incomes)
   end
 
   def post_outgoings(assessment_id)
-    post assessment_outgoings_path(assessment_id), params: outgoings_params, headers: headers
+    post assessment_outgoings_path(assessment_id), params: outgoings_params, headers: v3_headers
     output_response(:post, :outgoings)
   end
 
   def post_state_benefits(assessment_id)
-    post assessment_state_benefits_path(assessment_id), params: state_benefit_params, headers: headers
+    post assessment_state_benefits_path(assessment_id), params: state_benefit_params, headers: v3_headers
     output_response(:post, :state_benefits)
   end
 
   def post_explicit_remarks(assessment_id)
-    post assessment_explicit_remarks_path(assessment_id), params: explicit_remarks_params, headers: headers
+    post assessment_explicit_remarks_path(assessment_id), params: explicit_remarks_params, headers: v3_headers
     output_response(:post, :explicit_remarks)
   end
 
@@ -90,12 +90,8 @@ RSpec.describe "contribution_required Full Assessment with remarks" do
     ENV["VERBOSE"] == "true"
   end
 
-  def headers
-    { "CONTENT_TYPE" => "application/json" }
-  end
-
   def v3_headers
-    { "Accept" => "application/json;version=3" }
+    { "CONTENT_TYPE" => "application/json", "Accept" => "application/json;version=3" }
   end
 
   def assessment_params


### PR DESCRIPTION
This is done because V3 is now deprecated, and with V4 the default it becomes easier to
generate RSWAG documentation for V4


## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-XXX)

Describe what you did and why.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
