### PR TITLE
Configure rspec focus capabillity

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -77,12 +77,18 @@ RSpec.configure do |config|
 
   # The settings below are suggested to provide a good initial experience
   # with RSpec, but feel free to customize to your heart's content.
-  #   # This allows you to limit a spec run to individual examples or groups
-  #   # you care about by tagging them with `:focus` metadata. When nothing
-  #   # is tagged with `:focus`, all examples get run. RSpec also provides
-  #   # aliases for `it`, `describe`, and `context` that include `:focus`
-  #   # metadata: `fit`, `fdescribe` and `fcontext`, respectively.
-  #   config.filter_run_when_matching :focus
+
+  # These two settings work together to allow you to limit a spec run
+  # to individual examples or groups you care about by tagging them with
+  # `:focus` metadata. When nothing is tagged with `:focus`, all examples
+  # get run.
+  # NOTE: ENV['CI'] is a variable that is populated on circleci, at least, which
+  # thereby prevents focused running in the CI pipeline.
+  #
+  # NOTE: you can also use `fit`, `fdescribe`, `fcontext` to focus specs
+  #
+  config.filter_run_including focus: true unless ENV["CI"]
+  config.run_all_when_everything_filtered = true
   #
   #   # Allows RSpec to persist some state between runs in order to support
   #   # the `--only-failures` and `--next-failure` CLI options. We recommend


### PR DESCRIPTION
## What
Enable rspec focused spec running

Thought this had already be configured but looks like not. I, if no
one else, like to use `fdescribe` etc to run certain specs locally.

The check for `ENV['CI']` means it will never run focused specs on circle
(and Github actions I believe).


## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
