### PR TITLE
Remove the requirement for proceeding type for crime

### DIFF
--- a/app/services/creators/assessment_creator.rb
+++ b/app/services/creators/assessment_creator.rb
@@ -46,7 +46,7 @@ module Creators
     end
 
     def ccms_codes_for_application
-      @version == "3" || assessment_type == "criminal" ? dummy_code_for_domestic_abuse : codes_from_post
+      @version == "3" ? dummy_code_for_domestic_abuse : codes_from_post
     end
 
     # For version 3, which are all single_proceeding type (domestic abuse),
@@ -58,7 +58,7 @@ module Creators
     end
 
     def codes_from_post
-      @parsed_raw_post[:proceeding_types][:ccms_codes]
+      @parsed_raw_post[:proceeding_types] ? @parsed_raw_post[:proceeding_types][:ccms_codes] : []
     end
 
     def new_assessment

--- a/app/services/creators/eligibilities_creator.rb
+++ b/app/services/creators/eligibilities_creator.rb
@@ -9,7 +9,7 @@ module Creators
     end
 
     def call
-      if @assessment.assessment_type == "criminal"
+      if @assessment.criminal?
         AdjustedIncomeEligibilityCreator.call(@assessment)
       else
         GrossIncomeEligibilityCreator.call(@assessment)

--- a/spec/factories/assessment_factory.rb
+++ b/spec/factories/assessment_factory.rb
@@ -9,6 +9,9 @@ FactoryBot.define do
 
     trait :criminal do
       assessment_type { "criminal" }
+      proceeding_type_codes { nil }
+      matter_proceeding_type { nil }
+      version { "4" }
     end
 
     trait :with_applicant do

--- a/spec/integration/test_runner_spec.rb
+++ b/spec/integration/test_runner_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe "IntegrationTests::TestRunner", type: :request do
       worksheet.parse_worksheet
       assessment_id = post_assessment(worksheet)
 
-      worksheet.payload_objects.each { |obj| post_object(obj, assessment_id, worksheet.version) }
+      worksheet.payload_objects.each { |obj| post_object(obj, assessment_id, worksheet.version, worksheet.description) }
       actual_results = get_assessment(assessment_id, worksheet.version)
       worksheet.compare_results(actual_results)
     end
@@ -74,13 +74,13 @@ RSpec.describe "IntegrationTests::TestRunner", type: :request do
       parsed_response
     end
 
-    def noisy_post(url, payload, version)
+    def noisy_post(url, payload, version, description)
       puts ">>>>>>>>>>>> #{url} V#{version} #{__FILE__}:#{__LINE__} <<<<<<<<<<<<".yellow unless silent?
       pp payload if noisy?
       post url, params: payload.to_json, headers: headers(version)
       pp parsed_response if noisy?
       puts " \n" if noisy?
-      raise "Unsuccessful response: #{parsed_response.inspect}" unless parsed_response[:success]
+      raise "Unsuccessful response: #{parsed_response.inspect} *** #{description} ***" unless parsed_response[:success]
 
       parsed_response
     end
@@ -88,17 +88,17 @@ RSpec.describe "IntegrationTests::TestRunner", type: :request do
     def post_assessment(worksheet)
       url = worksheet.assessment.url
       payload = worksheet.assessment.payload
-      noisy_post url, payload, worksheet.version
+      noisy_post url, payload, worksheet.version, worksheet.description
       parsed_response[:assessment_id]
     end
 
-    def post_object(obj, assessment_id, version)
+    def post_object(obj, assessment_id, version, description)
       return if obj.blank?
 
       url_method = obj.__send__(:url_method)
       url = Rails.application.routes.url_helpers.__send__(url_method, assessment_id)
       payload = obj.__send__(:payload)
-      noisy_post(url, payload, version)
+      noisy_post(url, payload, version, description)
     end
 
     def silent?

--- a/spec/models/assessment_spec.rb
+++ b/spec/models/assessment_spec.rb
@@ -138,6 +138,7 @@ RSpec.describe Assessment, type: :model do
           client_reference_id: "client-ref-1",
           submission_date: Date.current,
           proceeding_type_codes: nil,
+          matter_proceeding_type: nil,
           assessment_type: "criminal",
           remote_ip: "127.0.0.1",
           version: "4",

--- a/spec/models/assessment_spec.rb
+++ b/spec/models/assessment_spec.rb
@@ -131,5 +131,24 @@ RSpec.describe Assessment, type: :model do
         expect(assessment.remarks.as_json).to eq Remarks.new(assessment.id).as_json
       end
     end
+
+    context "criminal" do
+      let(:param_hash) do
+        {
+          client_reference_id: "client-ref-1",
+          submission_date: Date.current,
+          proceeding_type_codes: nil,
+          assessment_type: "criminal",
+          remote_ip: "127.0.0.1",
+          version: "4",
+        }
+      end
+
+      it "creates a valid assessment" do
+        assessment = described_class.create param_hash
+        expect(assessment.persisted?).to be true
+        expect(assessment.valid?).to be true
+      end
+    end
   end
 end

--- a/spec/services/creators/assessment_creator_spec.rb
+++ b/spec/services/creators/assessment_creator_spec.rb
@@ -26,6 +26,14 @@ module Creators
       }.to_json
     end
 
+    let(:raw_post_crime) do
+      {
+        client_reference_id: "psr-123",
+        submission_date: "2022-06-22",
+        assessment_type: "criminal",
+      }.to_json
+    end
+
     subject(:creator) { described_class.call(remote_ip:, raw_post:, version:) }
 
     context "version 3" do
@@ -169,6 +177,30 @@ module Creators
               errors: [],
             }
             expect(creator.as_json).to eq expected_response
+          end
+        end
+      end
+
+      context "criminal assessment" do
+        let(:raw_post) { raw_post_crime }
+        let(:version) { "4" }
+  
+        context "valid request" do
+          it "is successful" do
+            expect(creator.success?).to eq true
+          end
+  
+          it "creates an Assessment record" do
+            expect { creator.success? }.to change(Assessment, :count).by(1)
+          end
+  
+          it "populates the assessment record with expected values" do
+            creator.success?
+            assessment = Assessment.first
+            expect(assessment.version).to eq "4"
+            expect(assessment.remote_ip).to eq "127.0.0.1"
+            expect(assessment.matter_proceeding_type).to be_nil
+            expect(assessment.proceeding_type_codes).to eq []
           end
         end
       end

--- a/spec/services/creators/assessment_creator_spec.rb
+++ b/spec/services/creators/assessment_creator_spec.rb
@@ -184,16 +184,16 @@ module Creators
       context "criminal assessment" do
         let(:raw_post) { raw_post_crime }
         let(:version) { "4" }
-  
+
         context "valid request" do
           it "is successful" do
             expect(creator.success?).to eq true
           end
-  
+
           it "creates an Assessment record" do
             expect { creator.success? }.to change(Assessment, :count).by(1)
           end
-  
+
           it "populates the assessment record with expected values" do
             creator.success?
             assessment = Assessment.first


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/EL-171)

Removes the requirement for a proceeding type to be present in crime assessments.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
