### PR TITLE
Ap 3318 changes to integration tests parser v5

### DIFF
--- a/app/services/decorators/v5/assessment_decorator.rb
+++ b/app/services/decorators/v5/assessment_decorator.rb
@@ -7,9 +7,8 @@ module Decorators
 
       # class aliases for V4
       GrossIncomeDecorator = ::Decorators::V4::GrossIncomeDecorator
-      DisposableIncomeDecorator = ::Decorators::V4::DisposableIncomeDecorator
       CapitalDecorator = ::Decorators::V4::CapitalDecorator
-      ResultSummaryDecorator = ::Decorators::V4::ResultSummaryDecorator
+      DisposableIncomeDecorator = ::Decorators::V4::DisposableIncomeDecorator
 
       attr_reader :assessment
 

--- a/app/services/decorators/v5/capital_result_decorator.rb
+++ b/app/services/decorators/v5/capital_result_decorator.rb
@@ -1,0 +1,30 @@
+module Decorators
+  module V5
+    class CapitalResultDecorator
+      def initialize(assessment)
+        @assessment = assessment
+      end
+
+      def as_json
+        {
+          total_liquid: summary.total_liquid.to_f,
+          total_non_liquid: summary.total_non_liquid.to_f,
+          total_vehicle: summary.total_vehicle.to_f,
+          total_property: summary.total_property.to_f,
+          total_mortgage_allowance: summary.total_mortgage_allowance.to_f,
+          total_capital: summary.total_capital.to_f,
+          pensioner_capital_disregard: summary.pensioner_capital_disregard.to_f,
+          capital_contribution: summary.capital_contribution.to_f,
+          assessed_capital: summary.assessed_capital.to_f,
+          proceeding_types: ProceedingTypesResultDecorator.new(summary).as_json,
+        }
+      end
+
+    private
+
+      def summary
+        @summary ||= @assessment.capital_summary
+      end
+    end
+  end
+end

--- a/app/services/decorators/v5/disposable_income_result_decorator.rb
+++ b/app/services/decorators/v5/disposable_income_result_decorator.rb
@@ -1,0 +1,49 @@
+module Decorators
+  module V5
+    class DisposableIncomeResultDecorator
+      def initialize(assessment)
+        @assessment = assessment
+      end
+
+      def as_json
+        {
+          dependant_allowance: summary.dependant_allowance.to_f,
+          gross_housing_costs: summary.gross_housing_costs.to_f,
+          housing_benefit: summary.housing_benefit.to_f,
+          net_housing_costs: summary.net_housing_costs.to_f,
+          maintenance_allowance: summary.maintenance_out_all_sources.to_f,
+          total_outgoings_and_allowances: summary.total_outgoings_and_allowances.to_f,
+          total_disposable_income: summary.total_disposable_income.to_f,
+          employment_income:,
+          income_contribution: summary.income_contribution.to_f,
+          proceeding_types: ProceedingTypesResultDecorator.new(summary).as_json,
+        }
+      end
+
+    private
+
+      def summary
+        @summary ||= @assessment.disposable_income_summary
+      end
+
+      def gross_income_summary
+        @gross_income_summary ||= @assessment.gross_income_summary
+      end
+
+      def net_employment_income
+        gross_income_summary.gross_employment_income + summary.employment_income_deductions + summary.fixed_employment_allowance
+      end
+
+      def employment_income
+        {
+          gross_income: gross_income_summary.gross_employment_income.to_f,
+          benefits_in_kind: gross_income_summary.benefits_in_kind.to_f,
+          tax: summary.tax.to_f,
+          national_insurance: summary.national_insurance.to_f,
+          fixed_employment_deduction: summary.fixed_employment_allowance.to_f,
+          net_employment_income: net_employment_income.to_f,
+        }
+      end
+    end
+  end
+end

--- a/app/services/decorators/v5/gross_income_result_decorator.rb
+++ b/app/services/decorators/v5/gross_income_result_decorator.rb
@@ -1,0 +1,26 @@
+module Decorators
+  module V5
+    class GrossIncomeResultDecorator
+      delegate :gross_income_summary, to: :assessment
+
+      attr_reader :assessment
+
+      def initialize(assessment)
+        @assessment = assessment
+      end
+
+      def as_json
+        {
+          total_gross_income: gross_income_summary.total_gross_income.to_f,
+          proceeding_types: ProceedingTypesResultDecorator.new(summary).as_json,
+        }
+      end
+
+    private
+
+      def summary
+        @summary ||= @assessment.gross_income_summary
+      end
+    end
+  end
+end

--- a/app/services/decorators/v5/matter_type_result_decorator.rb
+++ b/app/services/decorators/v5/matter_type_result_decorator.rb
@@ -1,0 +1,40 @@
+module Decorators
+  module V5
+    class MatterTypeResultDecorator
+      def initialize(assessment)
+        @assessment = assessment
+        @matter_types_hash = {}
+      end
+
+      def as_json
+        collate_results
+      end
+
+    private
+
+      def collate_results
+        @assessment.proceeding_types.each { |proceeding_type| add_matter_type(proceeding_type) }
+        @matter_types_hash.keys.sort.map do |matter_type|
+          {
+            matter_type:,
+            result: @matter_types_hash[matter_type],
+          }
+        end
+      end
+
+      def add_matter_type(proceeding_type)
+        matter_type = ProceedingTypeThreshold.matter_type(proceeding_type.ccms_code)
+        if @matter_types_hash.key?(matter_type)
+          raise "Different results for matter type #{matter_type}" unless @matter_types_hash[matter_type] == result(proceeding_type)
+        else
+          @matter_types_hash[matter_type] = result(proceeding_type)
+        end
+      end
+
+      def result(proceeding_type)
+        elig = @assessment.eligibilities.find_by(proceeding_type_code: proceeding_type.ccms_code)
+        elig.assessment_result
+      end
+    end
+  end
+end

--- a/app/services/decorators/v5/proceeding_types_result_decorator.rb
+++ b/app/services/decorators/v5/proceeding_types_result_decorator.rb
@@ -1,0 +1,35 @@
+module Decorators
+  module V5
+    class ProceedingTypesResultDecorator
+      def initialize(assessment_or_summary)
+        @assessment_or_summary = assessment_or_summary
+      end
+
+      def as_json
+        proceeding_types.map { |proceeding_type| pt_result(proceeding_type) }
+      end
+
+    private
+
+      def pt_result(proceeding_type)
+        elig = @assessment_or_summary.eligibilities.find_by(proceeding_type_code: proceeding_type.ccms_code)
+        {
+          ccms_code: proceeding_type.ccms_code,
+          client_involvement_type: proceeding_type.client_involvement_type,
+          upper_threshold: elig.upper_threshold.to_f,
+          lower_threshold: elig.lower_threshold.to_f,
+          result: elig.assessment_result,
+        }
+      end
+
+      def proceeding_types
+        case @assessment_or_summary.class.to_s
+        when "Assessment"
+          @assessment_or_summary.proceeding_types
+        when "DisposableIncomeSummary", "GrossIncomeSummary", "CapitalSummary"
+          @assessment_or_summary.assessment.proceeding_types
+        end
+      end
+    end
+  end
+end

--- a/app/services/decorators/v5/result_summary_decorator.rb
+++ b/app/services/decorators/v5/result_summary_decorator.rb
@@ -1,0 +1,30 @@
+module Decorators
+  module V5
+    class ResultSummaryDecorator
+      attr_reader :assessment
+
+      delegate :capital_summary,
+               :disposable_income_summary,
+               to: :assessment
+
+      def initialize(assessment)
+        @assessment = assessment
+      end
+
+      def as_json
+        {
+          overall_result: {
+            result: @assessment.assessment_result,
+            capital_contribution: capital_summary.capital_contribution.to_f,
+            income_contribution: disposable_income_summary.income_contribution.to_f,
+            matter_types: MatterTypeResultDecorator.new(@assessment).as_json,
+            proceeding_types: ProceedingTypesResultDecorator.new(@assessment).as_json,
+          },
+          gross_income: GrossIncomeResultDecorator.new(@assessment).as_json,
+          disposable_income: DisposableIncomeResultDecorator.new(@assessment).as_json,
+          capital: CapitalResultDecorator.new(@assessment).as_json,
+        }
+      end
+    end
+  end
+end

--- a/lib/integration_helpers/test_case/assessment.rb
+++ b/lib/integration_helpers/test_case/assessment.rb
@@ -13,7 +13,14 @@ module TestCase
 
     def payload
       @version = "3" if @version.nil?
-      @version == "3" ? version_3_payload : version_4_payload
+      case @version
+      when ""
+        version_3_payload
+      when "4"
+        version_4_payload
+      else
+        version_5_payload
+      end
     end
 
     def version_3_payload
@@ -31,6 +38,13 @@ module TestCase
         proceeding_types: {
           ccms_codes: @proceeding_type_codes,
         },
+      }
+    end
+
+    def version_5_payload
+      {
+        client_reference_id: @worksheet_name,
+        submission_date: @submission_date,
       }
     end
 

--- a/lib/integration_helpers/test_case/assessment.rb
+++ b/lib/integration_helpers/test_case/assessment.rb
@@ -14,7 +14,7 @@ module TestCase
     def payload
       @version = "3" if @version.nil?
       case @version
-      when ""
+      when "3"
         version_3_payload
       when "4"
         version_4_payload

--- a/lib/integration_helpers/test_case/proceeding_type.rb
+++ b/lib/integration_helpers/test_case/proceeding_type.rb
@@ -1,0 +1,20 @@
+module TestCase
+  class ProceedingType
+    def initialize(rows)
+      @proceeding_type_code = rows.first[3]
+      @client_involvement_type = rows.last[3]
+    end
+
+    def all_nil?
+      @proceeding_type_code.nil? &&
+        @client_involvement_type.nil?
+    end
+
+    def payload
+      {
+        ccms_code: @proceeding_type_code,
+        client_involvement_type: @client_involvement_type,
+      }
+    end
+  end
+end

--- a/lib/integration_helpers/test_case/proceeding_types_collection.rb
+++ b/lib/integration_helpers/test_case/proceeding_types_collection.rb
@@ -1,0 +1,36 @@
+require Rails.root.join("lib/integration_helpers/test_case/proceeding_type.rb")
+
+module TestCase
+  class ProceedingTypesCollection
+    def initialize(rows)
+      @proceeding_types = []
+      populate_proceeding_types(rows)
+    end
+
+    def url_method
+      :assessment_proceeding_types_path
+    end
+
+    def payload
+      {
+        proceeding_types: @proceeding_types.map(&:payload),
+      }
+    end
+
+    def empty?
+      false
+    end
+
+  private
+
+    def populate_proceeding_types(rows)
+      loop do
+        break if rows.empty?
+
+        proceeding_type_data = rows.shift(2)
+        proceeding_type = ::TestCase::ProceedingType.new(proceeding_type_data)
+        @proceeding_types << proceeding_type unless proceeding_type.all_nil?
+      end
+    end
+  end
+end

--- a/lib/integration_helpers/test_case/v5/expected_result.rb
+++ b/lib/integration_helpers/test_case/v5/expected_result.rb
@@ -1,0 +1,137 @@
+module TestCase
+  module V5
+    class ExpectedResult
+      attr_reader :result_set
+
+      def initialize(rows)
+        @rows = rows
+        @result_set = {}
+        @rows.shift
+        populate
+      end
+
+      def compare(actual_result, verbosity_level)
+        ResultComparer.call(actual_result, @result_set, verbosity_level)
+      end
+
+    private
+
+      def populate
+        while @rows.any?
+          col1 = @rows.first[0]
+          extracted_rows = extract_rows
+          __send__(col1, extracted_rows)
+        end
+      end
+
+      def remarks(rows)
+        hash = {}
+        current_issue = nil
+        current_type = nil
+        while rows.any?
+          row = rows.shift
+          _unused, type, issue, id = row
+          if type.present?
+            current_type = type.to_sym
+            hash[current_type] = {}
+          end
+          if issue.present?
+            current_issue = issue.to_sym
+            hash[current_type][current_issue] = []
+          end
+
+          hash[current_type][current_issue] << id
+        end
+        @result_set[:remarks] = hash
+      end
+
+      def extract_rows
+        row_index = @rows.index { |r| r.first.present? && r.first != @rows.first.first }
+        row_index.nil? ? @rows : @rows.shift(row_index)
+      end
+
+      def assessment(rows)
+        hash = {
+          matter_types: [],
+          proceeding_types: {},
+        }
+        while rows.any?
+          case rows.first[1]
+          when "matter_types"
+            store_matter_types(hash, extract_matter_type_rows(rows))
+          when /^proceeding_type:/
+            store_proceeding_types(hash, extract_proceeding_type_rows(rows))
+          else
+            hash[rows.first[1].to_sym] = rows.first[3]
+            rows.shift
+          end
+        end
+        @result_set[:assessment] = hash
+      end
+
+      def store_matter_types(hash, rows)
+        while rows.any?
+          row = rows.shift
+          next if row[2].nil?
+
+          hash[:matter_types] << { row[2].to_sym => row[3] }
+        end
+      end
+
+      def store_proceeding_types(hash, rows)
+        while rows.any?
+          row = rows.shift
+          if row[1] =~ /^proceeding_type:\s([A-Z]{2}[0-9]{3})$/
+            ptc = Regexp.last_match(1)
+            hash[:proceeding_types][ptc] = { result: row[3] }
+            next
+          end
+          hash[:proceeding_types][ptc][row[2].to_sym] = row[3]
+        end
+      end
+
+      def extract_matter_type_rows(rows)
+        row_index = rows.index { |r| r[1].present? && r[1] != "matter_types" }
+        rows.shift(row_index)
+      end
+
+      def extract_proceeding_type_rows(rows)
+        row_index = rows.index { |r| r[0].present? }
+        row_index.nil? ? rows : rows.shift(row_index)
+      end
+
+      def store_standard_expectations(section_name, rows)
+        hash = {}
+        while rows.any?
+          row = rows.shift
+          hash[row[1].to_sym] = row[3]
+        end
+        @result_set[section_name] = hash
+      end
+
+      def gross_income_summary(rows)
+        store_standard_expectations(:gross_income_summary, rows)
+      end
+
+      def disposable_income_summary(rows)
+        store_standard_expectations(:disposable_income_summary, rows)
+      end
+
+      def capital(rows)
+        store_standard_expectations(:capital, rows)
+      end
+
+      def monthly_income_equivalents(rows)
+        store_standard_expectations(:monthly_income_equivalents, rows)
+      end
+
+      def monthly_outgoing_equivalents(rows)
+        store_standard_expectations(:monthly_outgoing_equivalents, rows)
+      end
+
+      def deductions(rows)
+        store_standard_expectations(:deductions, rows)
+      end
+    end
+  end
+end

--- a/lib/integration_helpers/test_case/v5/remarks_comparer.rb
+++ b/lib/integration_helpers/test_case/v5/remarks_comparer.rb
@@ -1,0 +1,74 @@
+module TestCase
+  module V5
+    class RemarksComparer
+      def self.call(expected, actual, verbosity)
+        new(expected, actual, verbosity).call
+      end
+
+      def initialize(expected, actual, verbosity)
+        @expected = expected
+        @actual = actual
+        @verbosity = verbosity
+        @header_pattern = "%58s  %-26s %-s"
+        @result = true
+      end
+
+      def call
+        print_actual_remarks unless silent?
+
+        return true if @expected.blank?
+
+        compare_remarks
+
+        @result
+      end
+
+      def silent?
+        @verbosity.zero?
+      end
+
+      def compare_remarks
+        puts "Remarks >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>".green unless silent?
+
+        @expected.each { |remark_type, remark_type_hash| compare_remark_type(remark_type, remark_type_hash) }
+      end
+
+      def compare_remark_type(type, hash)
+        hash.each do |issue, _ids|
+          actual_unsorted_remarks = @actual&.dig(type)&.dig(issue)
+          actual_remarks = actual_unsorted_remarks.nil? ? nil : actual_unsorted_remarks.sort
+          next if actual_remarks == @expected[type][issue].sort
+
+          @result = false
+          print_remark_line(type, issue) unless silent?
+        end
+      end
+
+      def print_remark_line(type, issue)
+        color = :red
+        puts "#{type}/#{issue}".__send__(color)
+        puts "  expected:"
+        @expected[type][issue].each { |id| puts "    #{id}" }
+        puts "  actual:"
+        @actual&.dig(type)&.dig(issue)&.each { |id| puts "    #{id}" }
+        puts "  "
+      end
+
+      def print_actual_remarks
+        puts "Actual remaks returned from CFE >>>>>>>>>>>>>>>>>>>>>>>>>".blue
+        @actual.each do |type, issue|
+          puts "#{type}:".blue
+          issue.each do |issue_name, ids|
+            puts "  #{issue_name}:".blue
+            ids.each { |id| puts "    #{id}".blue }
+          end
+        end
+      end
+
+      def verbose(string, color = :green)
+        puts string.__send__(color) unless silent?
+        @result = false if color == :red
+      end
+    end
+  end
+end

--- a/lib/integration_helpers/test_case/v5/result_comparer.rb
+++ b/lib/integration_helpers/test_case/v5/result_comparer.rb
@@ -1,0 +1,338 @@
+require_relative "remarks_comparer"
+
+module TestCase
+  module V5
+    class ResultComparer
+      def self.call(actual, expected, verbosity)
+        new(actual, expected, verbosity).call
+      end
+
+      def initialize(actual, expected, verbosity)
+        @actual = actual
+        @expected = expected
+        @verbosity = verbosity
+        @result = true
+        @header_pattern = "%58s  %-26s %-s"
+      end
+
+      def call
+        print_headings
+        compare_assessment
+        compare_matter_types
+        compare_proceeding_types
+        compare_gross_income
+        compare_disposable_income
+        compare_capital
+        @result = false if RemarksComparer.call(@expected[:remarks], @actual[:assessment][:remarks], @verbosity) == false
+        @result
+      end
+
+    private
+
+      def silent?
+        @verbosity.zero?
+      end
+
+      def print_headings
+        verbose sprintf(@header_pattern, client_reference_id, "Expected", "Actual")
+        verbose sprintf(@header_pattern, "", "=========", "=========")
+      end
+
+      def print_mismatched_matter_types
+        verbose "Matter type names do not match expected", :red
+        verbose "  Expected: #{expected_matter_type_names.join(', ')}", :red
+        verbose "  Actual  : #{actual_matter_type_names.join(', ')}", :red
+      end
+
+      def print_mismatched_proceeding_type_codes
+        verbose "Proceeding type codes do not match expected", :red
+        verbose "  Expected: #{expected_proceeding_type_codes.join(', ')}", :red
+        verbose "  Actual  : #{actual_proceeding_type_codes.join(', ')}", :red
+      end
+
+      def print_matter_type_details
+        expected_matter_types.each do |matter_type_hash|
+          name = matter_type_hash.keys.first
+          expected_result = matter_type_hash[name]
+          actual_result = actual_matter_type_result_for(name)
+          color = actual_result == expected_result ? :green : :red
+          verbose sprintf(@header_pattern, "Matter type: #{name}", expected_result, actual_result), color
+        end
+      end
+
+      def client_reference_id
+        @actual[:assessment][:client_reference_id]
+      end
+
+      def compare_assessment
+        compare_and_print("assessment_result", actual_overall_result[:result], expected_assessment[:assessment_result])
+      end
+
+      def compare_matter_types
+        if expected_matter_type_names == actual_matter_type_names
+          print_matter_type_details
+        else
+          print_mismatched_matter_types
+        end
+      end
+
+      def compare_proceeding_types
+        if actual_proceeding_type_codes == expected_proceeding_type_codes
+          expected_proceeding_types.each { |code, expected_result_hash| compare_proceeding_type_detail(code, expected_result_hash) }
+        else
+          print_mismatched_proceeding_type_codes
+        end
+      end
+
+      def compare_proceeding_type_detail(code, expected_result_hash)
+        verbose "Proceeding_type #{code}", :green
+        compare_and_print("result", actual_proceeding_type_result(code), expected_result_hash[:result])
+        compare_and_print("capital lower threshold", actual_cap_result_for(code)[:lower_threshold], expected_result_hash[:capital_lower_threshold])
+        compare_and_print("capital upper threshold", actual_cap_result_for(code)[:upper_threshold], expected_result_hash[:capital_upper_threshold])
+        compare_and_print("gross income upper threshold", actual_gross_income_result_for(code)[:upper_threshold], expected_result_hash[:gross_income_upper_threshold])
+        compare_and_print("disposable income lower threshold", actual_disposable_income_result_for(code)[:lower_threshold],
+                          expected_result_hash[:disposable_income_lower_threshold])
+        compare_and_print("disposable income upper threshold", actual_disposable_income_result_for(code)[:upper_threshold],
+                          expected_result_hash[:disposable_income_upper_threshold])
+      end
+
+      def compare_and_print(legend, actual, expected)
+        color = :green
+        color = :red unless actual.to_s == expected.to_s
+        color = :blue if expected.nil?
+        verbose sprintf(@header_pattern, legend, expected, actual), color
+      end
+
+      def compare_gross_income
+        puts "Gross income >>>>>>>>>>>>>>>>>>>>>>>>>".green unless silent?
+        compare_and_print("monthly other income", actual_gross_other_income, expected_gi_other_income)
+        compare_and_print("monthly state benefits", actual_gross_state_benefits, expected_gi_state_benefits)
+        compare_and_print("monthly student loan", actual_student_loan, expected_gi_student_loan)
+        compare_and_print("employment_income_gross", actual_employment_income[:gross_income], expected_employment_income_gross)
+        compare_and_print("employment_income_benefits_in_kind", actual_employment_income[:benefits_in_kind], expected_employment_income_benefits_in_kind)
+        compare_and_print("employment_income_tax",  actual_employment_income[:tax], expected_employment_income_tax)
+        compare_and_print("employment_income_nic",  actual_employment_income[:national_insurance], expected_employment_income_nic)
+        compare_and_print("fixed_employment_allowance", actual_employment_income[:fixed_employment_deduction], expected_fixed_employment_allowance)
+        compare_and_print("total gross income", actual_total_gross_income, expected_total_gross_income)
+      end
+
+      def compare_disposable_income
+        puts "Disposable income >>>>>>>>>>>>>>>>>>>>>>".green unless silent?
+        compare_and_print("childcare", actual_disposable(:child_care), expected_disposable(:childcare))
+        compare_and_print("dependant allowance", actual_dependant_allowance, expected_disposable(:dependant_allowance))
+        compare_and_print("maintenance", actual_disposable(:maintenance_out), expected_disposable(:maintenance))
+        compare_and_print("gross_housing_costs", actual_disposable(:rent_or_mortgage), expected_disposable(:gross_housing_costs))
+        compare_and_print("housing benefit", disposable_income_result[:housing_benefit], expected_disposable(:housing_benefit))
+        compare_and_print("net housing costs", disposable_income_result[:net_housing_costs], expected_disposable(:net_housing_costs))
+        compare_and_print("total outgoings and allowances", disposable_income_result[:total_outgoings_and_allowances], expected_disposable(:total_outgoings_and_allowances))
+        compare_and_print("total disposable income", disposable_income_result[:total_disposable_income], expected_disposable(:total_disposable_income))
+        compare_and_print("income contribution", disposable_income_result[:income_contribution], expected_disposable(:income_contribution))
+      end
+
+      def compare_capital
+        puts "Capital >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>".green unless silent?
+        expected_capital.each do |key, value|
+          compare_and_print(key, actual_capital[key], value)
+        end
+      end
+
+      def verbose(string, color = :green)
+        puts string.__send__(color) unless silent?
+        @result = false if color == :red
+      end
+
+      def actual_result_summary
+        @actual[:result_summary]
+      end
+
+      def actual_overall_result
+        actual_result_summary[:overall_result]
+      end
+
+      def actual_matter_types
+        actual_overall_result[:matter_types]
+      end
+
+      def actual_matter_type_names
+        actual_matter_types.pluck(:matter_type).sort
+      end
+
+      def actual_matter_type_result_for(matter_type_name)
+        hash = actual_matter_types.detect { |h| h[:matter_type] == matter_type_name.to_s }
+        hash[:result]
+      end
+
+      def actual_proceeding_types
+        actual_overall_result[:proceeding_types]
+      end
+
+      def actual_proceeding_type_codes
+        actual_proceeding_types.map { |h| h.fetch(:ccms_code) }.sort
+      end
+
+      def actual_proceeding_type_result(code)
+        actual_proceeding_types.detect { |h| h[:ccms_code] == code }[:result]
+      end
+
+      def actual_cap_result
+        @actual[:result_summary][:capital]
+      end
+
+      def actual_cap_proceeding_types
+        actual_cap_result[:proceeding_types]
+      end
+
+      def actual_cap_result_for(code)
+        actual_cap_proceeding_types.detect { |h| h[:ccms_code] == code }
+      end
+
+      def actual_gross_income_result
+        @actual[:result_summary][:gross_income]
+      end
+
+      def actual_gross_income_proceeding_types
+        actual_gross_income_result[:proceeding_types]
+      end
+
+      def actual_gross_income_result_for(code)
+        actual_gross_income_proceeding_types.detect { |h| h[:ccms_code] == code }
+      end
+
+      def actual_disposable_income_result
+        @actual[:result_summary][:disposable_income]
+      end
+
+      def actual_disposable_income_proceeding_types
+        actual_disposable_income_result[:proceeding_types]
+      end
+
+      def actual_disposable_income_result_for(code)
+        actual_disposable_income_proceeding_types.detect { |h| h[:ccms_code] == code }
+      end
+
+      def actual_gross_income
+        @actual[:assessment][:gross_income]
+      end
+
+      def actual_gross_other_income
+        actual_gross_income[:other_income][:monthly_equivalents][:all_sources].values.sum(&:to_f)
+      end
+
+      def actual_gross_state_benefits
+        actual_gross_income[:state_benefits][:monthly_equivalents][:all_sources]
+      end
+
+      def actual_student_loan
+        actual_gross_income[:irregular_income][:monthly_equivalents][:student_loan]
+      end
+
+      def actual_total_gross_income
+        actual_result_summary[:gross_income][:total_gross_income]
+      end
+
+      def actual_disposable_income
+        @actual[:assessment][:disposable_income]
+      end
+
+      def actual_disposable(key)
+        actual_disposable_income[:monthly_equivalents][:all_sources][key]
+      end
+
+      def actual_dependant_allowance
+        actual_disposable_income[:deductions][:dependants_allowance]
+      end
+
+      def disposable_income_result
+        @actual[:result_summary][:disposable_income]
+      end
+
+      def actual_housing_benefit
+        disposable_income_result[:housing_benefit]
+      end
+
+      def actual_net_housing_costs
+        disposable_income_result[:net_housing_costs]
+      end
+
+      def actual_capital
+        @actual[:result_summary][:capital]
+      end
+
+      def actual_employment_income
+        disposable_income_result[:employment_income]
+      end
+
+      def expected_assessment
+        @expected[:assessment]
+      end
+
+      def expected_matter_types
+        expected_assessment[:matter_types]
+      end
+
+      def expected_matter_type_names
+        @expected[:assessment][:matter_types].map(&:keys).flatten.sort.map(&:to_s)
+      end
+
+      def expected_proceeding_types
+        expected_assessment[:proceeding_types]
+      end
+
+      def expected_proceeding_type_codes
+        expected_proceeding_types.keys.sort
+      end
+
+      def expected_gross_income
+        @expected[:gross_income_summary]
+      end
+
+      def expected_gi_other_income
+        expected_gross_income[:monthly_other_income]
+      end
+
+      def expected_gi_state_benefits
+        expected_gross_income[:monthly_state_benefits]
+      end
+
+      def expected_gi_student_loan
+        expected_gross_income[:monthly_student_loan]
+      end
+
+      def expected_total_gross_income
+        expected_gross_income[:total_gross_income]
+      end
+
+      def expected_disposable_income
+        @expected[:disposable_income_summary]
+      end
+
+      def expected_disposable(key)
+        expected_disposable_income[key]
+      end
+
+      def expected_capital
+        @expected[:capital]
+      end
+
+      def expected_employment_income_gross
+        expected_gross_income[:employment_income_gross]
+      end
+
+      def expected_employment_income_benefits_in_kind
+        expected_gross_income[:employment_income_benefits_in_kind]
+      end
+
+      def expected_employment_income_tax
+        expected_gross_income[:employment_income_tax]
+      end
+
+      def expected_employment_income_nic
+        expected_gross_income[:employment_income_nic]
+      end
+
+      def expected_fixed_employment_allowance
+        expected_gross_income[:fixed_employment_allowance]
+      end
+    end
+  end
+end

--- a/lib/integration_helpers/test_case/worksheet.rb
+++ b/lib/integration_helpers/test_case/worksheet.rb
@@ -10,6 +10,7 @@ module TestCase
                 :irregular_income,
                 :other_incomes,
                 :outgoings,
+                :proceeding_types,
                 :properties,
                 :state_benefits,
                 :submission_date,
@@ -18,6 +19,7 @@ module TestCase
                 :worksheet_name
 
     PAYLOAD_OBJECTS = %i[
+      proceeding_types
       applicant
       capitals
       cash_transactions
@@ -136,8 +138,19 @@ module TestCase
       @vehicle = Vehicle.new(vehicle_rows)
     end
 
+    def populate_proceeding_types
+      @proceeding_types = TestCase::ProceedingTypesCollection.new(@rows)
+    end
+
     def populate_expected_results
-      @expected_results = version == "4" ? V4::ExpectedResult.new(@rows) : V3::ExpectedResult.new(@rows)
+      @expected_results = case version
+                          when "4"
+                            V4::ExpectedResult.new(@rows)
+                          when "5"
+                            V5::ExpectedResult.new(@rows)
+                          else
+                            V3::ExpectedResult.new(@rows)
+                          end
     end
 
     def populate_earned_income

--- a/lib/integration_helpers/test_case/worksheet.rb
+++ b/lib/integration_helpers/test_case/worksheet.rb
@@ -139,7 +139,9 @@ module TestCase
     end
 
     def populate_proceeding_types
-      @proceeding_types = TestCase::ProceedingTypesCollection.new(@rows)
+      row_index = @rows.index { |r| r.first.present? && r.first != "proceeding_types" }
+      proceeding_type_rows = @rows.shift(row_index)
+      @proceeding_types = TestCase::ProceedingTypesCollection.new(proceeding_type_rows)
     end
 
     def populate_expected_results

--- a/spec/cassettes/IntegrationTests_TestRunner/run_integration_tests/processes_all_the_tests_on_all_the_sheets.yml
+++ b/spec/cassettes/IntegrationTests_TestRunner/run_integration_tests/processes_all_the_tests_on_all_the_sheets.yml
@@ -1,0 +1,61 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/threshold_waivers
+    body:
+      encoding: UTF-8
+      string: '{"request_id":"4efa3b2b-8c2b-43a2-97b4-5a51d3fd810b","proceedings":[{"ccms_code":"DA001","client_involvement_type":"A"},{"ccms_code":"SE013","client_involvement_type":"D"}]}'
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Faraday v1.10.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 18 Jul 2022 13:46:43 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Vary:
+      - Accept, Origin
+      Etag:
+      - W/"85b853359f905036a301b7c466c324ed"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 954786797a698a9d8a18a1d4d13af993
+      X-Runtime:
+      - '0.086090'
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+    body:
+      encoding: UTF-8
+      string: '{"request_id":"4efa3b2b-8c2b-43a2-97b4-5a51d3fd810b","success":true,"proceedings":[{"ccms_code":"DA001","matter_type":"Domestic
+        abuse","gross_income_upper":true,"disposable_income_upper":true,"capital_upper":true,"client_involvement_type":"A"},{"ccms_code":"SE013","matter_type":"Children
+        - section 8","gross_income_upper":false,"disposable_income_upper":false,"capital_upper":false,"client_involvement_type":"D"}]}'
+  recorded_at: Mon, 18 Jul 2022 13:46:43 GMT
+recorded_with: VCR 6.1.0

--- a/spec/integration/test_runner_spec.rb
+++ b/spec/integration/test_runner_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe "IntegrationTests::TestRunner", type: :request do
     mock_lfa_responses
   end
 
-  describe "run integration_tests" do
+  describe "run integration_tests", :vcr do
     it "processes all the tests on all the sheets" do
       failing_tests = []
       test_count = 0

--- a/spec/integration_helpers/test_case/proceeding_type_spec.rb
+++ b/spec/integration_helpers/test_case/proceeding_type_spec.rb
@@ -1,0 +1,26 @@
+require "rails_helper"
+require Rails.root.join("lib/integration_helpers/test_case/proceeding_type.rb")
+
+module TestCase
+  RSpec.describe ProceedingType do
+    let(:rows) do
+      [
+        ["proceeding_types", "one", "proceeding_type_codes", "DA001", nil, nil, nil, nil, nil, nil],
+        [nil, nil, "client_involvement_type", "A", nil, nil, nil, nil, nil, nil],
+      ]
+    end
+    let(:expected_payload) do
+      {
+        ccms_code: "DA001",
+        client_involvement_type: "A",
+      }
+    end
+
+    describe "payload" do
+      it "returns a hash suitable for sending to CFE" do
+        pt = described_class.new(rows)
+        expect(pt.payload).to eq(expected_payload)
+      end
+    end
+  end
+end

--- a/spec/integration_helpers/test_case/proceeding_types_collection_spec.rb
+++ b/spec/integration_helpers/test_case/proceeding_types_collection_spec.rb
@@ -1,0 +1,24 @@
+require "rails_helper"
+require Rails.root.join("lib/integration_helpers/test_case/proceeding_types_collection.rb")
+
+module TestCase
+  RSpec.describe ProceedingTypesCollection do
+
+    let(:rows) do
+      [
+        ["proceeding_types", "one", "proceeding_type_codes", "DA001", nil, nil, nil, nil, nil, nil],
+        [nil, nil, "client_involvement_type", "A", nil, nil, nil, nil, nil, nil],
+        [nil, "two", "proceeding_type_codes", "SE013", nil, nil, nil, nil, nil, nil],
+        [nil, nil, "client_involvement_type", "Z", nil, nil, nil, nil, nil, nil]
+      ]
+    end
+
+    describe "initialize" do
+      it "calls ProceedingType for each pair of rows" do
+        expect(ProceedingType).to receive(:new).with(rows[0, 2]).and_call_original
+        expect(ProceedingType).to receive(:new).with(rows[2, 2]).and_call_original
+        described_class.new(rows)
+      end
+    end
+  end
+end

--- a/spec/integration_helpers/test_case/proceeding_types_collection_spec.rb
+++ b/spec/integration_helpers/test_case/proceeding_types_collection_spec.rb
@@ -3,13 +3,12 @@ require Rails.root.join("lib/integration_helpers/test_case/proceeding_types_coll
 
 module TestCase
   RSpec.describe ProceedingTypesCollection do
-
     let(:rows) do
       [
         ["proceeding_types", "one", "proceeding_type_codes", "DA001", nil, nil, nil, nil, nil, nil],
         [nil, nil, "client_involvement_type", "A", nil, nil, nil, nil, nil, nil],
         [nil, "two", "proceeding_type_codes", "SE013", nil, nil, nil, nil, nil, nil],
-        [nil, nil, "client_involvement_type", "Z", nil, nil, nil, nil, nil, nil]
+        [nil, nil, "client_involvement_type", "Z", nil, nil, nil, nil, nil, nil],
       ]
     end
 

--- a/spec/services/decorators/v5/assessment_decorator_spec.rb
+++ b/spec/services/decorators/v5/assessment_decorator_spec.rb
@@ -38,7 +38,7 @@ module Decorators
           allow(::Decorators::V4::DisposableIncomeDecorator).to receive(:new).and_return(instance_double("disd", as_json: nil))
           allow(::Decorators::V4::CapitalDecorator).to receive(:new).and_return(instance_double("csd", as_json: nil))
           allow(::Decorators::V3::RemarksDecorator).to receive(:new).and_return(instance_double("rmk", as_json: nil))
-          allow(::Decorators::V4::ResultSummaryDecorator).to receive(:new).and_return(instance_double("rsd", as_json: nil))
+          allow(::Decorators::V5::ResultSummaryDecorator).to receive(:new).and_return(instance_double("rsd", as_json: nil))
           decorator
         end
       end


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-3318)

Describe what you did and why.

- Amended integration tests to handle v5 requests (this can be tested by running  bin/ispec -w Fake_HHH_example -vv)
- Added additional v5 decorators to generate v5 responses

NB this pr is based on https://github.com/ministryofjustice/check-financial-eligibility/pull/1005 and can not be merged until that pr has been merged.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
