### PR TITLE
ap-3160: convert outgoings controller to use json schema

### DIFF
--- a/app/controllers/outgoings_controller.rb
+++ b/app/controllers/outgoings_controller.rb
@@ -1,28 +1,4 @@
 class OutgoingsController < ApplicationController
-  # api! works but the links in resulting docs are broken. See https://github.com/Apipie/apipie-rails/issues/559
-  api :POST, "assessments/:assessment_id/outgoings", "Create outgoings"
-  formats(%w[json])
-  param :assessment_id, :uuid, required: true
-
-  param :outgoings, Array, desc: "Collection of other outgoing types" do
-    param :name, CFEConstants::VALID_OUTGOING_CATEGORIES, required: true, desc: "The type of outgoing"
-    param :payments, Array, desc: "Collection of payment dates and amounts" do
-      param :payment_date, Date, date_option: :today_or_older, required: true, desc: "The date payment made"
-      param :housing_costs_type, CFEConstants::VALID_OUTGOING_HOUSING_COST_TYPES, required: false, desc: "The type of housing cost (omit for non-housing cost outgoings)"
-      param :amount, :currency, currency_option: :not_negative, required: true, desc: "Amount of payment"
-      param :client_id, String, required: true, desc: "Uniquely identifying string from client"
-    end
-  end
-
-  returns code: :ok, desc: "Successful response" do
-    property :success, %w[true], desc: "Success flag shows true"
-    property :errors, [], desc: "Empty array of error messages"
-  end
-  returns code: :unprocessable_entity do
-    property :success, %w[false], desc: "Success flag shows false"
-    property :errors, array_of: String, desc: "Description of why object invalid"
-  end
-
   def create
     if outgoing_creation_service.success?
       render_success
@@ -35,12 +11,8 @@ private
 
   def outgoing_creation_service
     @outgoing_creation_service ||= Creators::OutgoingsCreator.call(
-      outgoings: input[:outgoings],
+      outgoings_params: request.raw_post,
       assessment_id: params[:assessment_id],
     )
-  end
-
-  def input
-    @input ||= JSON.parse(request.raw_post, symbolize_names: true)
   end
 end

--- a/app/models/outgoings/base_outgoing.rb
+++ b/app/models/outgoings/base_outgoing.rb
@@ -3,5 +3,7 @@ module Outgoings
     belongs_to :disposable_income_summary
 
     self.table_name = "outgoings"
+
+    validates :payment_date, cfe_date: { not_in_the_future: true }
   end
 end

--- a/app/validators/cfe_date_validator.rb
+++ b/app/validators/cfe_date_validator.rb
@@ -1,0 +1,37 @@
+class CFEDateValidator < ActiveModel::EachValidator
+  DEFAULT_FORMAT = "%Y-%m-%d".freeze
+
+  def validate_each(record, attribute, value)
+    value = parse_date(value, options[:format]) if value.is_a?(String)
+    return unless valid_date(record, attribute, value)
+
+    validate_not_in_future(record, attribute, value)
+  end
+
+private
+
+  def parse_date(date_str, format)
+    format ||= DEFAULT_FORMAT
+    Time.strptime(date_str, format).in_time_zone
+  rescue StandardError
+    nil
+  end
+
+  def valid_date(record, attribute, value)
+    message = options[:message] || "date not valid"
+    unless value.is_a?(Date)
+      record.errors.add(attribute, message)
+      return false
+    end
+    true
+  end
+
+  def validate_not_in_future(record, attribute, value)
+    required = options[:not_in_the_future]
+    return if required.blank?
+
+    message = required[:message] if required.is_a?(Hash)
+    message ||= "date is in the future"
+    record.errors.add(attribute, message) if value > Date.current
+  end
+end

--- a/config/initializers/apipie.rb
+++ b/config/initializers/apipie.rb
@@ -29,7 +29,6 @@ Apipie.configure do |config|
 
       POST /assessments/:assessment_id/cash_transactions  # adds cash income and outgoings
       POST /assessments/:assessment_id/irregular_incomes  # adds data about applicant's irregular income
-      POST /assessments/:assessment_id/outgoings          # adds data about applicant's outgoings
       POST /assessments/:assessment_id/explicit_remarks   # adds remarks to be included on the means report
       POST /assessments/:assessment_id/state_benefits     # adds data about applicant's income from state benefits
       POST /assessments/:assessment_id/vehicles           # adds data about vehicles owned by the applicant

--- a/public/schemas/outgoings.json.erb
+++ b/public/schemas/outgoings.json.erb
@@ -1,0 +1,41 @@
+{
+  "id": "file://#{@schema_dir}/outgoings.json",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Legal Aid Check Financial Eligibility create outgoings payload schema",
+  "required": ["outgoings"],
+  "properties": {
+    "outgoings": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["name"],
+        "properties": {
+          "payments": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": ["payment_date", "amount", "client_id"],
+              "properties": {
+                "payment_date": {
+                  "$ref": "<%= "file://#{@schema_dir}/common.json#date" %>"
+                },
+                "housing_costs_type": {
+                  "enum": <%= CFEConstants::VALID_OUTGOING_HOUSING_COST_TYPES.as_json %>
+                },
+                "amount": {
+                  "$ref": "<%= "file://#{@schema_dir}/common.json#positive_currency" %>"
+                },
+                "client_id": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "name": {
+            "enum": <%= CFEConstants::VALID_OUTGOING_CATEGORIES.as_json %>
+          }
+        }
+      }
+    }
+  }
+}

--- a/spec/requests/outgoings_controller_spec.rb
+++ b/spec/requests/outgoings_controller_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe OutgoingsController, type: :request do
 
     subject(:post_payload) { post assessment_outgoings_path(assessment), params: params.to_json, headers: }
 
-    it "returns http success", :show_in_doc do
+    it "returns http success" do
       post_payload
       expect(response).to have_http_status(:success)
     end
@@ -46,12 +46,12 @@ RSpec.describe OutgoingsController, type: :request do
 
       before { post_payload }
 
-      it "returns unprocessable", :show_in_doc do
+      it "returns unprocessable" do
         expect(response).to have_http_status(:unprocessable_entity)
       end
 
       it "returns error information" do
-        expect(parsed_response[:errors].join).to match(/Invalid.*assessment_id/)
+        expect(parsed_response[:errors].join).to match(/No such assessment id/)
       end
 
       it "sets success flag to false" do
@@ -69,7 +69,7 @@ RSpec.describe OutgoingsController, type: :request do
       end
 
       it "returns error information" do
-        expect(parsed_response[:errors].join).to match(/Invalid.*payment_date/)
+        expect(parsed_response[:errors].join).to match(/ActiveRecord::RecordInvalid: Validation failed: Payment date date is in the future/)
       end
 
       it "sets success flag to false" do
@@ -93,7 +93,7 @@ RSpec.describe OutgoingsController, type: :request do
 
       it "contains success false in the response body" do
         post_payload
-        expect(parsed_response).to eq(errors: ["Missing parameter client_id"], success: false)
+        expect(parsed_response).to match(errors: [/The property '#\/outgoings\/2\/payments\/0' did not contain a required property of 'client_id' in schema file/], success: false)
       end
 
       it "does not create outgoing records" do

--- a/spec/requests/swagger_docs/v4/outgoings_spec.rb
+++ b/spec/requests/swagger_docs/v4/outgoings_spec.rb
@@ -109,7 +109,7 @@ RSpec.describe "outgoings", type: :request, swagger_doc: "v4/swagger.yaml" do
 
         run_test! do |response|
           body = JSON.parse(response.body, symbolize_names: true)
-          expect(body[:errors]).to include(/Invalid parameter 'name' value/)
+          expect(body[:errors]).to include(/The property '#\/outgoings\/0\/name' value "foobar" did not match one of the following values: child_care, rent_or_mortgage, maintenance_out, legal_aid in schema file/)
         end
       end
     end

--- a/spec/requests/swagger_docs/v5/outgoings_spec.rb
+++ b/spec/requests/swagger_docs/v5/outgoings_spec.rb
@@ -109,7 +109,7 @@ RSpec.describe "outgoings", type: :request, swagger_doc: "v5/swagger.yaml" do
 
         run_test! do |response|
           body = JSON.parse(response.body, symbolize_names: true)
-          expect(body[:errors]).to include(/Invalid parameter 'name' value/)
+          expect(body[:errors]).to include(/The property '#\/outgoings\/0\/name' value "foobar" did not match one of the following values: child_care, rent_or_mortgage, maintenance_out, legal_aid in schema file/)
         end
       end
     end

--- a/spec/services/creators/outgoings_creator_spec.rb
+++ b/spec/services/creators/outgoings_creator_spec.rb
@@ -8,7 +8,7 @@ module Creators
       let(:housing_cost_type_rent) { "rent" }
       let(:housing_cost_type_mortgage) { "mortgage" }
 
-      subject(:creator) { described_class.call(assessment_id: assessment.id, outgoings:) }
+      subject(:creator) { described_class.call(assessment_id: assessment.id, outgoings_params: outgoings_params.to_json) }
 
       it "creates a disposable_income_summary if one doesnt already exist" do
         expect { creator }.to change(DisposableIncomeSummary, :count).by(1)
@@ -53,29 +53,31 @@ module Creators
       end
 
       def outgoings_params
-        [
-          {
-            name: "child_care",
-            payments: [
-              { payment_date: "2019-12-09", amount: 266.95 },
-              { payment_date: "2019-11-09", amount: 584.31 },
-            ],
-          },
-          {
-            name: "maintenance_out",
-            payments: [
-              { payment_date: "2019-12-06", amount: 193.47 },
-              { payment_date: "2019-11-06", amount: 506.78 },
-            ],
-          },
-          {
-            name: "rent_or_mortgage",
-            payments: [
-              { payment_date: "2019-12-01", amount: 299.38, housing_cost_type: housing_cost_type_rent },
-              { payment_date: "2019-11-01", amount: 810.38, housing_cost_type: housing_cost_type_mortgage },
-            ],
-          },
-        ]
+        {
+          outgoings: [
+            {
+              name: "child_care",
+              payments: [
+                { payment_date: "2019-12-09", amount: 266.95, client_id: "abc123" },
+                { payment_date: "2019-11-09", amount: 584.31, client_id: "abc123" },
+              ],
+            },
+            {
+              name: "maintenance_out",
+              payments: [
+                { payment_date: "2019-12-06", amount: 193.47, client_id: "abc123" },
+                { payment_date: "2019-11-06", amount: 506.78, client_id: "abc123" },
+              ],
+            },
+            {
+              name: "rent_or_mortgage",
+              payments: [
+                { payment_date: "2019-12-01", amount: 299.38, housing_cost_type: housing_cost_type_rent, client_id: "abc123" },
+                { payment_date: "2019-11-01", amount: 810.38, housing_cost_type: housing_cost_type_mortgage, client_id: "abc123" },
+              ],
+            },
+          ],
+        }
       end
     end
   end

--- a/spec/validators/cfe_date_validator_spec.rb
+++ b/spec/validators/cfe_date_validator_spec.rb
@@ -1,0 +1,34 @@
+require "rails_helper"
+
+class DummyClass
+  include ActiveModel::Model
+  include ActiveModel::Validations
+
+  attr_accessor :date_val
+
+  validates :date_val, cfe_date: { not_in_the_future: true }
+end
+
+RSpec.describe CFEDateValidator do
+  describe "not_in_the_future validation" do
+    let(:dummy) { DummyClass.new }
+
+    it "raises error if date is in the future" do
+      dummy.date_val = 3.days.from_now.to_date
+      expect(dummy).to be_invalid
+      expect(dummy.errors[:date_val]).to eq ["date is in the future"]
+    end
+
+    it "does not raise an error if date is not in the future" do
+      dummy.date_val = 3.days.ago.to_date
+      expect(dummy).to be_valid
+      expect(dummy.errors[:date_val]).to eq []
+    end
+
+    it "does not raise an error if date is today" do
+      dummy.date_val = Time.zone.today
+      expect(dummy).to be_valid
+      expect(dummy.errors[:date_val]).to eq []
+    end
+  end
+end


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-3160)

Describe what you did and why.

- amended outgoings controller to use json_schema for validation (and remove APIPIE).
- created a cfe_date_validator for date validations, eventually this will hopefully replace the APIPIE date_validator. Not sure about the naming in the meantime?

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
