### PR TITLE
Fix: Pre APIPIE removal tidy

### DIFF
--- a/config/initializers/apipie.rb
+++ b/config/initializers/apipie.rb
@@ -27,9 +27,6 @@ Apipie.configure do |config|
 
     The response to this action includes an assessment id that can then be used in the following steps:
 
-      POST /assessments/:assessment_id/cash_transactions  # adds cash income and outgoings
-      POST /assessments/:assessment_id/irregular_incomes  # adds data about applicant's irregular income
-      POST /assessments/:assessment_id/explicit_remarks   # adds remarks to be included on the means report
       POST /assessments/:assessment_id/vehicles           # adds data about vehicles owned by the applicant
 
     Once all the above calls have been made to build up a complete picture of the applicant's assets and income

--- a/spec/requests/capitals_controller_spec.rb
+++ b/spec/requests/capitals_controller_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe CapitalsController, type: :request do
       context "Active Record error" do
         let(:assessment_id) { SecureRandom.uuid }
 
-        it "errors and is shown in apidocs", :show_in_doc do
+        it "errors and is shown in apidocs" do
           expect(response).to have_http_status(:unprocessable_entity)
         end
 

--- a/spec/requests/properties_controller_spec.rb
+++ b/spec/requests/properties_controller_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe PropertiesController, type: :request do
     context "with valid payload" do
       let(:assessment_id) { assessment.id }
 
-      it "returns http status code 200", :show_in_doc do
+      it "returns http status code 200" do
         expect(response).to have_http_status(:success)
       end
 
@@ -64,7 +64,7 @@ RSpec.describe PropertiesController, type: :request do
         expect(parsed_response[:success]).to eq false
       end
 
-      it "returns expected error response", :show_in_doc do
+      it "returns expected error response" do
         expect(parsed_response[:errors]).to eq [%(No such assessment id)]
       end
 


### PR DESCRIPTION
## What

This removes a few APIPIE test generators and removes the names
of updated controllers from the APIPIE about page

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
