### PR TITLE
AP-3162: Remove APIPIE from state_benefit_types

### DIFF
--- a/app/controllers/state_benefit_type_controller.rb
+++ b/app/controllers/state_benefit_type_controller.rb
@@ -1,16 +1,4 @@
 class StateBenefitTypeController < ApplicationController
-  resource_description do
-    short "Return state benefit types"
-    formats(%w[json])
-    description <<-END_OF_TEXT
-    == Description
-      Returns all state benefit types' name, label and DWP code.
-    END_OF_TEXT
-  end
-
-  api :GET, "state_benefit_type", "List of state benefit types"
-  formats(%w[json])
-
   def index
     render json: StateBenefitType.as_cfe_json
   end

--- a/config/initializers/apipie.rb
+++ b/config/initializers/apipie.rb
@@ -36,13 +36,5 @@ Apipie.configure do |config|
     the following call should be made to perform the assessment and get the result:
 
       GET /assessment/:assessment_id
-
-    == Reference data
-
-    A list of state_benefit types, their full names, and the labels to use when posting to the state_benfits endpoint can
-    be obtained from this endpoint:
-
-    GET /state_benefit_type
-
   END_OF_TEXT
 end

--- a/spec/requests/state_benefit_type_controller_spec.rb
+++ b/spec/requests/state_benefit_type_controller_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe StateBenefitTypeController, type: :request do
   end
 
   context "full list for documentation" do
-    it "returns http success", :show_in_doc do
+    it "returns http success" do
       StateBenefitType.delete_all
       Dibber::Seeder.new(StateBenefitType, "data/state_benefit_types.yml", name_method: :label, overwrite: true).build
       get state_benefit_type_index_path


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-3162)

This does not need converting to JSON schema as it simplly returns the StateBenefitTypes mapped using as_cfe_json

It removes the apipie `show_in_doc` references and updates the apipie documentation header to remove the reference

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
