### PR TITLE
AP-3108 Ensure code coverage at 100%

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -10,7 +10,7 @@ Rails.application.configure do
   # Do not eager load code on boot. This avoids loading your whole application
   # just for the purpose of running a single test. If you are using a tool that
   # preloads Rails for running tests, you may have to set it to true.
-  config.eager_load = false
+  config.eager_load = true # set eager loading to true so that ALL files are reported by simplecov, not just those that are loaded
 
   # Configure public file server for tests with Cache-Control for performance.
   config.public_file_server.enabled = true

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -10,7 +10,7 @@ Rails.application.configure do
   # Do not eager load code on boot. This avoids loading your whole application
   # just for the purpose of running a single test. If you are using a tool that
   # preloads Rails for running tests, you may have to set it to true.
-  config.eager_load = true # set eager loading to true so that ALL files are reported by simplecov, not just those that are loaded
+  config.eager_load = ENV['CI'].present?
 
   # Configure public file server for tests with Cache-Control for performance.
   config.public_file_server.enabled = true

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -10,7 +10,7 @@ Rails.application.configure do
   # Do not eager load code on boot. This avoids loading your whole application
   # just for the purpose of running a single test. If you are using a tool that
   # preloads Rails for running tests, you may have to set it to true.
-  config.eager_load = ENV['CI'].present?
+  config.eager_load = ENV["CI"].present?
 
   # Configure public file server for tests with Cache-Control for performance.
   config.public_file_server.enabled = true

--- a/spec/factories/employment_factory.rb
+++ b/spec/factories/employment_factory.rb
@@ -2,7 +2,7 @@ FactoryBot.define do
   factory :employment do
     assessment
     client_id { SecureRandom.uuid }
-    sequence(:name) { |n| "Job #{n}" }
+    sequence(:name) { |n| sprintf("Job %04d", n) }
   end
 
   trait :with_monthly_payments do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -8,15 +8,6 @@ require "rspec/rails"
 require "pry-rescue/rspec" if Rails.env.development?
 require "super_diff/rspec-rails"
 
-puts ">>>>>>>>>>>>  #{__FILE__}:#{__LINE__} <<<<<<<<<<<<".yellow
-if ENV['CI'].present?
-  puts ">>>>>>>>>>>>  #{__FILE__}:#{__LINE__} <<<<<<<<<<<<".yellow
-  puts "Present"
-else
-  puts ">>>>>>>>>>>>  #{__FILE__}:#{__LINE__} <<<<<<<<<<<<".yellow
-  puts 'Absnet'
-end
-
 # Add additional requires below this line. Rails is not loaded until this point!
 
 # Requires supporting ruby files with custom matchers and macros, etc, in

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -8,6 +8,15 @@ require "rspec/rails"
 require "pry-rescue/rspec" if Rails.env.development?
 require "super_diff/rspec-rails"
 
+puts ">>>>>>>>>>>>  #{__FILE__}:#{__LINE__} <<<<<<<<<<<<".yellow
+if ENV['CI'].present?
+  puts ">>>>>>>>>>>>  #{__FILE__}:#{__LINE__} <<<<<<<<<<<<".yellow
+  puts "Present"
+else
+  puts ">>>>>>>>>>>>  #{__FILE__}:#{__LINE__} <<<<<<<<<<<<".yellow
+  puts 'Absnet'
+end
+
 # Add additional requires below this line. Rails is not loaded until this point!
 
 # Requires supporting ruby files with custom matchers and macros, etc, in


### PR DESCRIPTION
This PR addresses two issues:

1) The eager_loading setting in `/config/test.rb` was set to false.  This means that only those files
actually used during a test run are included in the coverage results.  By setting this to true in the `CI` 
environment variable is set, all files are covered in Circle CI tests, but running tests locally will mean the 
we don't suffer the time hit of loading all files before running a single test.

2) It fixes a flickering test error where employments were being created by the factory as
Job 1, Job 2 etc were being incorrectly sorted (Job 10 coming before Job 9) and therefore
not matching the expected order.  This fixes it by making sure the numerical element is a
four-digit leading zero number (e.g. Job 0010)


## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-XXX)

Describe what you did and why.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
