### PR TITLE
Fix: Deploying via Circle CI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,12 +7,12 @@ RUN set -ex
 
 RUN apk --no-cache add --virtual build-dependencies \
                     build-base \
-                    libxml2-dev \
-                    libxslt-dev \
                     postgresql-dev \
 && apk --no-cache add \
                   postgresql-client \
                   nodejs \
+                  libxml2-dev \
+                  libxslt-dev \
                   shared-mime-info \
                   yarn
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,8 @@ RUN set -ex
 
 RUN apk --no-cache add --virtual build-dependencies \
                     build-base \
+                    libxml2-dev \
+                    libxslt-dev \
                     postgresql-dev \
 && apk --no-cache add \
                   postgresql-client \


### PR DESCRIPTION
## What

Add the libxml2-dev and libxslt-dev packages into the docker file, these
are required in the `build.nokogiri --use-system-libraries` step.

Still not sure why it was working before Thursday, but...

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
