### PR TITLE
Change verbosity of integration tests

### DIFF
--- a/.github/workflows/manual-integration-tests.yml
+++ b/.github/workflows/manual-integration-tests.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Run Tests
         env:
           SKIP_COVERAGE: true
-          VERBOSE: true
+          VERBOSE: 1
           CLIENT_EMAIL: ${{ secrets.CLIENT_EMAIL }}
           CLIENT_ID: ${{ secrets.CLIENT_ID }}
           PRIVATE_KEY: ${{ secrets.PRIVATE_KEY }}


### PR DESCRIPTION
## What
These are running silently and no output is produced in the github action 
for the BA to see.

Seems to be because the VERBOSE env var is set to true which translates
to 0 (silent verbosity) in `spec/integration/test_runner_spec.rb`.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
