### PR TITLE
Ap 3164 vehicles controller convert json schema

### DIFF
--- a/app/controllers/vehicles_controller.rb
+++ b/app/controllers/vehicles_controller.rb
@@ -1,23 +1,4 @@
 class VehiclesController < ApplicationController
-  api :POST, "assessments/:assessment_id/vehicles", "Create vehicles"
-  formats(%w[json])
-  param :assessment_id, :uuid, required: true
-  param(:vehicles, Array, required: true, desc: "An array of vehicles owned by the applicant") do
-    param :value, :currency, currency_option: :not_negative, required: true, desc: "Value of the vehicle"
-    param :loan_amount_outstanding, :currency, required: false, desc: "Amount, if any, of a loan used to purchase the vehicle which is still left to pay"
-    param :date_of_purchase, Date, date_option: :today_or_older, required: true, desc: "Date the vehicle was purchased by the applicant"
-    param :in_regular_use, :boolean, required: false, desc: "Whether or not the vehicle is in regular use"
-  end
-
-  returns code: :ok, desc: "Successful response" do
-    property :success, %w[true], desc: "Success flag shows true"
-    property :errors, [], desc: "Empty array of error messages"
-  end
-  returns code: :unprocessable_entity do
-    property :success, %w[false], desc: "Success flag shows false"
-    property :errors, array_of: String, desc: "Description of why object invalid"
-  end
-
   def create
     if creation_service.success?
       render_success
@@ -31,11 +12,7 @@ private
   def creation_service
     @creation_service ||= Creators::VehicleCreator.call(
       assessment_id: params[:assessment_id],
-      vehicles_attributes: input[:vehicles],
+      vehicles_params: request.raw_post,
     )
-  end
-
-  def input
-    @input ||= JSON.parse(request.raw_post, symbolize_names: true)
   end
 end

--- a/app/models/vehicle.rb
+++ b/app/models/vehicle.rb
@@ -4,7 +4,7 @@ class Vehicle < ApplicationRecord
 
   belongs_to :capital_summary
 
-  validate :date_of_purchase_cannot_be_in_future
+  validates :date_of_purchase, cfe_date: { not_in_the_future: true }
 
   def assess!
     in_regular_use? ? assess_vehicle_in_regular_use : assess_vehicle_not_in_regular_use
@@ -12,10 +12,6 @@ class Vehicle < ApplicationRecord
   end
 
 private
-
-  def date_of_purchase_cannot_be_in_future
-    errors.add(:date_of_purchase, "cannot be in the future") if date_of_purchase > Date.current
-  end
 
   def assess_vehicle_not_in_regular_use
     self.included_in_assessment = true

--- a/app/services/creators/vehicle_creator.rb
+++ b/app/services/creators/vehicle_creator.rb
@@ -1,15 +1,19 @@
 module Creators
   class VehicleCreator < BaseCreator
-    attr_accessor :assessment_id, :vehicles_attributes, :vehicles
+    attr_accessor :assessment_id, :vehicles
 
-    def initialize(assessment_id:, vehicles_attributes:)
+    def initialize(assessment_id:, vehicles_params:)
       super()
       @assessment_id = assessment_id
-      @vehicles_attributes = vehicles_attributes
+      @vehicles_params = vehicles_params
     end
 
     def call
-      create_records
+      if json_validator.valid?
+        create_records
+      else
+        self.errors = json_validator.errors
+      end
       self
     end
 
@@ -33,6 +37,14 @@ module Creators
 
     def capital_summary
       @capital_summary ||= assessment.capital_summary
+    end
+
+    def vehicles_attributes
+      @vehicles_attributes ||= JSON.parse(@vehicles_params, symbolize_names: true)[:vehicles]
+    end
+
+    def json_validator
+      @json_validator ||= JsonValidator.new("vehicles", @vehicles_params)
     end
   end
 end

--- a/app/validators/cfe_date_validator.rb
+++ b/app/validators/cfe_date_validator.rb
@@ -12,7 +12,7 @@ private
 
   def parse_date(date_str, format)
     format ||= DEFAULT_FORMAT
-    Time.strptime(date_str, format).in_time_zone
+    Date.strptime(date_str, format)
   rescue StandardError
     nil
   end
@@ -31,7 +31,7 @@ private
     return if required.blank?
 
     message = required[:message] if required.is_a?(Hash)
-    message ||= "date is in the future"
+    message ||= "cannot be in the future"
     record.errors.add(attribute, message) if value > Date.current
   end
 end

--- a/public/schemas/vehicles.json.erb
+++ b/public/schemas/vehicles.json.erb
@@ -1,0 +1,29 @@
+{
+  "id": "http://localhost:3000/schemas/vehicles.json",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Legal Aid Check Financial Eligibility create vehicles payload schema",
+  "required": ["vehicles"],
+  "properties": {
+    "vehicles": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["value", "date_of_purchase"],
+        "properties": {
+          "value": {
+            "$ref": "<%= "file://#{@schema_dir}/common.json#positive_currency" %>"
+          },
+          "loan_amount_outstanding": {
+            "$ref": "<%= "file://#{@schema_dir}/common.json#currency" %>"
+          },
+          "date_of_purchase": {
+            "$ref": "<%= "file://#{@schema_dir}/common.json#date" %>"
+          },
+          "in_regular_use": {
+            "type": "boolean"
+          }
+        }
+      }
+    }
+  }
+}

--- a/spec/requests/outgoings_controller_spec.rb
+++ b/spec/requests/outgoings_controller_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe OutgoingsController, type: :request do
       end
 
       it "returns error information" do
-        expect(parsed_response[:errors].join).to match(/ActiveRecord::RecordInvalid: Validation failed: Payment date date is in the future/)
+        expect(parsed_response[:errors].join).to match(/ActiveRecord::RecordInvalid: Validation failed: Payment date cannot be in the future/)
       end
 
       it "sets success flag to false" do

--- a/spec/requests/swagger_docs/v4/vehicles_spec.rb
+++ b/spec/requests/swagger_docs/v4/vehicles_spec.rb
@@ -97,7 +97,7 @@ RSpec.describe "vehicles", type: :request, swagger_doc: "v4/swagger.yaml" do
 
         run_test! do |response|
           body = JSON.parse(response.body, symbolize_names: true)
-          expect(body[:errors]).to include(/Missing parameter value/)
+          expect(body[:errors]).to include(/The property '#\/vehicles\/0' did not contain a required property of 'value' in schema/)
         end
       end
     end

--- a/spec/requests/swagger_docs/v5/vehicles_spec.rb
+++ b/spec/requests/swagger_docs/v5/vehicles_spec.rb
@@ -97,7 +97,7 @@ RSpec.describe "vehicles", type: :request, swagger_doc: "v5/swagger.yaml" do
 
         run_test! do |response|
           body = JSON.parse(response.body, symbolize_names: true)
-          expect(body[:errors]).to include(/Missing parameter value/)
+          expect(body[:errors]).to include(/The property '#\/vehicles\/0' did not contain a required property of 'value' in schema/)
         end
       end
     end

--- a/spec/requests/vehicles_controller_spec.rb
+++ b/spec/requests/vehicles_controller_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe VehiclesController, type: :request do
 
     subject(:post_payload) { post assessment_vehicles_path(assessment), params: params.to_json, headers: }
 
-    it "returns http success", :show_in_doc do
+    it "returns http success" do
       post_payload
       expect(response).to have_http_status(:success)
     end
@@ -37,7 +37,7 @@ RSpec.describe VehiclesController, type: :request do
       end
 
       it "returns error information" do
-        expect(parsed_response[:errors].join).to match(/Invalid.*#{invalid_item}/)
+        expect(parsed_response[:errors].join).to match(invalid_item)
       end
 
       it "sets success flag to false" do
@@ -48,24 +48,24 @@ RSpec.describe VehiclesController, type: :request do
     context "with an invalid id" do
       let(:assessment) { 33 }
 
-      it "returns unprocessable", :show_in_doc do
+      it "returns unprocessable" do
         post_payload
         expect(response).to have_http_status(:unprocessable_entity)
       end
 
-      it_behaves_like "an unprocessable entity", "assessment_id"
+      it_behaves_like "an unprocessable entity", "No such assessment id"
     end
 
     context "with invalid input" do
       let(:vehicles) { :invalid }
 
-      it_behaves_like "an unprocessable entity", "vehicles"
+      it_behaves_like "an unprocessable entity", "The property '#/vehicles' of type string did not match the following type: array in schema"
     end
 
-    context "with a future wage slip" do
+    context "with a future date_of_purchase" do
       let(:vehicles) { [attributes_for(:vehicle, date_of_purchase: date_in_future)] }
 
-      it_behaves_like "an unprocessable entity", "date_of_purchase"
+      it_behaves_like "an unprocessable entity", "Date of purchase cannot be in the future"
     end
 
     context "with service returning error" do

--- a/spec/services/creators/state_benefits_creator_spec.rb
+++ b/spec/services/creators/state_benefits_creator_spec.rb
@@ -30,7 +30,7 @@ module Creators
         end
 
         it "returns an error" do
-          expect(creator.errors).to eq ["Payment date date is in the future"]
+          expect(creator.errors).to eq ["Payment date cannot be in the future"]
           expect(StateBenefitPayment.count).to eq 0
         end
       end

--- a/spec/services/creators/vehicle_creation_service_spec.rb
+++ b/spec/services/creators/vehicle_creation_service_spec.rb
@@ -4,13 +4,13 @@ module Creators
   RSpec.describe VehicleCreator do
     let(:assessment) { create :assessment, :with_capital_summary }
     let(:capital_summary) { assessment.capital_summary }
-    let(:vehicles_attributes) { attributes_for_list(:vehicle, 2) }
+    let(:vehicles_params) { { vehicles: attributes_for_list(:vehicle, 2) }.to_json }
 
     describe ".call" do
       subject(:service) do
         described_class.call(
           assessment_id: assessment.id,
-          vehicles_attributes:,
+          vehicles_params:,
         )
       end
 
@@ -27,7 +27,7 @@ module Creators
       end
 
       context "with error" do
-        let(:vehicles_attributes) { attributes_for_list(:vehicle, 2, date_of_purchase: Faker::Date.between(from: 2.months.from_now, to: 6.years.from_now)) }
+        let(:vehicles_params) { { vehicles: attributes_for_list(:vehicle, 2, date_of_purchase: Faker::Date.between(from: 2.months.from_now, to: 6.years.from_now)) }.to_json }
 
         it "does not generates two vehicles" do
           expect { service }.not_to change(assessment.vehicles, :count)

--- a/spec/validators/cfe_date_validator_spec.rb
+++ b/spec/validators/cfe_date_validator_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe CFEDateValidator do
     it "raises error if date is in the future" do
       dummy.date_val = 3.days.from_now.to_date
       expect(dummy).to be_invalid
-      expect(dummy.errors[:date_val]).to eq ["date is in the future"]
+      expect(dummy.errors[:date_val]).to eq ["cannot be in the future"]
     end
 
     it "does not raise an error if date is not in the future" do
@@ -29,6 +29,18 @@ RSpec.describe CFEDateValidator do
       dummy.date_val = Time.zone.today
       expect(dummy).to be_valid
       expect(dummy.errors[:date_val]).to eq []
+    end
+
+    it "does not raise an error if date is a valid date string" do
+      dummy.date_val = 3.days.ago.to_date.to_s
+      expect(dummy).to be_valid
+      expect(dummy.errors[:date_val]).to eq []
+    end
+
+    it "raises an error if date is an invalid date string" do
+      dummy.date_val = "invalid"
+      expect(dummy).to be_invalid
+      expect(dummy.errors[:date_val]).to eq ["date not valid"]
     end
   end
 end


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-3164)

Removed apipie from vehicles_controller
Validate vehicles_controller with json_schema
As vehicles_controller was the final controller that used apipie removed apipie from the rest of the codebase, including Gemfile, config/initializors, Readme, validators etc.


## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
