### PR TITLE
Run individual workersheets as separate examples using rspec

### DIFF
--- a/.github/workflows/manual-integration-tests.yml
+++ b/.github/workflows/manual-integration-tests.yml
@@ -52,14 +52,13 @@ jobs:
       - name: Run Tests
         env:
           SKIP_COVERAGE: true
-          VERBOSE: 1
           CLIENT_EMAIL: ${{ secrets.CLIENT_EMAIL }}
           CLIENT_ID: ${{ secrets.CLIENT_ID }}
           PRIVATE_KEY: ${{ secrets.PRIVATE_KEY }}
           PRIVATE_KEY_ID: ${{ secrets.PRIVATE_KEY_ID }}
           ALLOW_FUTURE_SUBMISSION_DATE: true
         run: |
-          bundle exec rspec spec/integration/test_runner_spec.rb
+          bin/ispec -v -r
 
   slackNotification:
     name: Slack Notification

--- a/bin/ispec
+++ b/bin/ispec
@@ -24,7 +24,7 @@ class Ispec
   def run
     display_help if @help
 
-    command = "#{verbosity} #{freshness} #{target} bundle exec rspec spec/integration/test_runner_spec.rb"
+    command = "ISPEC_RUN=true #{verbosity} #{freshness} #{target} bundle exec rspec spec/integration/test_runner_spec.rb"
     puts command
     system command
   end


### PR DESCRIPTION
## What
Amend integration specs for standard rspec runs

[came out of learnings from AP-3439](https://dsdmoj.atlassian.net/browse/AP-3439)

This allows the integration specs to behave in a more typical fashion
when run directly using rspec - namely, with individual worksheets outputing success
or failure.

examples. to try on branch
```
bundle exec rspec spec/integration/test_runner_spec.rb
OR
bundle exec rspec --format d spec/integration/test_runner_spec.rb
```

But you can continue to use the bin/ispec and its various options
as normal:

```
 bin/ispec -r -v -w III_REGTR_1-V5
```


## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
