### PR TITLE
[AP-3474] Enable 3 monthly frequency for regular transactions

### DIFF
--- a/app/constants/cfe_constants.rb
+++ b/app/constants/cfe_constants.rb
@@ -68,6 +68,7 @@ module CFEConstants
 
   # Frequencies
   #
+  VALID_REGULAR_TRANSACTION_FREQUENCIES = %i[three_monthly monthly four_weekly two_weekly weekly unknown].freeze
   VALID_FREQUENCIES = %i[monthly four_weekly two_weekly weekly unknown].freeze
   NUMBER_OF_MONTHS_TO_AVERAGE = 3
 

--- a/app/models/regular_transaction.rb
+++ b/app/models/regular_transaction.rb
@@ -17,7 +17,7 @@ class RegularTransaction < ApplicationRecord
   }, if: :debit?
 
   validates :frequency, inclusion: {
-    in: CFEConstants::VALID_FREQUENCIES.map(&:to_s),
+    in: CFEConstants::VALID_REGULAR_TRANSACTION_FREQUENCIES.map(&:to_s),
     message: "is not a valid frequency: %<value>s",
   }
 

--- a/app/services/concerns/monthly_equivalent_calculatable.rb
+++ b/app/services/concerns/monthly_equivalent_calculatable.rb
@@ -1,21 +1,14 @@
 module MonthlyEquivalentCalculatable
 private
 
-  def determine_calc_method(period)
-    case period.to_sym
-    when :monthly
-      :monthly_to_monthly
-    when :four_weekly
-      :four_weekly_to_monthly
-    when :two_weekly
-      :two_weekly_to_monthly
-    when :weekly
-      :weekly_to_monthly
-    when :unknown
-      :blunt_average
-    else
-      raise ArgumentError, "unexpected period #{period}"
-    end
+  def determine_calc_method(frequency)
+    raise ArgumentError, "unexpected frequency #{frequency}" unless frequency_conversions.key?(frequency)
+
+    frequency_conversions[frequency]
+  end
+
+  def three_monthly_to_monthly(value)
+    (value / 3).round(2)
   end
 
   def monthly_to_monthly(value)
@@ -32,6 +25,15 @@ private
 
   def weekly_to_monthly(value)
     (value * 52 / 12).round(2)
+  end
+
+  def frequency_conversions
+    { three_monthly: :three_monthly_to_monthly,
+      monthly: :monthly_to_monthly,
+      four_weekly: :four_weekly_to_monthly,
+      two_weekly: :two_weekly_to_monthly,
+      weekly: :weekly_to_monthly,
+      unknown: :blunt_average }.with_indifferent_access
   end
 
   def monthly_regular_transaction_amount_by(operation:, category:)

--- a/public/schemas/regular_transactions.json.erb
+++ b/public/schemas/regular_transactions.json.erb
@@ -22,7 +22,7 @@
           },
           "frequency": {
             "type": "string",
-            "enum": <%= CFEConstants::VALID_FREQUENCIES.as_json %>
+            "enum": <%= CFEConstants::VALID_REGULAR_TRANSACTION_FREQUENCIES.as_json %>
           },
           "amount": {
             "$ref": "<%= "file://#{@schema_dir}/common.json#currency" %>"

--- a/spec/requests/swagger_docs/v5/regular_transactions_spec.rb
+++ b/spec/requests/swagger_docs/v5/regular_transactions_spec.rb
@@ -50,9 +50,9 @@ RSpec.describe "regular_transactions", type: :request, swagger_doc: "v5/swagger.
                           },
                           frequency: {
                             type: :string,
-                            enum: CFEConstants::VALID_FREQUENCIES,
+                            enum: CFEConstants::VALID_REGULAR_TRANSACTION_FREQUENCIES,
                             description: "Frequency with which regular transaction is made or received",
-                            example: CFEConstants::VALID_FREQUENCIES.first,
+                            example: CFEConstants::VALID_REGULAR_TRANSACTION_FREQUENCIES.first,
                           },
                           amount: {
                             type: :number,
@@ -113,7 +113,7 @@ RSpec.describe "regular_transactions", type: :request, swagger_doc: "v5/swagger.
           expect(body[:errors])
             .to include(%r{The property '#/regular_transactions/0/category' value "" did not match one of the following values:},
                         %r{The property '#/regular_transactions/0/operation' value "" did not match one of the following values: credit, debit},
-                        %r{The property '#/regular_transactions/0/frequency' value "" did not match one of the following values: monthly, four_weekly, two_weekly, weekly, unknown},
+                        %r{The property '#/regular_transactions/0/frequency' value "" did not match one of the following values: three_monthly, monthly, four_weekly, two_weekly, weekly, unknown},
                         %r{The property '#/regular_transactions/0/amount' value "" did not match the regex})
         end
       end

--- a/spec/services/concerns/monthly_equivalent_calculatable_spec.rb
+++ b/spec/services/concerns/monthly_equivalent_calculatable_spec.rb
@@ -1,0 +1,97 @@
+RSpec.describe MonthlyEquivalentCalculatable do
+  subject(:result) { klass.new.call(frequency, value) }
+
+  let(:klass) do
+    Class.new do
+      include MonthlyEquivalentCalculatable
+
+      def call(frequency, value)
+        send(determine_calc_method(frequency), value)
+      end
+
+    private
+
+      def blunt_average(value)
+        value
+      end
+    end
+  end
+
+  context "with frequency of three_monthly" do
+    let(:frequency) { :three_monthly }
+    let(:value) { 1000.00 }
+
+    it "divides by 3 and rounds to 2 decimals" do
+      expect(result).to be 333.33
+    end
+  end
+
+  context "with frequency of monthly" do
+    let(:frequency) { :monthly }
+    let(:value) { 1000.001 }
+
+    it "returns input value unaltered" do
+      expect(result).to be 1000.001
+    end
+  end
+
+  context "with frequency of four weekly" do
+    let(:frequency) { :four_weekly }
+    let(:value) { 1000.00 }
+
+    it "divides by 4, multiples by 52, divides by 12 and rounds to 2 decimals" do
+      expect(result).to be 1083.33
+    end
+  end
+
+  context "with frequency of two weekly" do
+    let(:frequency) { :two_weekly }
+    let(:value) { 1000.00 }
+
+    it "divides by 2, multiples by 52, divides by 12 and rounds to 2 decimals" do
+      expect(result).to be 2166.67
+    end
+  end
+
+  context "with frequency of weekly" do
+    let(:frequency) { :weekly }
+    let(:value) { 1000.00 }
+
+    it "multiples by 52, divides by 12 and rounds to 2 decimals" do
+      expect(result).to be 4333.33
+    end
+  end
+
+  context "with invalid frequency" do
+    let(:frequency) { :quarterly }
+    let(:value) { 1000.00 }
+
+    it "raises error" do
+      expect { result }.to raise_error(ArgumentError, "unexpected frequency quarterly")
+    end
+  end
+
+  context "with frequency of unknown" do
+    subject(:result) { instance.call(:unknown, 111.11) }
+
+    let(:instance) { klass.new }
+
+    it "calls blunt_average of owning class" do
+      allow(instance).to receive(:blunt_average).and_return("foobar")
+      expect(result).to match("foobar")
+      expect(instance).to have_received(:blunt_average).with(111.11)
+    end
+  end
+
+  context "with frequency as string" do
+    subject(:result) { instance.call("weekly", 1000.00) }
+
+    let(:instance) { klass.new }
+
+    it "calls matching calculation method" do
+      allow(instance).to receive(:weekly_to_monthly).and_call_original
+      expect(result).to be 4333.33
+      expect(instance).to have_received(:weekly_to_monthly).with(1000.00)
+    end
+  end
+end

--- a/spec/services/creators/regular_transactions_creator_spec.rb
+++ b/spec/services/creators/regular_transactions_creator_spec.rb
@@ -158,7 +158,7 @@ RSpec.describe Creators::RegularTransactionsCreator do
         expect(creator.errors)
           .to include(%r{The property '#/regular_transactions/0/category' value "" did not match one of the following values:},
                       %r{The property '#/regular_transactions/0/operation' value "" did not match one of the following values: credit, debit},
-                      %r{The property '#/regular_transactions/0/frequency' value "" did not match one of the following values: monthly, four_weekly, two_weekly, weekly, unknown},
+                      %r{The property '#/regular_transactions/0/frequency' value "" did not match one of the following values: three_monthly, monthly, four_weekly, two_weekly, weekly, unknown},
                       %r{The property '#/regular_transactions/0/amount' value "" did not match the regex})
       end
     end

--- a/spec/services/utilities/employment_income_monthly_equivalent_calculator_spec.rb
+++ b/spec/services/utilities/employment_income_monthly_equivalent_calculator_spec.rb
@@ -246,8 +246,8 @@ RSpec.describe Utilities::EmploymentIncomeMonthlyEquivalentCalculator do
       allow(Utilities::PaymentPeriodAnalyser).to receive(:new).and_return(mock_analyser)
     end
 
-    it "raises an argument error with period :unknown" do
-      expect { described_class.call(employment) }.to raise_error ArgumentError, "unexpected period testing"
+    it "raises an argument error for unacceptable period" do
+      expect { described_class.call(employment) }.to raise_error ArgumentError, "unexpected frequency testing"
     end
   end
 end

--- a/swagger/v5/swagger.yaml
+++ b/swagger/v5/swagger.yaml
@@ -1086,6 +1086,7 @@ paths:
                       frequency:
                         type: string
                         enum:
+                        - three_monthly
                         - monthly
                         - four_weekly
                         - two_weekly
@@ -1093,7 +1094,7 @@ paths:
                         - unknown
                         description: Frequency with which regular transaction is made
                           or received
-                        example: monthly
+                        example: three_monthly
                       amount:
                         type: number
                         format: decimal


### PR DESCRIPTION
## What
Add three_monthly equivalent frequency

[Link to story](https://dsdmoj.atlassian.net/browse/AP-3474)

This is required as a design option for
presentation in the Apply service. There
therefore should be a matching frequency in CFE
for consistency and to avoid calculations on
the Apply side.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
