### PR TITLE
[AP-3480] Calculate net_housing_costs for regular transactions

### DIFF
--- a/app/constants/cfe_constants.rb
+++ b/app/constants/cfe_constants.rb
@@ -11,6 +11,7 @@ module CFEConstants
   # Income categories
   #
   VALID_INCOME_CATEGORIES = %w[benefits friends_or_family maintenance_in property_or_lodger pension].freeze
+  VALID_REGULAR_INCOME_CATEGORIES = VALID_INCOME_CATEGORIES + %w[housing_benefit].freeze
   HUMANIZED_INCOME_CATEGORIES = (VALID_INCOME_CATEGORIES + VALID_INCOME_CATEGORIES.map(&:humanize)).freeze
 
   # Outgoings categories

--- a/app/models/gross_income_summary.rb
+++ b/app/models/gross_income_summary.rb
@@ -12,7 +12,6 @@ class GrossIncomeSummary < ApplicationRecord
            dependent: :destroy
 
   def housing_benefit_payments
-    # TODO: could return regular transaction records for housing_benefit here as well? or handle in HousingCostsCalculator
     state_benefits.find_by(state_benefit_type_id: StateBenefitType.housing_benefit&.id)&.state_benefit_payments || []
   end
 

--- a/app/models/gross_income_summary.rb
+++ b/app/models/gross_income_summary.rb
@@ -12,6 +12,7 @@ class GrossIncomeSummary < ApplicationRecord
            dependent: :destroy
 
   def housing_benefit_payments
+    # TODO: could return regular transaction records for housing_benefit here as well? or handle in HousingCostsCalculator
     state_benefits.find_by(state_benefit_type_id: StateBenefitType.housing_benefit&.id)&.state_benefit_payments || []
   end
 

--- a/app/models/regular_transaction.rb
+++ b/app/models/regular_transaction.rb
@@ -7,7 +7,7 @@ class RegularTransaction < ApplicationRecord
                                      message: "%<value>s is not a valid operation" }
 
   validates :category, inclusion: {
-    in: CFEConstants::VALID_INCOME_CATEGORIES,
+    in: CFEConstants::VALID_REGULAR_INCOME_CATEGORIES,
     message: "is not a valid credit category: %<value>s",
   }, if: :credit?
 

--- a/app/services/calculators/housing_costs_calculator.rb
+++ b/app/services/calculators/housing_costs_calculator.rb
@@ -19,12 +19,14 @@ module Calculators
     end
 
     def gross_housing_costs
-      @gross_housing_costs ||= gross_housing_costs_bank + gross_housing_costs_regular_transactions + gross_housing_costs_cash
+      @gross_housing_costs ||= gross_housing_costs_bank +
+        gross_housing_costs_regular_transactions +
+        gross_housing_costs_cash
     end
 
     def monthly_housing_benefit
-      # TODO: could sum in regular transaction records for housing_benefit here as well? or handle in GrossIncomeSummary
-      @monthly_housing_benefit = disposable_income_summary.calculate_monthly_equivalent(collection: housing_benefit_records)
+      @monthly_housing_benefit ||= disposable_income_summary.calculate_monthly_equivalent(collection: housing_benefit_records) +
+        monthly_housing_benefit_regular_transactions
     end
 
   private
@@ -42,6 +44,13 @@ module Calculators
       monthly_regular_transaction_amount_by(operation: :debit, category: :rent_or_mortgage)
     end
 
+    def monthly_housing_benefit_regular_transactions
+      monthly_regular_transaction_amount_by(operation: :credit, category: :housing_benefit)
+    end
+
+    # TODO: regular transactions may need accounting for here at some point
+    # but at time of writing they do not include sub-types of housing costs,
+    # specifically "board and lodging", so this should never get called.
     def monthly_actual_housing_costs
       @monthly_actual_housing_costs ||= calculate_actual_housing_costs + gross_housing_costs_cash
     end
@@ -59,7 +68,8 @@ module Calculators
     end
 
     def all_board_and_lodging?
-      housing_cost_outgoings.map(&:housing_cost_type).all?("board_and_lodging")
+      housing_cost_outgoings.present? &&
+        housing_cost_outgoings.map(&:housing_cost_type).all?("board_and_lodging")
     end
 
     def should_halve_full_cost_minus_benefits?
@@ -67,11 +77,12 @@ module Calculators
     end
 
     def should_exclude_housing_benefit?
-      applicant_has_dependants? && receiving_benefits?
+      applicant_has_dependants? && receiving_housing_benefits?
     end
 
-    def receiving_benefits?
-      gross_income_summary&.housing_benefit_payments.present?
+    def receiving_housing_benefits?
+      gross_income_summary&.housing_benefit_payments.present? ||
+        monthly_housing_benefit_regular_transactions.positive?
     end
 
     def single_monthly_housing_costs_cap

--- a/app/services/calculators/housing_costs_calculator.rb
+++ b/app/services/calculators/housing_costs_calculator.rb
@@ -23,6 +23,7 @@ module Calculators
     end
 
     def monthly_housing_benefit
+      # TODO: could sum in regular transaction records for housing_benefit here as well? or handle in GrossIncomeSummary
       @monthly_housing_benefit = disposable_income_summary.calculate_monthly_equivalent(collection: housing_benefit_records)
     end
 

--- a/app/services/collators/housing_costs_collator.rb
+++ b/app/services/collators/housing_costs_collator.rb
@@ -2,6 +2,7 @@ module Collators
   class HousingCostsCollator < BaseWorkflowService
     def call
       housing_calculator = Calculators::HousingCostsCalculator.new(assessment)
+
       disposable_income_summary.update!(
         housing_benefit: housing_calculator.monthly_housing_benefit,
         gross_housing_costs: housing_calculator.gross_housing_costs,

--- a/app/services/workflows/non_passported_workflow.rb
+++ b/app/services/workflows/non_passported_workflow.rb
@@ -21,13 +21,9 @@ module Workflows
       Assessors::GrossIncomeAssessor.call(assessment)
     end
 
-    def collate_outgoings
-      Collators::OutgoingsCollator.call(assessment)
-    end
-
     # TODO: make the Collators::DisposableIncomeCollator increment/sum to existing values so order of "collation" becomes unimportant
     def disposable_income_assessment
-      collate_outgoings
+      Collators::OutgoingsCollator.call(assessment)
       Collators::DisposableIncomeCollator.call(assessment)
       Collators::RegularOutgoingsCollator.call(assessment) # here OR call in Collators::DisposableIncomeCollator
       Assessors::DisposableIncomeAssessor.call(assessment)

--- a/lib/integration_helpers/test_case/regular_transaction.rb
+++ b/lib/integration_helpers/test_case/regular_transaction.rb
@@ -23,10 +23,12 @@ module TestCase
 
     def operation
       case category
-      when *CFEConstants::VALID_INCOME_CATEGORIES
+      when *CFEConstants::VALID_REGULAR_INCOME_CATEGORIES
         "credit"
       when *CFEConstants::VALID_OUTGOING_CATEGORIES
         "debit"
+      else
+        raise ArgumentError, "unexpected category \"#{category}\" with no available operation"
       end
     end
 

--- a/public/schemas/regular_transactions.json.erb
+++ b/public/schemas/regular_transactions.json.erb
@@ -14,7 +14,7 @@
         "properties": {
           "category": {
             "type": "string",
-            "enum": <%= CFEConstants::VALID_INCOME_CATEGORIES.as_json + CFEConstants::VALID_OUTGOING_CATEGORIES.as_json %>
+            "enum": <%= CFEConstants::VALID_REGULAR_INCOME_CATEGORIES.as_json + CFEConstants::VALID_OUTGOING_CATEGORIES.as_json %>
           },
           "operation": {
             "type": "string",

--- a/spec/lib/integration_helpers/test_case/regular_transaction_spec.rb
+++ b/spec/lib/integration_helpers/test_case/regular_transaction_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe TestCase::RegularTransaction do
 
     context "with a credit category" do
       let(:category) { "maintenance_in" }
+
       let(:data) do
         [
           %w[irrelevant irrelevant irrelevant 111.11],
@@ -28,6 +29,7 @@ RSpec.describe TestCase::RegularTransaction do
 
     context "with a debit category" do
       let(:category) { "maintenance_out" }
+
       let(:data) do
         [
           %w[irrelevant irrelevant irrelevant 111.11],
@@ -42,6 +44,20 @@ RSpec.describe TestCase::RegularTransaction do
           amount: "111.11",
           frequency: "monthly",
         })
+      end
+    end
+
+    context "with an unknown category" do
+      let(:category) { "foobar" }
+      let(:data) do
+        [
+          %w[irrelevant irrelevant irrelevant 111.11],
+          %w[irrelevant irrelevant irrelevant monthly],
+        ]
+      end
+
+      it "raise argument error" do
+        expect { payload }.to raise_error ArgumentError, "unexpected category \"foobar\" with no available operation"
       end
     end
 

--- a/spec/models/regular_transaction_spec.rb
+++ b/spec/models/regular_transaction_spec.rb
@@ -75,6 +75,12 @@ RSpec.describe RegularTransaction, type: :model do
     end
   end
 
+  context "when category is housing_benefit" do
+    subject(:regular_transaction) { build(:regular_transaction, operation: "credit", category: "housing_benefit") }
+
+    it { is_expected.to be_valid }
+  end
+
   context "with valid frequency" do
     subject(:regular_transaction) { build(:regular_transaction, frequency: "monthly") }
 

--- a/spec/requests/swagger_docs/v5/regular_transactions_spec.rb
+++ b/spec/requests/swagger_docs/v5/regular_transactions_spec.rb
@@ -38,9 +38,9 @@ RSpec.describe "regular_transactions", type: :request, swagger_doc: "v5/swagger.
                         properties: {
                           category: {
                             type: :string,
-                            enum: CFEConstants::VALID_INCOME_CATEGORIES + CFEConstants::VALID_OUTGOING_CATEGORIES,
+                            enum: CFEConstants::VALID_REGULAR_INCOME_CATEGORIES + CFEConstants::VALID_OUTGOING_CATEGORIES,
                             description: "Identifying category for this regular transaction",
-                            example: CFEConstants::VALID_INCOME_CATEGORIES.first,
+                            example: CFEConstants::VALID_REGULAR_INCOME_CATEGORIES.first,
                           },
                           operation: {
                             type: :string,

--- a/spec/services/calculators/housing_costs_calculator_spec.rb
+++ b/spec/services/calculators/housing_costs_calculator_spec.rb
@@ -2,307 +2,429 @@ require "rails_helper"
 
 module Calculators
   RSpec.describe HousingCostsCalculator do
-    let(:assessment) { create :assessment, :with_gross_income_summary_and_records, :with_disposable_income_summary, with_child_dependants: children }
-    let(:rent_or_mortgage_category) { assessment.cash_transaction_categories.detect { |cat| cat.name == "rent_or_mortgage" } }
-    let(:rent_or_mortgage_transactions) { rent_or_mortgage_category.cash_transactions.order(:date) }
-    let(:monthly_cash_housing) { rent_or_mortgage_transactions.average(:amount).round(2).to_d }
-    let(:children) { 0 }
-
     subject(:calculator) { described_class.new(assessment) }
 
-    before do
-      create :bank_holiday
-      [2.months.ago, 1.month.ago, Date.current].each do |date|
-        create :housing_cost_outgoing,
-               disposable_income_summary: assessment.disposable_income_summary,
-               payment_date: date,
-               amount: housing_cost_amount,
-               housing_cost_type:
+    context "when using outgoings and state_benefits" do
+      let(:assessment) { create :assessment, :with_gross_income_summary_and_records, :with_disposable_income_summary, with_child_dependants: children }
+      let(:rent_or_mortgage_category) { assessment.cash_transaction_categories.detect { |cat| cat.name == "rent_or_mortgage" } }
+      let(:rent_or_mortgage_transactions) { rent_or_mortgage_category.cash_transactions.order(:date) }
+      let(:monthly_cash_housing) { rent_or_mortgage_transactions.average(:amount).round(2).to_d }
+      let(:children) { 0 }
+
+      before do
+        stub_request(:get, "https://www.gov.uk/bank-holidays.json")
+          .to_return(body: file_fixture("bank-holidays.json").read)
+
+        [2.months.ago, 1.month.ago, Date.current].each do |date|
+          create :housing_cost_outgoing,
+                 disposable_income_summary: assessment.disposable_income_summary,
+                 payment_date: date,
+                 amount: housing_cost_amount,
+                 housing_cost_type:
+        end
+
+        calculator
+        assessment.disposable_income_summary.reload
+        @assessment = assessment
       end
 
-      calculator
-      assessment.disposable_income_summary.reload
-      @assessment = assessment
-    end
+      context "when applicant has no dependants" do
+        let(:housing_cost_amount) { 1200.00 }
 
-    context "when applicant has no dependants" do
-      let(:housing_cost_amount) { 1200.00 }
+        context "and does not receive housing benefit" do
+          context "with board and lodging" do
+            let(:housing_cost_type) { "board_and_lodging" }
+            let(:housing_cost_amount) { 1500.00 }
 
-      context "and does not receive housing benefit" do
-        context "board and lodging" do
-          let(:housing_cost_type) { "board_and_lodging" }
-          let(:housing_cost_amount) { 1500.00 }
+            it "caps the return" do
+              expect(calculator.gross_housing_costs).to eq BigDecimal("750.00") + monthly_cash_housing
+              expect(calculator.monthly_housing_benefit).to eq 0.0
+              expect(calculator.net_housing_costs).to eq 545.00 # Cap applied
+            end
 
-          it "caps the return" do
-            expect(calculator.gross_housing_costs).to eq BigDecimal("750.00") + monthly_cash_housing
-            expect(calculator.monthly_housing_benefit).to eq 0.0
-            expect(calculator.net_housing_costs).to eq 545.00 # Cap applied
+            context "when 50% of monthly bank outgoings are below the cap but overall above it when including cash payments" do
+              let(:housing_cost_amount) { 1088.00 }
+
+              it "returns the gross cost as net" do
+                expect(calculator.gross_housing_costs).to eq BigDecimal("544.00") + monthly_cash_housing
+                expect(calculator.monthly_housing_benefit).to eq 0.0
+                expect(calculator.net_housing_costs).to eq 545.00 # Cap applied
+              end
+            end
+
+            context "when 50% of monthly bank and cash outgoings are below the cap" do
+              let(:housing_cost_amount) { 888.0 }
+
+              it "returns the gross cost as net" do
+                expect(calculator.gross_housing_costs).to eq BigDecimal("444.0") + monthly_cash_housing # all variables are always decimals
+                expect(calculator.monthly_housing_benefit).to eq 0.0
+                expect(calculator.net_housing_costs).to eq (BigDecimal("444.0") + monthly_cash_housing).to_f # net_housing_costs is always a float
+              end
+            end
           end
 
-          context "when 50% of monthly bank outgoings are below the cap but overall above it when including cash payments" do
-            let(:housing_cost_amount) { 1088.00 }
+          context "with rent" do
+            let(:housing_cost_type) { "rent" }
 
-            it "returns the gross cost as net" do
-              expect(calculator.gross_housing_costs).to eq BigDecimal("544.00") + monthly_cash_housing
+            it "caps the return" do
+              expect(calculator.gross_housing_costs).to eq BigDecimal("1200.00") + monthly_cash_housing
               expect(calculator.monthly_housing_benefit).to eq 0.0
+              expect(calculator.net_housing_costs).to eq 545.00 # Cap applied
+            end
+
+            context "when net cost is below housing cap" do
+              let(:housing_cost_amount) { 420.00 }
+
+              it "returns the net cost" do
+                expect(calculator.gross_housing_costs).to eq BigDecimal("420.00") + monthly_cash_housing
+                expect(calculator.monthly_housing_benefit).to eq 0.0
+                expect(calculator.net_housing_costs).to eq 420.00 + monthly_cash_housing
+              end
+            end
+          end
+
+          context "with mortgage" do
+            let(:housing_cost_type) { "mortgage" }
+
+            it "caps the return" do
+              expect(calculator.gross_housing_costs).to eq BigDecimal("1200.00") + monthly_cash_housing
+              expect(calculator.monthly_housing_benefit).to eq 0.0
+              expect(calculator.net_housing_costs).to eq 545.00 # Cap applied
+            end
+
+            context "when net cost is below housing cap" do
+              let(:housing_cost_amount) { 420.00 }
+
+              it "returns the net cost" do
+                expect(calculator.gross_housing_costs).to eq BigDecimal("420.00") + monthly_cash_housing # all variables are always decimals
+                expect(calculator.monthly_housing_benefit).to eq 0.0
+                expect(calculator.net_housing_costs).to eq (BigDecimal("420.00") + monthly_cash_housing).to_f # net_housing_costs is always a float
+              end
+            end
+          end
+        end
+
+        context "and receives housing benefit as a state_benefit" do
+          let(:housing_benefit_amount) { 500.00 }
+
+          before { create_housing_benefit_payments(housing_benefit_amount) }
+
+          context "with board and lodging" do
+            let(:housing_cost_type) { "board_and_lodging" }
+            let(:housing_cost_amount) { 1500.00 }
+            let(:housing_benefit_amount) { 100.00 }
+
+            it "caps the return" do
+              expect(calculator.gross_housing_costs).to eq BigDecimal("750.00") + monthly_cash_housing
+              expect(calculator.monthly_housing_benefit).to eq 100.00
               expect(calculator.net_housing_costs).to eq 545.00 # Cap applied
             end
           end
 
-          context "when 50% of monthly bank and cash outgoings are below the cap" do
-            let(:housing_cost_amount) { 888.0 }
-
-            it "returns the gross cost as net" do
-              expect(calculator.gross_housing_costs).to eq BigDecimal("444.0") + monthly_cash_housing # all variables are always decimals
-              expect(calculator.monthly_housing_benefit).to eq 0.0
-              expect(calculator.net_housing_costs).to eq (BigDecimal("444.0") + monthly_cash_housing).to_f # net_housing_costs is always a float
-            end
-          end
-        end
-
-        context "rent" do
-          let(:housing_cost_type) { "rent" }
-
-          it "caps the return" do
-            expect(calculator.gross_housing_costs).to eq BigDecimal("1200.00") + monthly_cash_housing
-            expect(calculator.monthly_housing_benefit).to eq 0.0
-            expect(calculator.net_housing_costs).to eq 545.00 # Cap applied
-          end
-
-          context "when net cost is below housing cap" do
-            let(:housing_cost_amount) { 420.00 }
-
-            it "returns the net cost" do
-              expect(calculator.gross_housing_costs).to eq BigDecimal("420.00") + monthly_cash_housing
-              expect(calculator.monthly_housing_benefit).to eq 0.0
-              expect(calculator.net_housing_costs).to eq 420.00 + monthly_cash_housing
-            end
-          end
-        end
-
-        context "mortgage" do
-          let(:housing_cost_type) { "mortgage" }
-
-          it "caps the return" do
-            expect(calculator.gross_housing_costs).to eq BigDecimal("1200.00") + monthly_cash_housing
-            expect(calculator.monthly_housing_benefit).to eq 0.0
-            expect(calculator.net_housing_costs).to eq 545.00 # Cap applied
-          end
-
-          context "when net cost is below housing cap" do
-            let(:housing_cost_amount) { 420.00 }
-
-            it "returns the net cost" do
-              expect(calculator.gross_housing_costs).to eq BigDecimal("420.00") + monthly_cash_housing # all variables are always decimals
-              expect(calculator.monthly_housing_benefit).to eq 0.0
-              expect(calculator.net_housing_costs).to eq (BigDecimal("420.00") + monthly_cash_housing).to_f # net_housing_costs is always a float
-            end
-          end
-        end
-      end
-
-      context "and receives housing benefit" do
-        let(:housing_benefit_amount) { 500.00 }
-
-        before { create_benefit_payments(housing_benefit_amount) }
-
-        context "and pays board and lodging" do
-          let(:housing_cost_type) { "board_and_lodging" }
-          let(:housing_cost_amount) { 1500.00 }
-          let(:housing_benefit_amount) { 100.00 }
-
-          it "caps the return" do
-            expect(calculator.gross_housing_costs).to eq BigDecimal("750.00") + monthly_cash_housing
-            expect(calculator.monthly_housing_benefit).to eq 100.00
-            expect(calculator.net_housing_costs).to eq 545.00 # Cap applied
-          end
-        end
-
-        context "rent" do
-          let(:housing_cost_type) { "rent" }
-
-          it "caps the return" do
-            expect(calculator.gross_housing_costs).to eq BigDecimal("1200.00") + monthly_cash_housing
-            expect(calculator.monthly_housing_benefit).to eq 500.0
-            expect(calculator.net_housing_costs).to eq 545.00 # Cap applied
-          end
-
-          context "when net amount will be below the cap" do
-            let(:housing_cost_amount) { 1200.00 }
-            let(:housing_benefit_amount) { 500.00 }
+          context "with rent" do
+            let(:housing_cost_type) { "rent" }
 
             it "caps the return" do
               expect(calculator.gross_housing_costs).to eq BigDecimal("1200.00") + monthly_cash_housing
               expect(calculator.monthly_housing_benefit).to eq 500.0
               expect(calculator.net_housing_costs).to eq 545.00 # Cap applied
             end
+
+            context "when net cost is below housing cap" do
+              let(:housing_cost_amount) { 1000.00 }
+              let(:housing_benefit_amount) { 600.00 }
+
+              it "returns gross less housing benefits" do
+                expect(calculator.gross_housing_costs).to eq 1000.00 + monthly_cash_housing
+                expect(calculator.monthly_housing_benefit).to eq 600.0
+                expect(calculator.net_housing_costs).to eq 400.00 + monthly_cash_housing
+              end
+            end
+          end
+
+          context "with mortgage" do
+            let(:housing_cost_type) { "mortgage" }
+
+            it "caps the return" do
+              expect(calculator.gross_housing_costs).to eq BigDecimal("1200.00") + monthly_cash_housing
+              expect(calculator.monthly_housing_benefit).to eq 500.00
+              expect(calculator.net_housing_costs).to eq 545.00 # Cap applied
+            end
+
+            context "when net amount will be below the cap" do
+              let(:housing_cost_amount) { 600.00 }
+              let(:housing_benefit_amount) { 200.00 }
+
+              it "returns net as gross_cost minus housing_benefit" do
+                expect(calculator.gross_housing_costs).to eq BigDecimal("600.00") + monthly_cash_housing
+                expect(calculator.monthly_housing_benefit).to eq 200.0
+                expect(calculator.net_housing_costs).to eq BigDecimal("400.00") + monthly_cash_housing
+              end
+            end
+          end
+        end
+      end
+
+      context "when applicant has dependants" do
+        let(:housing_cost_amount) { 1200.00 }
+        let(:children) { 1 }
+
+        context "with no housing benefit" do
+          context "board and lodging" do
+            let(:housing_cost_type) { "board_and_lodging" }
+            let(:housing_cost_amount) { 1500.00 }
+
+            it "records half the monthly housing cost" do
+              expect(calculator.gross_housing_costs).to eq BigDecimal("750.00") + monthly_cash_housing
+              expect(calculator.monthly_housing_benefit).to eq 0.0
+              expect(calculator.net_housing_costs).to eq BigDecimal("750.00") + monthly_cash_housing
+            end
+
+            context "when net cost is below housing cap" do
+              let(:housing_cost_amount) { 900.00 }
+
+              it "returns half the monthly housing cost" do
+                expect(calculator.gross_housing_costs).to eq BigDecimal("450.00") + monthly_cash_housing
+                expect(calculator.monthly_housing_benefit).to eq 0.0
+                expect(calculator.net_housing_costs).to eq BigDecimal("450.00") + monthly_cash_housing
+              end
+            end
+          end
+
+          context "rent" do
+            let(:housing_cost_type) { "rent" }
+
+            it "records the full monthly housing costs" do
+              expect(calculator.gross_housing_costs).to eq BigDecimal("1200.00") + monthly_cash_housing
+              expect(calculator.monthly_housing_benefit).to eq 0.0
+              expect(calculator.net_housing_costs).to eq BigDecimal("1200.00") + monthly_cash_housing
+            end
+
+            context "when net cost is below housing cap" do
+              let(:housing_cost_amount) { 520.00 }
+
+              it "returns the net cost" do
+                expect(calculator.gross_housing_costs).to eq BigDecimal("520.00") + monthly_cash_housing
+                expect(calculator.monthly_housing_benefit).to eq 0.0
+                expect(calculator.net_housing_costs).to eq BigDecimal("520.00") + monthly_cash_housing
+              end
+            end
+          end
+
+          context "mortgage" do
+            let(:housing_cost_type) { "mortgage" }
+
+            it "records the full monthly housing costs" do
+              expect(calculator.gross_housing_costs).to eq BigDecimal("1200.00") + monthly_cash_housing
+              expect(calculator.monthly_housing_benefit).to eq 0.0
+              expect(calculator.net_housing_costs).to eq BigDecimal("1200.00") + monthly_cash_housing
+            end
+
+            context "when net cost is below housing cap" do
+              let(:housing_cost_amount) { 520.00 }
+
+              it "returns the gross cost as net" do
+                expect(calculator.gross_housing_costs).to eq BigDecimal("520.00") + monthly_cash_housing
+                expect(calculator.monthly_housing_benefit).to eq 0.0
+                expect(calculator.net_housing_costs).to eq BigDecimal("520.00") + monthly_cash_housing
+              end
+            end
           end
         end
 
-        context "mortgage" do
-          let(:housing_cost_type) { "mortgage" }
+        context "with housing benefit as a state_benefit" do
+          let(:housing_benefit_amount) { 500.00 }
 
-          it "caps the return" do
-            expect(calculator.gross_housing_costs).to eq BigDecimal("1200.00") + monthly_cash_housing
-            expect(calculator.monthly_housing_benefit).to eq 500.00
-            expect(calculator.net_housing_costs).to eq 545.00 # Cap applied
+          before { create_housing_benefit_payments(housing_benefit_amount) }
+
+          context "board and lodging" do
+            let(:housing_cost_type) { "board_and_lodging" }
+            let(:housing_cost_amount) { 1200.00 }
+            let(:housing_benefit_amount) { 100.00 }
+
+            it "records half the monthly outgoing less the housing benefit" do
+              expect(calculator.gross_housing_costs).to eq BigDecimal("600.00") + monthly_cash_housing
+              expect(calculator.monthly_housing_benefit).to eq 100.000
+              expect(calculator.net_housing_costs).to eq((housing_cost_amount.to_d + monthly_cash_housing - housing_benefit_amount.to_d) / 2)
+            end
           end
 
-          context "when net amount will be below the cap" do
-            let(:housing_cost_amount) { 600.00 }
-            let(:housing_benefit_amount) { 200.00 }
+          context "board and lodging different values" do
+            let(:housing_cost_type) { "board_and_lodging" }
+            let(:housing_cost_amount) { 1500.00 }
+            let(:housing_benefit_amount) { 100.00 }
 
-            it "returns net as gross_cost minus housing_benefit" do
-              expect(calculator.gross_housing_costs).to eq BigDecimal("600.00") + monthly_cash_housing
-              expect(calculator.monthly_housing_benefit).to eq 200.0
-              expect(calculator.net_housing_costs).to eq BigDecimal("400.00") + monthly_cash_housing
+            it "records half the housing cost less the housing benefit" do
+              expect(calculator.gross_housing_costs).to eq BigDecimal("750.00") + monthly_cash_housing
+              expect(calculator.monthly_housing_benefit).to eq 100.00
+              expect(calculator.net_housing_costs).to eq((housing_cost_amount.to_d + monthly_cash_housing - housing_benefit_amount.to_d) / 2)
+            end
+          end
+
+          context "rent" do
+            let(:housing_cost_type) { "rent" }
+
+            it "records the full monthly housing costs" do
+              expect(calculator.gross_housing_costs).to eq BigDecimal("1200.00") + monthly_cash_housing
+              expect(calculator.monthly_housing_benefit).to eq 500.00
+              expect(calculator.net_housing_costs).to eq BigDecimal("700.00") + monthly_cash_housing
+            end
+
+            context "when net cost is below housing cap" do
+              let(:housing_cost_amount) { 600.00 }
+              let(:housing_benefit_amount) { 200.00 }
+
+              it "returns net as gross_cost minus housing_benefit" do
+                expect(calculator.gross_housing_costs).to eq BigDecimal("600.00") + monthly_cash_housing
+                expect(calculator.monthly_housing_benefit).to eq 200.0
+                expect(calculator.net_housing_costs).to eq BigDecimal("400.00") + monthly_cash_housing
+              end
+            end
+          end
+
+          context "mortgage" do
+            let(:housing_cost_type) { "mortgage" }
+
+            it "records the full housing costs less the housing benefit" do
+              expect(calculator.gross_housing_costs).to eq BigDecimal("1200.00") + monthly_cash_housing
+              expect(calculator.monthly_housing_benefit).to eq 500.00
+              expect(calculator.net_housing_costs).to eq BigDecimal("700.00") + monthly_cash_housing
+            end
+
+            context "when net cost is below housing cap" do
+              let(:housing_cost_amount) { 600.00 }
+              let(:housing_benefit_amount) { 200.00 }
+
+              it "returns net as gross_cost minus housing_benefit" do
+                expect(calculator.gross_housing_costs).to eq BigDecimal("600.00") + monthly_cash_housing
+                expect(calculator.monthly_housing_benefit).to eq 200.0
+                expect(calculator.net_housing_costs).to eq BigDecimal("400.00") + monthly_cash_housing
+              end
             end
           end
         end
       end
     end
 
-    context "when applicant has dependants" do
-      let(:housing_cost_amount) { 1200.00 }
-      let(:children) { 1 }
+    context "when using regular_transactions" do
+      let(:instance) { described_class.new(assessment) }
+      let(:assessment) { create :assessment, :with_gross_income_summary, :with_disposable_income_summary }
+      let(:dates) { [Date.current, 1.month.ago, 2.months.ago] }
 
-      context "no housing benefit" do
-        context "board and lodging" do
-          let(:housing_cost_type) { "board_and_lodging" }
-          let(:housing_cost_amount) { 1500.00 }
+      before do
+        stub_request(:get, "https://www.gov.uk/bank-holidays.json")
+          .to_return(body: file_fixture("bank-holidays.json").read)
+      end
 
-          it "records half the monthly housing cost" do
-            expect(calculator.gross_housing_costs).to eq BigDecimal("750.00") + monthly_cash_housing
-            expect(calculator.monthly_housing_benefit).to eq 0.0
-            expect(calculator.net_housing_costs).to eq BigDecimal("750.00") + monthly_cash_housing
-          end
+      describe "#gross_housing_costs" do
+        subject(:gross_housing_costs) { instance.gross_housing_costs }
 
-          context "when net cost is below housing cap" do
-            let(:housing_cost_amount) { 900.00 }
-
-            it "returns half the monthly housing cost" do
-              expect(calculator.gross_housing_costs).to eq BigDecimal("450.00") + monthly_cash_housing
-              expect(calculator.monthly_housing_benefit).to eq 0.0
-              expect(calculator.net_housing_costs).to eq BigDecimal("450.00") + monthly_cash_housing
-            end
-          end
+        context "with no housing costs" do
+          it { is_expected.to eq 0 }
         end
 
-        context "rent" do
-          let(:housing_cost_type) { "rent" }
+        context "with all forms of housing costs" do
+          before do
+            # add monthly equivalent bank transactions of 111.11
+            create(:housing_cost_outgoing, disposable_income_summary: assessment.disposable_income_summary, payment_date: dates[0], amount: 333.33)
 
-          it "records the full monthly housing costs" do
-            expect(calculator.gross_housing_costs).to eq BigDecimal("1200.00") + monthly_cash_housing
-            expect(calculator.monthly_housing_benefit).to eq 0.0
-            expect(calculator.net_housing_costs).to eq BigDecimal("1200.00") + monthly_cash_housing
+            # add average cash transactions of 111.11
+            rent_or_mortgage = create(:cash_transaction_category, name: "rent_or_mortgage", operation: "debit", gross_income_summary: assessment.gross_income_summary)
+            create(:cash_transaction, cash_transaction_category: rent_or_mortgage, date: dates[0], amount: 111.11)
+            create(:cash_transaction, cash_transaction_category: rent_or_mortgage, date: dates[1], amount: 111.11)
+            create(:cash_transaction, cash_transaction_category: rent_or_mortgage, date: dates[2], amount: 111.11)
+
+            # add monthly equivalent regular transaction of 333.33
+            create(:regular_transaction, gross_income_summary: assessment.gross_income_summary, operation: "debit", category: "rent_or_mortgage", frequency: "three_monthly", amount: 1000.00)
           end
 
-          context "when net cost is below housing cap" do
-            let(:housing_cost_amount) { 520.00 }
-
-            it "returns the net cost" do
-              expect(calculator.gross_housing_costs).to eq BigDecimal("520.00") + monthly_cash_housing
-              expect(calculator.monthly_housing_benefit).to eq 0.0
-              expect(calculator.net_housing_costs).to eq BigDecimal("520.00") + monthly_cash_housing
-            end
-          end
-        end
-
-        context "mortgage" do
-          let(:housing_cost_type) { "mortgage" }
-
-          it "records the full monthly housing costs" do
-            expect(calculator.gross_housing_costs).to eq BigDecimal("1200.00") + monthly_cash_housing
-            expect(calculator.monthly_housing_benefit).to eq 0.0
-            expect(calculator.net_housing_costs).to eq BigDecimal("1200.00") + monthly_cash_housing
-          end
-
-          context "when net cost is below housing cap" do
-            let(:housing_cost_amount) { 520.00 }
-
-            it "returns the gross cost as net" do
-              expect(calculator.gross_housing_costs).to eq BigDecimal("520.00") + monthly_cash_housing
-              expect(calculator.monthly_housing_benefit).to eq 0.0
-              expect(calculator.net_housing_costs).to eq BigDecimal("520.00") + monthly_cash_housing
-            end
+          # NOTE: expected API use cases should not add both bank and regular transactions
+          it "sums monthly bank, regular and cash transactions" do
+            expect(gross_housing_costs).to eq 555.55 # 111.11 + 111.11 + 333.33
           end
         end
       end
 
-      context "housing benefit" do
-        let(:housing_benefit_amount) { 500.00 }
+      describe "#monthly_housing_benefit" do
+        subject(:monthly_housing_benefit) { instance.monthly_housing_benefit }
 
-        before { create_benefit_payments(housing_benefit_amount) }
+        context "with state_benefits of housing_benefit type" do
+          before do
+            housing_benefit = create(:state_benefit,
+                                     gross_income_summary: assessment.gross_income_summary,
+                                     state_benefit_type: build(:state_benefit_type, label: "housing_benefit"))
 
-        context "board and lodging" do
-          let(:housing_cost_type) { "board_and_lodging" }
-          let(:housing_cost_amount) { 1200.00 }
-          let(:housing_benefit_amount) { 100.00 }
+            create(:state_benefit_payment, state_benefit: housing_benefit, amount: 222.22, payment_date: dates[0])
+            create(:state_benefit_payment, state_benefit: housing_benefit, amount: 222.22, payment_date: dates[2])
+          end
 
-          it "records half the monthly outgoing less the housing benefit" do
-            expect(calculator.gross_housing_costs).to eq BigDecimal("600.00") + monthly_cash_housing
-            expect(calculator.monthly_housing_benefit).to eq 100.000
-            expect(calculator.net_housing_costs).to eq((housing_cost_amount.to_d + monthly_cash_housing - housing_benefit_amount.to_d) / 2)
+          it "returns monthly equivalent" do
+            expect(monthly_housing_benefit).to eq 148.15 # (222.22 + 222.22) / 3
           end
         end
 
-        context "board and lodging different values" do
-          let(:housing_cost_type) { "board_and_lodging" }
-          let(:housing_cost_amount) { 1500.00 }
-          let(:housing_benefit_amount) { 100.00 }
+        context "with regular_transactions of housing_benefit type" do
+          before do
+            create(:regular_transaction, gross_income_summary: assessment.gross_income_summary, operation: "credit", category: "housing_benefit", frequency: "three_monthly", amount: 1000.00)
+          end
 
-          it "records half the housing cost less the housing benefit" do
-            expect(calculator.gross_housing_costs).to eq BigDecimal("750.00") + monthly_cash_housing
-            expect(calculator.monthly_housing_benefit).to eq 100.00
-            expect(calculator.net_housing_costs).to eq((housing_cost_amount.to_d + monthly_cash_housing - housing_benefit_amount.to_d) / 2)
+          it "returns monthly equivalent" do
+            expect(monthly_housing_benefit).to eq 333.33 # 1000.00 / 3
+          end
+        end
+      end
+
+      describe "#net_housing_costs" do
+        subject(:net_housing_costs) { instance.net_housing_costs }
+
+        context "when single, with no dependants" do
+          it "returns gross housing cost less benefits" do
+            create(:regular_transaction, gross_income_summary: assessment.gross_income_summary, operation: "debit", category: "rent_or_mortgage", frequency: "monthly", amount: 1000.00)
+            create(:regular_transaction, gross_income_summary: assessment.gross_income_summary, operation: "credit", category: "housing_benefit", frequency: "monthly", amount: 500.00)
+
+            expect(net_housing_costs).to eq 500.00
+          end
+
+          it "implements a cap" do
+            create(:regular_transaction, gross_income_summary: assessment.gross_income_summary, operation: "debit", category: "rent_or_mortgage", frequency: "monthly", amount: 1000.00)
+            create(:regular_transaction, gross_income_summary: assessment.gross_income_summary, operation: "credit", category: "housing_benefit", frequency: "monthly", amount: 400.00)
+
+            expect(net_housing_costs).to be 545.00
           end
         end
 
-        context "rent" do
-          let(:housing_cost_type) { "rent" }
-
-          it "records the full monthly housing costs" do
-            expect(calculator.gross_housing_costs).to eq BigDecimal("1200.00") + monthly_cash_housing
-            expect(calculator.monthly_housing_benefit).to eq 500.00
-            expect(calculator.net_housing_costs).to eq BigDecimal("700.00") + monthly_cash_housing
+        context "when has dependants and receives housing benefit" do
+          before do
+            create(:dependant, :child_relative, assessment:)
           end
 
-          context "when net cost is below housing cap" do
-            let(:housing_cost_amount) { 600.00 }
-            let(:housing_benefit_amount) { 200.00 }
+          it "returns gross housing cost less benefits" do
+            create(:regular_transaction, gross_income_summary: assessment.gross_income_summary, operation: "debit", category: "rent_or_mortgage", frequency: "monthly", amount: 1000.00)
+            create(:regular_transaction, gross_income_summary: assessment.gross_income_summary, operation: "credit", category: "housing_benefit", frequency: "monthly", amount: 500.00)
 
-            it "returns net as gross_cost minus housing_benefit" do
-              expect(calculator.gross_housing_costs).to eq BigDecimal("600.00") + monthly_cash_housing
-              expect(calculator.monthly_housing_benefit).to eq 200.0
-              expect(calculator.net_housing_costs).to eq BigDecimal("400.00") + monthly_cash_housing
-            end
+            expect(net_housing_costs).to eq 500.00
           end
         end
 
-        context "mortgage" do
-          let(:housing_cost_type) { "mortgage" }
-
-          it "records the full housing costs less the housing benefit" do
-            expect(calculator.gross_housing_costs).to eq BigDecimal("1200.00") + monthly_cash_housing
-            expect(calculator.monthly_housing_benefit).to eq 500.00
-            expect(calculator.net_housing_costs).to eq BigDecimal("700.00") + monthly_cash_housing
+        # NOTE: when has dependants without benefits
+        # or when not single and with no dependants??
+        #
+        context "when any other situation" do
+          before do
+            create(:dependant, :child_relative, assessment:)
           end
 
-          context "when net cost is below housing cap" do
-            let(:housing_cost_amount) { 600.00 }
-            let(:housing_benefit_amount) { 200.00 }
+          it "returns gross housing without a cap" do
+            create(:regular_transaction, gross_income_summary: assessment.gross_income_summary, operation: "debit", category: "rent_or_mortgage", frequency: "monthly", amount: 1000.00)
+            create(:regular_transaction, gross_income_summary: assessment.gross_income_summary, operation: "credit", category: "housing_benefit", frequency: "monthly", amount: 400.00)
 
-            it "returns net as gross_cost minus housing_benefit" do
-              expect(calculator.gross_housing_costs).to eq BigDecimal("600.00") + monthly_cash_housing
-              expect(calculator.monthly_housing_benefit).to eq 200.0
-              expect(calculator.net_housing_costs).to eq BigDecimal("400.00") + monthly_cash_housing
-            end
+            expect(net_housing_costs).to eq 600.00
           end
         end
       end
     end
 
-    def create_benefit_payments(amount)
+    def create_housing_benefit_payments(amount)
       housing_benefit_type = create :state_benefit_type, label: "housing_benefit"
       state_benefit = create :state_benefit, gross_income_summary: assessment.gross_income_summary, state_benefit_type: housing_benefit_type
       [2.months.ago, 1.month.ago, Date.current].each do |pay_date|

--- a/spec/services/collators/regular_income_collator_spec.rb
+++ b/spec/services/collators/regular_income_collator_spec.rb
@@ -25,6 +25,28 @@ RSpec.describe Collators::RegularIncomeCollator do
       end
     end
 
+    context "with housing_benefit regular transactions" do
+      before do
+        create(:regular_transaction, gross_income_summary:, operation: "credit", category: "housing_benefit", frequency: "three_monthly", amount: 1000.0)
+      end
+
+      it "does not increment #<cagtegory>_all_sources data" do
+        collator
+        gross_income_summary.reload
+        expect(gross_income_summary).to have_attributes(
+          benefits_all_sources: 0.0,
+          maintenance_in_all_sources: 0.0,
+          pension_all_sources: 0.0,
+          friends_or_family_all_sources: 0.0,
+          property_or_lodger_all_sources: 0.0,
+        )
+      end
+
+      it "does not increment #total_gross_income" do
+        expect(gross_income_summary.total_gross_income).to be_zero
+      end
+    end
+
     context "with three monthly regular transactions" do
       before do
         create(:regular_transaction, gross_income_summary:, operation: "credit", category: "maintenance_in", frequency: "three_monthly", amount: 100.0)

--- a/swagger/v5/swagger.yaml
+++ b/swagger/v5/swagger.yaml
@@ -1052,6 +1052,7 @@ paths:
                         - maintenance_in
                         - property_or_lodger
                         - pension
+                        - housing_benefit
                         - child_care
                         - rent_or_mortgage
                         - maintenance_out


### PR DESCRIPTION
## What
Calcuate net housing costs for non passported regular transactions workflow

[Link to story](https://dsdmoj.atlassian.net/browse/AP-3480)

net housing costs = housing payments - housing benefits. This must be added to disposable_income_summary
to obtain an accurate CFE result.

**Detail**
When calculating gross and net housing costs relevant
regular transaction records must also be considered.

This can be summarised as:

 - #gross_housing_costs should be the sum of any applicable*
    outgoings (a.k.a bank transactions), cash transactions
    and regular transactions.

 - #monthly_housing_benefit should be the sum of applicable** #state_benefits
    plus regular transactions

 - #net_housing_costs can be uncapped or capped (based on having dependants)
   and is usually gross, less benefits.

_\* applicable Housing costs:_
 - outgoings#name of rent_or_mortgage
 - cash_transactions#category of rent_or_mortgage
 - regular_transactions#category of rent_or_mortgage

_\** applicable Housing benefits:_
 - state_benefit#state_benefit_type of housing_benefit
 - regular_transactions#category of housing_benefit

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
