### PR TITLE
Fix: Allow the test action to be triggered via Github

### DIFF
--- a/.github/workflows/manual-integration-tests.yml
+++ b/.github/workflows/manual-integration-tests.yml
@@ -1,6 +1,7 @@
 name: manual-integration-tests
 
 on:
+  workflow_dispatch:
   repository_dispatch:
     types: manual-trigger
   schedule:


### PR DESCRIPTION
## What

This has been triggered remotely via the slack bot, but that will be turned off for a while.  This alternative should allow users to trigger it via the actions page on github and reduce the need for Devs to run tests for non-dev staff

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
