### PR TITLE
Refactor so that it doesn't appear assign the value to itself

### DIFF
--- a/app/services/collators/disposable_income_collator.rb
+++ b/app/services/collators/disposable_income_collator.rb
@@ -39,22 +39,28 @@ module Collators
       attrs = {}
 
       outgoing_categories.each do |category|
-        monthly_cash_amount = category == :child_care ? __send__("#{category}_cash") : monthly_cash_by_category(category)
+        monthly_cash_amount = monthly_cash_amount_for(category)
+        monthly_bank_amount = monthly_bank_amount_for(category)
+
         @monthly_cash_transactions_total += monthly_cash_amount unless category == :rent_or_mortgage
 
         attrs[:"#{category}_cash"] = monthly_cash_amount
-        attrs[:"#{category}_all_sources"] = bank_amount_for(category) + attrs[:"#{category}_cash"]
+        attrs[:"#{category}_all_sources"] = monthly_bank_amount + monthly_cash_amount
       end
 
       attrs.merge(default_attrs)
     end
 
-    def bank_amount_for(category)
-      __send__("#{category}_bank")
+    def monthly_cash_amount_for(category)
+      if category == :child_care
+        public_send("#{category}_cash")
+      else
+        monthly_cash_transaction_amount_by(operation: :debit, category:)
+      end
     end
 
-    def monthly_cash_by_category(category)
-      monthly_cash_transaction_amount_by(operation: :debit, category:)
+    def monthly_bank_amount_for(category)
+      public_send("#{category}_bank")
     end
 
     def default_attrs

--- a/app/services/collators/disposable_income_collator.rb
+++ b/app/services/collators/disposable_income_collator.rb
@@ -35,8 +35,6 @@ module Collators
       CFEConstants::VALID_OUTGOING_CATEGORIES.map(&:to_sym)
     end
 
-    # TODO: This line seems redundant as it updates the column to its existing value!
-    # `attrs[:"#{category}_bank"] = __send__("#{category}_bank")`
     def populate_attrs
       attrs = {}
 
@@ -44,12 +42,15 @@ module Collators
         monthly_cash_amount = category == :child_care ? __send__("#{category}_cash") : monthly_cash_by_category(category)
         @monthly_cash_transactions_total += monthly_cash_amount unless category == :rent_or_mortgage
 
-        attrs[:"#{category}_bank"] = __send__("#{category}_bank")
         attrs[:"#{category}_cash"] = monthly_cash_amount
-        attrs[:"#{category}_all_sources"] = attrs[:"#{category}_bank"] + attrs[:"#{category}_cash"]
+        attrs[:"#{category}_all_sources"] = bank_amount_for(category) + attrs[:"#{category}_cash"]
       end
 
       attrs.merge(default_attrs)
+    end
+
+    def bank_amount_for(category)
+      __send__("#{category}_bank")
     end
 
     def monthly_cash_by_category(category)


### PR DESCRIPTION
## Refactor to make code more readable



The line `attrs[:"#{category}_bank"] = __send__("#{category}_bank")` was confusing because it appeared as if you were just adding the value of the column to a hash which would then be re-assigned back to the column.

This has been removed, and the subsequent line which relied on it changed to take the value from the column.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
