### PR TITLE
Prevent less than zero for net housing costs

### DIFF
--- a/app/services/calculators/housing_costs_calculator.rb
+++ b/app/services/calculators/housing_costs_calculator.rb
@@ -7,15 +7,17 @@ module Calculators
     delegate :housing_cost_outgoings, to: :disposable_income_summary
 
     def net_housing_costs
-      if housing_costs_cap_apply?
-        [gross_housing_costs, gross_cost_minus_housing_benefit, single_monthly_housing_costs_cap].min.to_f
-      elsif should_halve_full_cost_minus_benefits?
-        (monthly_actual_housing_costs - monthly_housing_benefit) / 2
-      elsif should_exclude_housing_benefit?
-        gross_cost_minus_housing_benefit
-      else
-        gross_housing_costs
-      end
+      net_housing_costs = if housing_costs_cap_apply?
+                            [gross_housing_costs, gross_cost_minus_housing_benefit, single_monthly_housing_costs_cap].min.to_f
+                          elsif should_halve_full_cost_minus_benefits?
+                            (monthly_actual_housing_costs - monthly_housing_benefit) / 2
+                          elsif should_exclude_housing_benefit?
+                            gross_cost_minus_housing_benefit
+                          else
+                            gross_housing_costs
+                          end
+
+      [net_housing_costs, 0.0].max
     end
 
     def gross_housing_costs

--- a/spec/services/calculators/housing_costs_calculator_spec.rb
+++ b/spec/services/calculators/housing_costs_calculator_spec.rb
@@ -389,7 +389,13 @@ module Calculators
             create(:regular_transaction, gross_income_summary: assessment.gross_income_summary, operation: "debit", category: "rent_or_mortgage", frequency: "monthly", amount: 1000.00)
             create(:regular_transaction, gross_income_summary: assessment.gross_income_summary, operation: "credit", category: "housing_benefit", frequency: "monthly", amount: 400.00)
 
-            expect(net_housing_costs).to be 545.00
+            expect(net_housing_costs).to eq 545.00
+          end
+
+          it "has zero floor" do
+            create(:regular_transaction, gross_income_summary: assessment.gross_income_summary, operation: "credit", category: "housing_benefit", frequency: "monthly", amount: 400.00)
+
+            expect(net_housing_costs).to eq 0.00
           end
         end
 
@@ -403,6 +409,12 @@ module Calculators
             create(:regular_transaction, gross_income_summary: assessment.gross_income_summary, operation: "credit", category: "housing_benefit", frequency: "monthly", amount: 500.00)
 
             expect(net_housing_costs).to eq 500.00
+          end
+
+          it "has zero floor" do
+            create(:regular_transaction, gross_income_summary: assessment.gross_income_summary, operation: "credit", category: "housing_benefit", frequency: "monthly", amount: 400.00)
+
+            expect(net_housing_costs).to eq 0.00
           end
         end
 

--- a/spec/services/collators/housing_costs_collator_spec.rb
+++ b/spec/services/collators/housing_costs_collator_spec.rb
@@ -24,8 +24,6 @@ module Collators
           end
         end
 
-        # TODO: missing spec? remove? - this tests existing functionality which shows it is possible
-        # return a negative net_housing_costs. Should it not return zero?
         context "with housing benefit as a state_benefit" do
           before do
             housing_benefit_type = create :state_benefit_type, label: "housing_benefit"
@@ -41,7 +39,7 @@ module Collators
               .to have_attributes(
                 gross_housing_costs: 0.0,
                 housing_benefit: 101.02,
-                net_housing_costs: -101.02,
+                net_housing_costs: 0,
               )
           end
         end


### PR DESCRIPTION
## What
Prevent less than zero net housing costs.

[came out of story](https://dsdmoj.atlassian.net/browse/AP-3480)

This closes of an edge case that does not follow
any use case but is technically possible.

BA agreed that in such a situation where housing benefits
are recorded but no housing costs the net housing cost should
, nonetheless, not be below zero.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
