### PR TITLE
Do not force refresh on integration test worksheets on rspec run

### DIFF
--- a/spec/integration/test_runner_spec.rb
+++ b/spec/integration/test_runner_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe "IntegrationTests::TestRunner", type: :request do
         expect(failing_tests).to be_empty, "Failing tests: #{failing_tests.join(', ')}"
       end
     else
-      TestCase::GroupRunner.new(0, "true").each do |worksheet|
+      TestCase::GroupRunner.new(0, "false").each do |worksheet|
         next if worksheet.skippable?
 
         it "#{worksheet.description} passes" do


### PR DESCRIPTION

## What
Do not force refresh on rspec suite runt

Stale worksheets will be refreshed anyway.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
