### PR TITLE
[AP-3451] Remove minItem schema validation for regular transactions

### DIFF
--- a/public/schemas/regular_transactions.json.erb
+++ b/public/schemas/regular_transactions.json.erb
@@ -8,7 +8,6 @@
     "regular_transactions": {
       "description": "Describes simple regular transactions received by applicant",
       "type": "array",
-      "minItems": 1,
       "items": {
         "type": "object",
         "properties": {

--- a/spec/requests/regular_transactions_controller_spec.rb
+++ b/spec/requests/regular_transactions_controller_spec.rb
@@ -78,7 +78,19 @@ RSpec.describe RegularTransactionsController, type: :request do
     context "with empty regular_transactions" do
       let(:params) { { regular_transactions: [] } }
 
-      it_behaves_like "unsuccessful response", "The property '#/regular_transactions' did not contain a minimum number of items 1 in schema"
+      it "returns http success" do
+        request
+        expect(response).to have_http_status(:success)
+      end
+
+      it "response contains success true" do
+        request
+        expect(parsed_response[:success]).to be true
+      end
+
+      it "does not create the regular transaction record" do
+        expect { request }.not_to change(RegularTransaction, :count)
+      end
     end
 
     context "with missing required properties" do

--- a/spec/requests/swagger_docs/v5/regular_transactions_spec.rb
+++ b/spec/requests/swagger_docs/v5/regular_transactions_spec.rb
@@ -29,9 +29,8 @@ RSpec.describe "regular_transactions", type: :request, swagger_doc: "v5/swagger.
                   properties: {
                     regular_transactions: {
                       type: :array,
-                      minItems: 1,
                       required: %i[category operation frequency amount],
-                      description: "One or more regular transactions",
+                      description: "Zero or more regular transactions",
                       items: {
                         type: :object,
                         description: "regular transaction detail",

--- a/spec/services/creators/regular_transactions_creator_spec.rb
+++ b/spec/services/creators/regular_transactions_creator_spec.rb
@@ -126,7 +126,13 @@ RSpec.describe Creators::RegularTransactionsCreator do
         expect { creator }.not_to change(RegularTransaction, :count)
       end
 
-      it_behaves_like "unsuccessful creation", "The property '#/regular_transactions' did not contain a minimum number of items 1 in schema file://public/schemas/regular_transactions.json"
+      it "marks it as success" do
+        expect(creator).to be_success
+      end
+
+      it "does not add an error" do
+        expect(creator.errors).to be_empty
+      end
     end
 
     context "with missing required properties" do

--- a/swagger/v5/swagger.yaml
+++ b/swagger/v5/swagger.yaml
@@ -1033,13 +1033,12 @@ paths:
               properties:
                 regular_transactions:
                   type: array
-                  minItems: 1
                   required:
                   - category
                   - operation
                   - frequency
                   - amount
-                  description: One or more regular transactions
+                  description: Zero or more regular transactions
                   items:
                     type: object
                     description: regular transaction detail


### PR DESCRIPTION

## What
Remove minItem 1 validation from schema for regular_transactions

[Link to story](https://dsdmoj.atlassian.net/browse/AP-3451)

Other endpoints and creator services allow for and handle an empty
payload items from Apply. The `RegularTransactionsCreator` already
does too.

This validation raised errors on testing via Apply as empty payload
items are sent, inline with other endpoints.

There is a related ticket [AP-3511](https://dsdmoj.atlassian.net/browse/AP-3511) I have
raised to question whether we should actually be doing this.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
