### PR TITLE
AP-3509 Gracefully prevent calling GET on the same assessment twice

### DIFF
--- a/spec/integration/v5_full_assessment_spec.rb
+++ b/spec/integration/v5_full_assessment_spec.rb
@@ -66,6 +66,35 @@ RSpec.describe "Full V5 passported spec", :vcr do
     end
   end
 
+  context "When GET is called twice on the same assessment" do
+    let(:qualifying_benefit) { false }
+    let(:assessment_id) { post_assessment }
+
+    before do
+      post_proceeding_types(assessment_id)
+      post_applicant(assessment_id)
+      post_capitals(assessment_id)
+      post_dependants(assessment_id)
+      post_outgoings(assessment_id)
+      post_state_benefits(assessment_id)
+      post_other_incomes(assessment_id)
+      post_irregular_income(assessment_id)
+
+      get assessment_path(assessment_id), headers: v5_headers
+    end
+
+    it "returns error payload" do
+      get assessment_path(assessment_id), headers: v5_headers
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(parsed_response).to eq(
+        {
+          errors: ["Unable to call GET on the same assessment twice - please create new assessment and resubmit data"],
+          success: false,
+        },
+      )
+    end
+  end
+
   context "when debugging " do
     it "does not return error" do
       rq = "{\"client_reference_id\":\"L-KUT-FW2\",\"submission_date\":\"2022-07-15\"}"

--- a/spec/requests/swagger_docs/v5/assessments_spec.rb
+++ b/spec/requests/swagger_docs/v5/assessments_spec.rb
@@ -67,6 +67,11 @@ RSpec.describe "V5 Assessments", type: :request, vcr: true, swagger_doc: "v5/swa
       tags "Assessment"
       produces "application/json"
 
+      description <<~DESCIPTION.chomp
+        This endpoint will cause an assessment to be calculated using all the data that has been uploaded to the
+        other endpoints and return the result.  You call this endpoint twice for the same assessment_id.
+      DESCIPTION
+
       response(200, "successful") do
         let(:assessment) { create(:assessment, :passported, :with_everything) }
         let(:id) { assessment.id }

--- a/spec/requests/swagger_docs/v5/assessments_spec.rb
+++ b/spec/requests/swagger_docs/v5/assessments_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe "V5 Assessments", type: :request, vcr: true, swagger_doc: "v5/swa
 
       description <<~DESCIPTION.chomp
         This endpoint will cause an assessment to be calculated using all the data that has been uploaded to the
-        other endpoints and return the result.  You call this endpoint twice for the same assessment_id.
+        other endpoints and return the result.  You cannot call this endpoint twice for the same assessment_id.
       DESCIPTION
 
       response(200, "successful") do

--- a/swagger/v5/swagger.yaml
+++ b/swagger/v5/swagger.yaml
@@ -106,7 +106,7 @@ paths:
       - Assessment
       description: |-
         This endpoint will cause an assessment to be calculated using all the data that has been uploaded to the
-        other endpoints and return the result.  You call this endpoint twice for the same assessment_id.
+        other endpoints and return the result.  You cannot call this endpoint twice for the same assessment_id.
       responses:
         '200':
           description: successful

--- a/swagger/v5/swagger.yaml
+++ b/swagger/v5/swagger.yaml
@@ -104,6 +104,9 @@ paths:
       summary: show assessment
       tags:
       - Assessment
+      description: |-
+        This endpoint will cause an assessment to be calculated using all the data that has been uploaded to the
+        other endpoints and return the result.  You call this endpoint twice for the same assessment_id.
       responses:
         '200':
           description: successful


### PR DESCRIPTION
## Gracefully prevent calling GET on the same assessment twice

Users reported getting exceptions when calling GET more than once for the same assessment.

This was because during the assessment process, eligibilty records are created and were failing because they already existed.  In order to enable calling GET on the assessment to be truly idempotent, we wold have had to delete any eligibilty records, remarks records and zeroise all the totals on the summary records.

For that reason it was felt better to gracefully refuse to carry out a seconds assesment as this would not be a normal use-case anyay, and return and explanatory message.

The swagger documentation has been updated to reflect this.

The error being raised with this was:
```
PG::UniqueViolation: ERROR: duplicate key value violates unique constraint "eligibilities_unique_type_ptc" 
...
```

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
