### PR TITLE
Bump alpine 3.14 to 3.16

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:3.1.2-alpine3.14
+FROM ruby:3.1.2-alpine3.16
 MAINTAINER apply for legal aid team
 
 ENV RAILS_ENV production


### PR DESCRIPTION
## What

Bump alpine 3.14 to 3.16

Patch zlib cirtical vulnerability amongst others - this was
reported on hmrc-interface. [example]https://github.com/ministryofjustice/laa-hmrc-interface-service-api/security/code-scanning/12()

Updates r3 from r0
```
zlib-dev-1.2.12-r3 x86_64 {zlib} (Zlib) [installed]
zlib-1.2.12-r3 x86_64 {zlib} (Zlib) [installed]
```

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
