### PR TITLE
[AP-3516] extend integration tests

### DIFF
--- a/spec/integration/v5_full_assessment_spec.rb
+++ b/spec/integration/v5_full_assessment_spec.rb
@@ -57,11 +57,18 @@ RSpec.describe "Full V5 passported spec", :vcr do
       expect(remarks).to include(expected_remarks)
     end
 
-    it "returns the expected disposable income summary in payload" do
+    it "returns the expected gross income in payload" do
+      output_response(:get, :assessment)
+      gross_income = parsed_response[:result_summary][:gross_income]
+
+      expect(gross_income).to include(expected_gross_income)
+    end
+
+    it "returns the expected disposable income in payload" do
       output_response(:get, :assessment)
       disposable_income = parsed_response[:result_summary][:disposable_income]
 
-      expect(disposable_income).to include(expected_disposable_income_summary)
+      expect(disposable_income).to include(expected_disposable_income)
     end
   end
 
@@ -69,21 +76,30 @@ RSpec.describe "Full V5 passported spec", :vcr do
     let(:qualifying_benefit) { false }
     let(:assessment_id) { post_assessment }
 
-    it "returns the expected disposable income summary in payload" do
-      assessment_id = post_assessment
+    before do
       post_proceeding_types(assessment_id)
       post_applicant(assessment_id)
       post_capitals(assessment_id)
       post_dependants(assessment_id)
       post_regular_transactions(assessment_id)
       post_irregular_income(assessment_id)
-      get assessment_path(assessment_id), headers: v5_headers
 
+      get assessment_path(assessment_id), headers: v5_headers
+    end
+
+    it "returns the expected gross income in payload" do
+      output_response(:get, :assessment)
+      gross_income = parsed_response[:result_summary][:gross_income]
+
+      expect(gross_income).to include(expected_gross_income)
+    end
+
+    it "returns the expected disposable income in payload" do
       output_response(:get, :assessment)
 
       disposable_income = parsed_response[:result_summary][:disposable_income]
 
-      expect(disposable_income).to include(expected_disposable_income_summary)
+      expect(disposable_income).to include(expected_disposable_income)
     end
   end
 
@@ -476,7 +492,19 @@ RSpec.describe "Full V5 passported spec", :vcr do
                                                    TX-outgoing-rent-legal-aid-3] } }
   end
 
-  def expected_disposable_income_summary
+  def expected_gross_income
+    {
+      total_gross_income: 252.31333333333333,
+      proceeding_types: [
+        { ccms_code: "DA004", client_involvement_type: "A", upper_threshold: 999_999_999_999.0, lower_threshold: 0.0, result: "eligible" },
+        { ccms_code: "DA020", client_involvement_type: "A", upper_threshold: 999_999_999_999.0, lower_threshold: 0.0, result: "eligible" },
+        { ccms_code: "SE004", client_involvement_type: "A", upper_threshold: 2657.0, lower_threshold: 0.0, result: "eligible" },
+        { ccms_code: "SE013", client_involvement_type: "A", upper_threshold: 2657.0, lower_threshold: 0.0, result: "eligible" },
+      ],
+    }
+  end
+
+  def expected_disposable_income
     {
       dependant_allowance: 296.65,
       gross_housing_costs: 61.14,

--- a/spec/integration/v5_full_assessment_spec.rb
+++ b/spec/integration/v5_full_assessment_spec.rb
@@ -54,17 +54,7 @@ RSpec.describe "Full V5 passported spec", :vcr do
       output_response(:get, :assessment)
       remarks = parsed_response[:assessment][:remarks]
 
-      deep_match(remarks[:state_benefit_payment], expected_remarks[:state_benefit_payment])
-      expect(remarks[:other_income_payment][:amount_variation]).to match_array expected_remarks[:other_income_payment][:amount_variation]
-      expect(remarks[:other_income_payment][:unknown_frequency]).to match_array expected_remarks[:other_income_payment][:unknown_frequency]
-      expect(remarks[:outgoings_maintenance].keys).to match_array(%i[amount_variation unknown_frequency])
-      expect(remarks[:outgoings_maintenance][:amount_variation]).to match_array(expected_remarks[:outgoings_maintenance][:amount_variation])
-      expect(remarks[:outgoings_maintenance][:unknown_frequency]).to match_array(expected_remarks[:outgoings_maintenance][:unknown_frequency])
-      expect(remarks[:outgoings_housing_cost]).to match_array expected_remarks[:outgoings_housing_cost]
-      expect(remarks[:outgoings_childcare]).to match_array expected_remarks[:outgoings_childcare]
-      expect(remarks[:outgoings_legal_aid]).to match_array expected_remarks[:outgoings_legal_aid]
-      expect(remarks[:other_income_payment][:amount_variation]).to match_array(expected_remarks[:other_income_payment][:amount_variation])
-      expect(remarks[:other_income_payment][:unknown_frequency]).to match_array(expected_remarks[:other_income_payment][:unknown_frequency])
+      expect(remarks).to include(expected_remarks)
     end
 
     it "returns the expected disposable income summary in payload" do


### PR DESCRIPTION
## What
Add CFE intgration tests for disposable income summary

[Link to story](https://dsdmoj.atlassian.net/browse/AP-3516)

Extend plain rspec integration tests rather than rely purely
on worksheet tests:

We should be using these CFE integration tests to cover overall
results more extensively, as a separate set of testing to the
Worksheet based integration tests. The latter are more intended
for use by the BA to setup scenarios.

This adds two tests, one to test existing disposable income
result for a prexexisting tests requests. This is to provide
a regression and comparison for the second test, which uses
the regular transaction mechanism to add income, outgoings
and husing benefits.

The second test uses the exact equivalent values of the
the first test's request but supplied via the regular
transaction's flow.


## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
