### PR TITLE
Add lang attribute to html tag

### DIFF
--- a/app/views/layouts/apipie_override.html.erb
+++ b/app/views/layouts/apipie_override.html.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
   <title><%= t('apipie.api_documentation', :default => 'Api Documentation') %></title>
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>


### PR DESCRIPTION


## What
Add lang attribte to html tag

See [sonarcloud bug](https://sonarcloud.io/component_measures?metric=reliability_rating&selected=ministryofjustice_check-financial-eligibility%3Aapp%2Fviews%2Flayouts%2Fapipie_override.html.erb&view=list&id=ministryofjustice_check-financial-eligibility)

The <html> element should provide the lang and/or xml:lang attribute in order to identify the default language of a document.

It enables assistive technologies, such as screen readers, to provide a comfortable reading experience by adapting the pronunciation and accent to the language. It also helps braille translation software, telling it to switch the control codes for accented characters for instance.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
