### PR TITLE
Validate date_of_birth using `:comparison`

### DIFF
--- a/app/models/applicant.rb
+++ b/app/models/applicant.rb
@@ -6,11 +6,7 @@ class Applicant < ApplicationRecord
 
   enum involvement_type: enum_hash_for(:applicant)
 
-  validate :date_of_birth_in_past
-
-  def date_of_birth_in_past
-    errors.add(:date_of_birth, "cannot be in future") if date_of_birth > Date.current
-  end
+  validates :date_of_birth, comparison: { less_than_or_equal_to: Date.current }
 
   def age_at_submission
     return unless submission_date

--- a/app/models/dependant.rb
+++ b/app/models/dependant.rb
@@ -4,9 +4,5 @@ class Dependant < ApplicationRecord
 
   enum relationship: enum_hash_for(:child_relative, :adult_relative)
 
-  validate :date_of_birth_in_past
-
-  def date_of_birth_in_past
-    errors.add(:date_of_birth, "cannot be in future") if date_of_birth > Date.current
-  end
+  validates :date_of_birth, comparison: { less_than_or_equal_to: Date.current }
 end

--- a/config/locales/activerecord.yml
+++ b/config/locales/activerecord.yml
@@ -1,0 +1,12 @@
+en:
+  activerecord:
+    errors:
+      models:
+        applicant:
+          attributes:
+            date_of_birth:
+              less_than_or_equal_to: cannot be in future
+        dependant:
+          attributes:
+            date_of_birth:
+              less_than_or_equal_to: cannot be in future

--- a/spec/models/applicant_spec.rb
+++ b/spec/models/applicant_spec.rb
@@ -1,6 +1,32 @@
 require "rails_helper"
 
-describe Applicant do
+RSpec.describe Applicant, type: :model do
+  describe "#validate" do
+    let(:applicant) { build_stubbed(:applicant) }
+
+    context "when date_of_birth is in the future" do
+      let(:applicant) { build_stubbed(:applicant, date_of_birth: Date.tomorrow) }
+
+      before { freeze_time }
+
+      it "is invalid" do
+        expect(applicant).to be_invalid
+        expect(applicant.errors).to be_added(
+          :date_of_birth,
+          :less_than_or_equal_to,
+          count: Date.current,
+          value: Date.tomorrow,
+        )
+      end
+    end
+
+    context "when all attributes are valid" do
+      it "is valid" do
+        expect(applicant).to be_valid
+      end
+    end
+  end
+
   describe "#age_at_submission" do
     let(:age) { 31 }
     let(:date_of_birth) { (age.years + 6.months).ago }

--- a/spec/models/dependant_spec.rb
+++ b/spec/models/dependant_spec.rb
@@ -1,0 +1,31 @@
+require "rails_helper"
+
+RSpec.describe Dependant, type: :model do
+  let(:dependant) { build_stubbed(:dependant) }
+
+  describe "#validate" do
+    context "when date_of_birth is in the future" do
+      let(:dependant) { build_stubbed(:dependant, date_of_birth: Date.tomorrow) }
+
+      before { freeze_time }
+
+      it "is invalid" do
+        expect(dependant).to be_invalid
+        expect(dependant.errors).to be_added(
+          :date_of_birth,
+          :less_than_or_equal_to,
+          count: Date.current,
+          value: Date.tomorrow,
+        )
+      end
+    end
+
+    context "when all attributes are valid" do
+      it "is valid" do
+        dependant = build_stubbed(:dependant)
+
+        expect(dependant).to be_valid
+      end
+    end
+  end
+end


### PR DESCRIPTION
This replaces the custom validation with the default `validates` method using the `comparison` key.

Dependants and Applicants  with a date of birth in the future are invalid.

Tests have also been added.