### PR TITLE
Remove redundant Applicant method

### DIFF
--- a/app/models/applicant.rb
+++ b/app/models/applicant.rb
@@ -7,10 +7,4 @@ class Applicant < ApplicationRecord
   enum involvement_type: enum_hash_for(:applicant)
 
   validates :date_of_birth, comparison: { less_than_or_equal_to: Date.current }
-
-  def age_at_submission
-    return unless submission_date
-
-    ((submission_date.to_time - date_of_birth.to_time) / 1.year).to_i
-  end
 end

--- a/spec/models/applicant_spec.rb
+++ b/spec/models/applicant_spec.rb
@@ -26,24 +26,4 @@ RSpec.describe Applicant, type: :model do
       end
     end
   end
-
-  describe "#age_at_submission" do
-    let(:age) { 31 }
-    let(:date_of_birth) { (age.years + 6.months).ago }
-    let(:submission_date) { 1.day.ago }
-    let(:assessment) { create :assessment, submission_date: }
-    let(:applicant) { create :applicant, date_of_birth:, assessment: }
-
-    it "returns the age" do
-      expect(applicant.age_at_submission).to eq(age)
-    end
-
-    context "with old assessment" do
-      let(:submission_date) { 8.months.ago }
-
-      it "returns age at submission" do
-        expect(applicant.age_at_submission).to eq(age - 1)
-      end
-    end
-  end
 end


### PR DESCRIPTION
The `#age_at_submission` method was not used anywhere, so it has been removed.