### PR TITLE
EL-400: Allow 'unspecified_source_income'/'quarterly' irregular payment type

### DIFF
--- a/app/constants/cfe_constants.rb
+++ b/app/constants/cfe_constants.rb
@@ -59,9 +59,9 @@ module CFEConstants
   ANNUAL_FREQUENCY = "annual".freeze
   QUARTERLY_FREQUENCY = "quarterly".freeze
   STUDENT_LOAN = "student_loan".freeze
-  UNSPECIFIED_SOURCE_INCOME = "unspecified_source_income".freeze
+  UNSPECIFIED_SOURCE = "unspecified_source".freeze
   VALID_IRREGULAR_INCOME_FREQUENCIES = [ANNUAL_FREQUENCY, QUARTERLY_FREQUENCY].freeze
-  VALID_IRREGULAR_INCOME_TYPES = [STUDENT_LOAN, UNSPECIFIED_SOURCE_INCOME].freeze
+  VALID_IRREGULAR_INCOME_TYPES = [STUDENT_LOAN, UNSPECIFIED_SOURCE].freeze
 
   # Date and bank holidays
   #

--- a/app/constants/cfe_constants.rb
+++ b/app/constants/cfe_constants.rb
@@ -57,9 +57,11 @@ module CFEConstants
   # Irregular income categories and frequencies
   #
   ANNUAL_FREQUENCY = "annual".freeze
+  QUARTERLY_FREQUENCY = "quarterly".freeze
   STUDENT_LOAN = "student_loan".freeze
-  VALID_IRREGULAR_INCOME_FREQUENCIES = [ANNUAL_FREQUENCY].freeze
-  VALID_IRREGULAR_INCOME_TYPES = [STUDENT_LOAN].freeze
+  UNSPECIFIED_SOURCE_INCOME = "unspecified_source_income".freeze
+  VALID_IRREGULAR_INCOME_FREQUENCIES = [ANNUAL_FREQUENCY, QUARTERLY_FREQUENCY].freeze
+  VALID_IRREGULAR_INCOME_TYPES = [STUDENT_LOAN, UNSPECIFIED_SOURCE_INCOME].freeze
 
   # Date and bank holidays
   #

--- a/app/models/gross_income_summary.rb
+++ b/app/models/gross_income_summary.rb
@@ -11,6 +11,9 @@ class GrossIncomeSummary < ApplicationRecord
            foreign_key: :parent_id,
            dependent: :destroy
 
+  has_many :student_loan_payments, -> { student_loan }, class_name: "IrregularIncomePayment"
+  has_many :unspecified_source_payments, -> { unspecified_source }, class_name: "IrregularIncomePayment"
+
   def housing_benefit_payments
     state_benefits.find_by(state_benefit_type_id: StateBenefitType.housing_benefit&.id)&.state_benefit_payments || []
   end

--- a/app/models/irregular_income_payment.rb
+++ b/app/models/irregular_income_payment.rb
@@ -4,4 +4,7 @@ class IrregularIncomePayment < ApplicationRecord
   validates :income_type, inclusion: { in: CFEConstants::VALID_IRREGULAR_INCOME_TYPES }
   validates :frequency, inclusion: { in: CFEConstants::VALID_IRREGULAR_INCOME_FREQUENCIES }
   validates :amount, numericality: { greater_than_or_equal_to: 0 }
+
+  scope :student_loan, -> { where(income_type: CFEConstants::STUDENT_LOAN) }
+  scope :unspecified, -> { where(income_type: CFEConstants::UNSPECIFIED_SOURCE_INCOME) }
 end

--- a/app/models/irregular_income_payment.rb
+++ b/app/models/irregular_income_payment.rb
@@ -6,5 +6,14 @@ class IrregularIncomePayment < ApplicationRecord
   validates :amount, numericality: { greater_than_or_equal_to: 0 }
 
   scope :student_loan, -> { where(income_type: CFEConstants::STUDENT_LOAN) }
-  scope :unspecified, -> { where(income_type: CFEConstants::UNSPECIFIED_SOURCE_INCOME) }
+  scope :unspecified_source, -> { where(income_type: CFEConstants::UNSPECIFIED_SOURCE) }
+
+  MONTHS_PER_PERIOD = {
+    CFEConstants::ANNUAL_FREQUENCY => 12,
+    CFEConstants::QUARTERLY_FREQUENCY => 3,
+  }.freeze
+
+  def monthly_equivalent_amount
+    amount / MONTHS_PER_PERIOD.fetch(frequency)
+  end
 end

--- a/app/services/base_workflow_service.rb
+++ b/app/services/base_workflow_service.rb
@@ -13,7 +13,8 @@ class BaseWorkflowService
   delegate :upper_threshold,
            :state_benefits,
            :other_income_sources,
-           :irregular_income_payments, to: :gross_income_summary
+           :irregular_income_payments,
+           :student_loan_payments, to: :gross_income_summary
 
   attr_reader :assessment
 

--- a/app/services/collators/childcare_collator.rb
+++ b/app/services/collators/childcare_collator.rb
@@ -30,7 +30,7 @@ module Collators
     end
 
     def applicant_has_student_loan?
-      return true if irregular_income_payments&.present?
+      return true if irregular_income_payments&.student_loan&.present?
 
       false
     end

--- a/app/services/collators/childcare_collator.rb
+++ b/app/services/collators/childcare_collator.rb
@@ -30,9 +30,7 @@ module Collators
     end
 
     def applicant_has_student_loan?
-      return true if irregular_income_payments&.student_loan&.present?
-
-      false
+      student_loan_payments.any?
     end
   end
 end

--- a/app/services/decorators/v5/gross_income_decorator.rb
+++ b/app/services/decorators/v5/gross_income_decorator.rb
@@ -62,6 +62,7 @@ module Decorators
           monthly_equivalents:
             {
               student_loan: summary.monthly_student_loan.to_f,
+              unspecified_source_income: summary.monthly_unspecified_source_income.to_f,
             },
         }
       end

--- a/app/services/decorators/v5/gross_income_decorator.rb
+++ b/app/services/decorators/v5/gross_income_decorator.rb
@@ -62,7 +62,7 @@ module Decorators
           monthly_equivalents:
             {
               student_loan: summary.monthly_student_loan.to_f,
-              unspecified_source_income: summary.monthly_unspecified_source_income.to_f,
+              unspecified_source: summary.monthly_unspecified_source.to_f,
             },
         }
       end

--- a/app/services/decorators/v5/gross_income_summary_decorator.rb
+++ b/app/services/decorators/v5/gross_income_summary_decorator.rb
@@ -33,7 +33,7 @@ module Decorators
           irregular_income: {
             monthly_equivalents: {
               student_loan: record.monthly_student_loan,
-              unspecified_source_income: record.unspecified_source_income,
+              unspecified_source: record.monthly_unspecified_source,
             },
           },
           state_benefits: {

--- a/app/services/decorators/v5/gross_income_summary_decorator.rb
+++ b/app/services/decorators/v5/gross_income_summary_decorator.rb
@@ -33,6 +33,7 @@ module Decorators
           irregular_income: {
             monthly_equivalents: {
               student_loan: record.monthly_student_loan,
+              unspecified_source_income: record.unspecified_source_income,
             },
           },
           state_benefits: {

--- a/db/migrate/20221014131213_add_unspecified_source_income_to_gross_income_summaries.rb
+++ b/db/migrate/20221014131213_add_unspecified_source_income_to_gross_income_summaries.rb
@@ -1,0 +1,8 @@
+class AddUnspecifiedSourceIncomeToGrossIncomeSummaries < ActiveRecord::Migration[7.0]
+  def change
+    change_table :gross_income_summaries, bulk: true do |t|
+      t.decimal "unspecified_source_income", default: "0.0"
+      t.decimal "monthly_unspecified_source_income"
+    end
+  end
+end

--- a/db/migrate/20221014131213_add_unspecified_source_income_to_gross_income_summaries.rb
+++ b/db/migrate/20221014131213_add_unspecified_source_income_to_gross_income_summaries.rb
@@ -1,8 +1,8 @@
 class AddUnspecifiedSourceIncomeToGrossIncomeSummaries < ActiveRecord::Migration[7.0]
   def change
     change_table :gross_income_summaries, bulk: true do |t|
-      t.decimal "unspecified_source_income", default: "0.0"
-      t.decimal "monthly_unspecified_source_income"
+      t.decimal "unspecified_source", default: "0.0"
+      t.decimal "monthly_unspecified_source"
     end
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_09_15_153334) do
+ActiveRecord::Schema[7.0].define(version: 2022_10_14_131213) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -226,6 +226,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_09_15_153334) do
     t.decimal "pension_cash", default: "0.0"
     t.decimal "gross_employment_income", default: "0.0", null: false
     t.decimal "benefits_in_kind", default: "0.0", null: false
+    t.decimal "unspecified_source_income", default: "0.0"
+    t.decimal "monthly_unspecified_source_income"
     t.index ["assessment_id"], name: "index_gross_income_summaries_on_assessment_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -226,8 +226,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_10_14_131213) do
     t.decimal "pension_cash", default: "0.0"
     t.decimal "gross_employment_income", default: "0.0", null: false
     t.decimal "benefits_in_kind", default: "0.0", null: false
-    t.decimal "unspecified_source_income", default: "0.0"
-    t.decimal "monthly_unspecified_source_income"
+    t.decimal "unspecified_source", default: "0.0"
+    t.decimal "monthly_unspecified_source"
     t.index ["assessment_id"], name: "index_gross_income_summaries_on_assessment_id"
   end
 

--- a/public/schemas/irregular_incomes.json.erb
+++ b/public/schemas/irregular_incomes.json.erb
@@ -5,21 +5,23 @@
   "type": "object",
   "properties": {
     "payments": {
-      "description": "Describes irregular payments received by applicant (currently annual student loan is the only irregular income allowed)",
+      "description": "Describes irregular payments received by applicant",
       "type": "array",
       "minItems": 0,
-      "maxItems": 1,
+      "maxItems": 2,
       "items": {
         "type": "object",
         "properties": {
           "income_type": {
             "enum": [
-              "student_loan"
+              "student_loan",
+              "unspecified_source_income"
             ]
           },
           "frequency": {
             "enum": [
-              "annual"
+              "annual",
+              "quarterly"
             ]
           },
           "amount": {

--- a/public/schemas/irregular_incomes.json.erb
+++ b/public/schemas/irregular_incomes.json.erb
@@ -15,7 +15,7 @@
           "income_type": {
             "enum": [
               "student_loan",
-              "unspecified_source_income"
+              "unspecified_source"
             ]
           },
           "frequency": {

--- a/spec/integration/policy_disregards_spec.rb
+++ b/spec/integration/policy_disregards_spec.rb
@@ -259,7 +259,7 @@ RSpec.describe "Eligible Full Assessment with policy disregard remarks" do
           [{ "income_type" => "student_loan",
              "frequency" => "annual",
              "amount" => 100.0 },
-           { "income_type" => "unspecified_source_income",
+           { "income_type" => "unspecified_source",
              "frequency" => "quarterly",
              "amount" => 303.0 }] }.to_json
   end

--- a/spec/integration/policy_disregards_spec.rb
+++ b/spec/integration/policy_disregards_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe "Eligible Full Assessment with policy disregard remarks" do
   end
 
   def post_irregular_income(assessment_id)
-    post assessment_irregular_incomes_path(assessment_id), params: student_loan_params, headers: headers
+    post assessment_irregular_incomes_path(assessment_id), params: irregular_income_params, headers: headers
     output_response(:post, :irregular_income)
   end
 
@@ -254,11 +254,14 @@ RSpec.describe "Eligible Full Assessment with policy disregard remarks" do
                     "client_id" => "TX-state-benefits-3" }] }] }.to_json
   end
 
-  def student_loan_params
+  def irregular_income_params
     { "payments" =>
           [{ "income_type" => "student_loan",
              "frequency" => "annual",
-             "amount" => 100.0 }] }.to_json
+             "amount" => 100.0 },
+           { "income_type" => "unspecified_source_income",
+             "frequency" => "quarterly",
+             "amount" => 303.0 }] }.to_json
   end
 
   def explicit_remarks_params

--- a/spec/integration/v5_full_assessment_spec.rb
+++ b/spec/integration/v5_full_assessment_spec.rb
@@ -437,7 +437,7 @@ RSpec.describe "Full V5 passported spec", :vcr do
         [{ "income_type" => "student_loan",
            "frequency" => "annual",
            "amount" => 100.0 },
-         { "income_type" => "unspecified_source_income",
+         { "income_type" => "unspecified_source",
            "frequency" => "quarterly",
            "amount" => 303 }] }.to_json
   end

--- a/spec/integration/v5_full_assessment_spec.rb
+++ b/spec/integration/v5_full_assessment_spec.rb
@@ -191,7 +191,7 @@ RSpec.describe "Full V5 passported spec", :vcr do
   end
 
   def post_irregular_income(assessment_id)
-    post assessment_irregular_incomes_path(assessment_id), params: student_loan_params, headers: headers
+    post assessment_irregular_incomes_path(assessment_id), params: irregular_income_params, headers: headers
     output_response(:post, :irregular_income)
   end
 
@@ -432,11 +432,14 @@ RSpec.describe "Full V5 passported spec", :vcr do
     }.to_json
   end
 
-  def student_loan_params
+  def irregular_income_params
     { "payments" =>
         [{ "income_type" => "student_loan",
            "frequency" => "annual",
-           "amount" => 100.0 }] }.to_json
+           "amount" => 100.0 },
+         { "income_type" => "unspecified_source_income",
+           "frequency" => "quarterly",
+           "amount" => 303 }] }.to_json
   end
 
   def expected_remarks
@@ -494,7 +497,7 @@ RSpec.describe "Full V5 passported spec", :vcr do
 
   def expected_gross_income
     {
-      total_gross_income: 252.31333333333333,
+      total_gross_income: 353.31333333333333,
       proceeding_types: [
         { ccms_code: "DA004", client_involvement_type: "A", upper_threshold: 999_999_999_999.0, lower_threshold: 0.0, result: "eligible" },
         { ccms_code: "DA020", client_involvement_type: "A", upper_threshold: 999_999_999_999.0, lower_threshold: 0.0, result: "eligible" },
@@ -512,7 +515,7 @@ RSpec.describe "Full V5 passported spec", :vcr do
       net_housing_costs: 23.55,
       maintenance_allowance: 4.33,
       total_outgoings_and_allowances: 375.25,
-      total_disposable_income: -122.93666666666667,
+      total_disposable_income: -21.936666666666667,
       employment_income: { gross_income: 0.0, benefits_in_kind: 0.0, tax: 0.0, national_insurance: 0.0, fixed_employment_deduction: 0.0, net_employment_income: 0.0 },
       income_contribution: 0.0,
       proceeding_types: [{ ccms_code: "DA004", client_involvement_type: "A", upper_threshold: 999_999_999_999.0, lower_threshold: 315.0, result: "eligible" },

--- a/spec/requests/irregular_incomes_controller_spec.rb
+++ b/spec/requests/irregular_incomes_controller_spec.rb
@@ -31,6 +31,28 @@ RSpec.describe IrregularIncomesController, type: :request do
         expect(parsed_response[:success]).to eq true
         expect(parsed_response[:errors]).to be_empty
       end
+
+      context "unspecified source income" do
+        let(:params) do
+          {
+            payments: [
+              {
+                income_type: "unspecified_source_income",
+                frequency: "quarterly",
+                amount: 123_456.78,
+              },
+            ],
+          }
+        end
+
+        it "creates the required number of IrregularIncomePayment records" do
+          expect { post_payload }.to change(IrregularIncomePayment, :count).by(1)
+          payments = gross_income_summary.irregular_income_payments
+          expect(payments[0].income_type).to eq CFEConstants::UNSPECIFIED_SOURCE_INCOME
+          expect(payments[0].frequency).to eq CFEConstants::QUARTERLY_FREQUENCY
+          expect(payments[0].amount).to eq 123_456.78
+        end
+      end
     end
 
     context "invalid_payload" do
@@ -75,7 +97,7 @@ RSpec.describe IrregularIncomesController, type: :request do
 
         it "contains an error message" do
           post_payload
-          expect(parsed_response).to eq({ success: false, errors: ["The property '#/payments/0/income_type' value \"imagined_type\" did not match one of the following values: student_loan in schema file://public/schemas/irregular_incomes.json"] })
+          expect(parsed_response).to eq({ success: false, errors: ["The property '#/payments/0/income_type' value \"imagined_type\" did not match one of the following values: student_loan, unspecified_source_income in schema file://public/schemas/irregular_incomes.json"] })
         end
 
         it "does not create irregular income payments record" do

--- a/spec/requests/irregular_incomes_controller_spec.rb
+++ b/spec/requests/irregular_incomes_controller_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe IrregularIncomesController, type: :request do
           {
             payments: [
               {
-                income_type: "unspecified_source_income",
+                income_type: "unspecified_source",
                 frequency: "quarterly",
                 amount: 123_456.78,
               },
@@ -48,7 +48,7 @@ RSpec.describe IrregularIncomesController, type: :request do
         it "creates the required number of IrregularIncomePayment records" do
           expect { post_payload }.to change(IrregularIncomePayment, :count).by(1)
           payments = gross_income_summary.irregular_income_payments
-          expect(payments[0].income_type).to eq CFEConstants::UNSPECIFIED_SOURCE_INCOME
+          expect(payments[0].income_type).to eq CFEConstants::UNSPECIFIED_SOURCE
           expect(payments[0].frequency).to eq CFEConstants::QUARTERLY_FREQUENCY
           expect(payments[0].amount).to eq 123_456.78
         end
@@ -97,7 +97,7 @@ RSpec.describe IrregularIncomesController, type: :request do
 
         it "contains an error message" do
           post_payload
-          expect(parsed_response).to eq({ success: false, errors: ["The property '#/payments/0/income_type' value \"imagined_type\" did not match one of the following values: student_loan, unspecified_source_income in schema file://public/schemas/irregular_incomes.json"] })
+          expect(parsed_response).to eq({ success: false, errors: ["The property '#/payments/0/income_type' value \"imagined_type\" did not match one of the following values: student_loan, unspecified_source in schema file://public/schemas/irregular_incomes.json"] })
         end
 
         it "does not create irregular income payments record" do

--- a/spec/services/assessors/gross_income_assessor_spec.rb
+++ b/spec/services/assessors/gross_income_assessor_spec.rb
@@ -11,7 +11,7 @@ module Assessors
       context "gross income has been summarised" do
         context "monthly income below upper threshold" do
           it "is eligible" do
-            set_gross_income_values gross_income_summary, 1_023, 0.0, 45.3, 2_567
+            set_gross_income_values gross_income_summary, 1_023, 0.0, 0.0, 45.3, 2_567
             assessor
             expect(gross_income_summary.summarized_assessment_result).to eq :eligible
           end
@@ -19,7 +19,7 @@ module Assessors
 
         context "monthly income equals upper threshold" do
           it "is not eligible" do
-            set_gross_income_values gross_income_summary, 2_000, 0.0, 567.00, 2_567.00
+            set_gross_income_values gross_income_summary, 2_000, 0.0, 0.0, 567.00, 2_567.00
             assessor
             expect(gross_income_summary.summarized_assessment_result).to eq :ineligible
           end
@@ -27,17 +27,17 @@ module Assessors
 
         context "monthly income above upper threshold" do
           it "is not eligible" do
-            set_gross_income_values gross_income_summary, 2_100.0, 0.0, 500.2, 2_567
+            set_gross_income_values gross_income_summary, 2_100.0, 0.0, 0.0, 500.2, 2_567
             assessor
             expect(gross_income_summary.summarized_assessment_result).to eq :ineligible
           end
         end
 
-        def set_gross_income_values(record, other_income, monthly_student_loan, state_benefits, threshold)
+        def set_gross_income_values(record, other_income, monthly_student_loan, monthly_unspecified_source_income, state_benefits, threshold)
           record.update!(monthly_other_income: other_income,
                          monthly_student_loan:,
                          monthly_state_benefits: state_benefits,
-                         total_gross_income: other_income + state_benefits + monthly_student_loan,
+                         total_gross_income: other_income + state_benefits + monthly_student_loan + monthly_unspecified_source_income,
                          upper_threshold: threshold,
                          assessment_result: "summarised")
           create :gross_income_eligibility, gross_income_summary: record, upper_threshold: threshold

--- a/spec/services/assessors/gross_income_assessor_spec.rb
+++ b/spec/services/assessors/gross_income_assessor_spec.rb
@@ -33,11 +33,11 @@ module Assessors
           end
         end
 
-        def set_gross_income_values(record, other_income, monthly_student_loan, monthly_unspecified_source_income, state_benefits, threshold)
+        def set_gross_income_values(record, other_income, monthly_student_loan, monthly_unspecified_source, state_benefits, threshold)
           record.update!(monthly_other_income: other_income,
                          monthly_student_loan:,
                          monthly_state_benefits: state_benefits,
-                         total_gross_income: other_income + state_benefits + monthly_student_loan + monthly_unspecified_source_income,
+                         total_gross_income: other_income + state_benefits + monthly_student_loan + monthly_unspecified_source,
                          upper_threshold: threshold,
                          assessment_result: "summarised")
           create :gross_income_eligibility, gross_income_summary: record, upper_threshold: threshold

--- a/spec/services/collators/gross_income_collator_spec.rb
+++ b/spec/services/collators/gross_income_collator_spec.rb
@@ -82,20 +82,20 @@ module Collators
           end
         end
 
-        context "monthly_unspecified_source_income" do
+        context "monthly_unspecified_source" do
           context "there are no irregular income payments" do
             it "set monthly income from unspecified sources to zero" do
               collator
-              expect(gross_income_summary.reload.monthly_unspecified_source_income).to eq 0.0
+              expect(gross_income_summary.reload.monthly_unspecified_source).to eq 0.0
             end
           end
 
-          context "monthly_unspecified_source_income exists" do
+          context "monthly_unspecified_source exists" do
             before do
               create :irregular_income_payment,
                      gross_income_summary:,
                      amount: 12_000,
-                     income_type: "unspecified_source_income",
+                     income_type: "unspecified_source",
                      frequency: "quarterly"
             end
 
@@ -106,7 +106,7 @@ module Collators
               expect(gross_income_summary.maintenance_in_all_sources).to be_zero
               expect(gross_income_summary.pension_all_sources).to be_zero
               expect(gross_income_summary.monthly_other_income).to eq 0.0
-              expect(gross_income_summary.monthly_unspecified_source_income).to eq 12_000 / 3
+              expect(gross_income_summary.monthly_unspecified_source).to eq 12_000 / 3
               expect(gross_income_summary.total_gross_income).to eq 12_000 / 3
             end
           end
@@ -141,7 +141,7 @@ module Collators
               gross_income_summary.property_or_lodger_all_sources +
               gross_income_summary.pension_all_sources +
               gross_income_summary.monthly_student_loan +
-              gross_income_summary.monthly_unspecified_source_income
+              gross_income_summary.monthly_unspecified_source
 
             expect(gross_income_summary.total_gross_income).to eq all_sources_total
           end

--- a/spec/services/collators/regular_income_collator_spec.rb
+++ b/spec/services/collators/regular_income_collator_spec.rb
@@ -206,6 +206,7 @@ RSpec.describe Collators::RegularIncomeCollator do
       before do
         assessment.gross_income_summary.update!(
           student_loan: 111.11,
+          unspecified_source_income: 444.44,
           benefits_cash: 222.22,
           benefits_all_sources: 222.22,
           total_gross_income: 333.33,
@@ -215,6 +216,7 @@ RSpec.describe Collators::RegularIncomeCollator do
       it "has expected values prior to regular income collation" do
         expect(gross_income_summary).to have_attributes(
           student_loan: 111.11,
+          unspecified_source_income: 444.44,
           benefits_bank: 0.0,
           benefits_cash: 222.22,
           benefits_all_sources: 222.22,

--- a/spec/services/collators/regular_income_collator_spec.rb
+++ b/spec/services/collators/regular_income_collator_spec.rb
@@ -206,7 +206,7 @@ RSpec.describe Collators::RegularIncomeCollator do
       before do
         assessment.gross_income_summary.update!(
           student_loan: 111.11,
-          unspecified_source_income: 444.44,
+          unspecified_source: 444.44,
           benefits_cash: 222.22,
           benefits_all_sources: 222.22,
           total_gross_income: 333.33,
@@ -216,7 +216,7 @@ RSpec.describe Collators::RegularIncomeCollator do
       it "has expected values prior to regular income collation" do
         expect(gross_income_summary).to have_attributes(
           student_loan: 111.11,
-          unspecified_source_income: 444.44,
+          unspecified_source: 444.44,
           benefits_bank: 0.0,
           benefits_cash: 222.22,
           benefits_all_sources: 222.22,

--- a/spec/services/creators/irregular_income_creator_spec.rb
+++ b/spec/services/creators/irregular_income_creator_spec.rb
@@ -62,7 +62,7 @@ module Creators
         end
 
         it "returns an error" do
-          expect(creator.errors).to eq ["The property '#/payments' had more items than the allowed 1 in schema file://public/schemas/irregular_incomes.json"]
+          expect(creator.errors).to eq ["The property '#/payments' had more items than the allowed 2 in schema file://public/schemas/irregular_incomes.json"]
         end
       end
     end
@@ -100,6 +100,11 @@ module Creators
           },
           {
             income_type: "student_loan",
+            frequency:,
+            amount: 123_456.78,
+          },
+          {
+            income_type: "unspecified_source_income",
             frequency:,
             amount: 123_456.78,
           },

--- a/spec/services/creators/irregular_income_creator_spec.rb
+++ b/spec/services/creators/irregular_income_creator_spec.rb
@@ -104,7 +104,7 @@ module Creators
             amount: 123_456.78,
           },
           {
-            income_type: "unspecified_source_income",
+            income_type: "unspecified_source",
             frequency:,
             amount: 123_456.78,
           },

--- a/spec/services/decorators/v5/gross_income_decorator_spec.rb
+++ b/spec/services/decorators/v5/gross_income_decorator_spec.rb
@@ -9,7 +9,7 @@ module Decorators
         create :gross_income_summary,
                assessment:,
                monthly_student_loan: 250,
-               monthly_unspecified_source_income: 423.35,
+               monthly_unspecified_source: 423.35,
                benefits_all_sources: 1_322.6,
                benefits_bank: 1_322.6,
                maintenance_in_all_sources: 350,
@@ -92,7 +92,7 @@ module Decorators
             monthly_equivalents:
               {
                 student_loan: 250.0,
-                unspecified_source_income: 423.35,
+                unspecified_source: 423.35,
               },
           },
           state_benefits: {

--- a/spec/services/decorators/v5/gross_income_decorator_spec.rb
+++ b/spec/services/decorators/v5/gross_income_decorator_spec.rb
@@ -9,6 +9,7 @@ module Decorators
         create :gross_income_summary,
                assessment:,
                monthly_student_loan: 250,
+               monthly_unspecified_source_income: 423.35,
                benefits_all_sources: 1_322.6,
                benefits_bank: 1_322.6,
                maintenance_in_all_sources: 350,
@@ -91,6 +92,7 @@ module Decorators
             monthly_equivalents:
               {
                 student_loan: 250.0,
+                unspecified_source_income: 423.35,
               },
           },
           state_benefits: {

--- a/spec/services/decorators/v5/gross_income_summary_decorator_spec.rb
+++ b/spec/services/decorators/v5/gross_income_summary_decorator_spec.rb
@@ -51,7 +51,7 @@ module Decorators
             end
 
             it "returns expected keys for irregular payments" do
-              expected_keys = %i[student_loan unspecified_source_income]
+              expected_keys = %i[student_loan unspecified_source]
               expect(decorator[:irregular_income][:monthly_equivalents].keys).to match expected_keys
             end
 

--- a/spec/services/decorators/v5/gross_income_summary_decorator_spec.rb
+++ b/spec/services/decorators/v5/gross_income_summary_decorator_spec.rb
@@ -50,8 +50,8 @@ module Decorators
               expect(decorator[:state_benefits][:monthly_equivalents].keys).to match expected_keys
             end
 
-            it "returns expected keys for student_loan" do
-              expected_keys = %i[student_loan]
+            it "returns expected keys for irregular payments" do
+              expected_keys = %i[student_loan unspecified_source_income]
               expect(decorator[:irregular_income][:monthly_equivalents].keys).to match expected_keys
             end
 

--- a/swagger/v5/swagger.yaml
+++ b/swagger/v5/swagger.yaml
@@ -616,12 +616,14 @@ paths:
                         type: string
                         enum:
                         - student_loan
+                        - unspecified_source_income
                         description: Identifying name for this irregular income payment
                         example: student_loan
                       frequency:
                         type: string
                         enum:
                         - annual
+                        - quarterly
                         description: Frequency of the payment received
                         example: annual
                       amount:

--- a/swagger/v5/swagger.yaml
+++ b/swagger/v5/swagger.yaml
@@ -616,7 +616,7 @@ paths:
                         type: string
                         enum:
                         - student_loan
-                        - unspecified_source_income
+                        - unspecified_source
                         description: Identifying name for this irregular income payment
                         example: student_loan
                       frequency:


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/EL-400)

We want to capture income that is from an unspecified source, expressed by the user as a single total figure received over the past 3 months. By 'unspecified source' we mean income that doesn't fall under any of the named types of regular or irregular payments that CFE accepts, with no requirement on the user to describe the source in any way.

So this PR adds 'unspecified_source_income' as a valid irregular type, and 'quarterly' as a valid income frequency, to the irregular payments model/endpoint.

Also, because prior to this there was only one irregular payment type - student loans - there was a bit of logic that assumed all irregular payments were student loans, an assumption that started to break with the new type. So I unpicked that logic.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
