### PR TITLE
Update applicant schema

### DIFF
--- a/public/schemas/applicant_v5.json.erb
+++ b/public/schemas/applicant_v5.json.erb
@@ -10,6 +10,7 @@
       "required": [
         "date_of_birth",
         "has_partner_opponent",
+        "involvement_type",
         "receives_qualifying_benefit"
       ],
       "properties": {

--- a/public/schemas/applicant_v5.json.erb
+++ b/public/schemas/applicant_v5.json.erb
@@ -7,7 +7,11 @@
   "properties": {
     "applicant": {
       "type": "object",
-      "required": ["date_of_birth", "has_partner_opponent", "receives_qualifying_benefit"],
+      "required": [
+        "date_of_birth",
+        "has_partner_opponent",
+        "receives_qualifying_benefit"
+      ],
       "properties": {
         "date_of_birth": {
           "$ref": "<%= "file://#{@schema_dir}/common.json#date" %>"
@@ -18,7 +22,14 @@
         "has_partner_opponent": {
           "type": "boolean"
         },
+        "involvement_type": {
+          "type": ["string", "null"],
+          "enum": ["applicant", null]
+        },
         "receives_qualifying_benefit": {
+          "type": "boolean"
+        },
+        "self_employed": {
           "type": "boolean"
         }
       }

--- a/spec/integration/policy_disregards_spec.rb
+++ b/spec/integration/policy_disregards_spec.rb
@@ -111,6 +111,7 @@ RSpec.describe "Eligible Full Assessment with policy disregard remarks" do
     { "applicant" =>
           { "date_of_birth" => "1981-04-11",
             "has_partner_opponent" => false,
+            "involvement_type" => "applicant",
             "receives_qualifying_benefit" => false } }.to_json
   end
 

--- a/spec/integration/remarks_spec.rb
+++ b/spec/integration/remarks_spec.rb
@@ -112,6 +112,7 @@ RSpec.describe "contribution_required Full Assessment with remarks" do
       applicant: {
         date_of_birth: 20.years.ago.to_date,
         has_partner_opponent: false,
+        involvement_type: "applicant",
         receives_qualifying_benefit: true,
       },
     }.to_json

--- a/spec/requests/applicants_controller_spec.rb
+++ b/spec/requests/applicants_controller_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe ApplicantsController, type: :request do
         applicant: {
           date_of_birth: 20.years.ago.to_date,
           has_partner_opponent: false,
+          involvement_type: "applicant",
           receives_qualifying_benefit: true,
           employed: false,
         },
@@ -40,8 +41,8 @@ RSpec.describe ApplicantsController, type: :request do
             assessment_id: assessment.id,
             applicant: {
               date_of_birth: future_date,
-              involvement_type: "applicant",
               has_partner_opponent: false,
+              involvement_type: "applicant",
               receives_qualifying_benefit: true,
             },
           }
@@ -78,6 +79,7 @@ RSpec.describe ApplicantsController, type: :request do
           applicant: {
             date_of_birth: 20.years.ago.to_date,
             has_partner_opponent: false,
+            involvement_type: "applicant",
             receives_qualifying_benefit: true,
             employed: nil,
           },

--- a/spec/requests/swagger_docs/v5/applicants_spec.rb
+++ b/spec/requests/swagger_docs/v5/applicants_spec.rb
@@ -78,6 +78,7 @@ RSpec.describe "applicants", type: :request, swagger_doc: "v5/swagger.yaml" do
             applicant: {
               date_of_birth: "1992-07-22",
               has_partner_opponent: false,
+              involvement_type: "applicant",
               receives_qualifying_benefit: true,
             },
           }

--- a/spec/requests/swagger_docs/v5/applicants_spec.rb
+++ b/spec/requests/swagger_docs/v5/applicants_spec.rb
@@ -15,31 +15,60 @@ RSpec.describe "applicants", type: :request, swagger_doc: "v5/swagger.yaml" do
 
       assessment_id_parameter
 
-      parameter name: :params,
-                in: :body,
-                required: true,
-                schema: {
-                  type: :object,
-                  required: %i[date_of_birth involvement_type has_partner_opponent receives_qualifying_benefit],
-                  properties: {
-                    applicant: {
-                      type: :object,
-                      description: "Object describing pertinent applicant details",
-                      properties: {
-                        date_of_birth: { type: :string,
-                                         format: :date,
-                                         example: "1992-07-22",
-                                         description: "Applicant date of birth" },
-                        has_partner_opponent: { type: :boolean,
-                                                example: false,
-                                                description: "Applicant has partner opponent" },
-                        receives_qualifying_benefit: { type: :boolean,
-                                                       example: false,
-                                                       description: "Applicant receives qualifying benefit" },
-                      },
-                    },
-                  },
-                }
+      parameter(
+        name: :params,
+        in: :body,
+        required: true,
+        schema: {
+          type: :object,
+          required: %i[
+            date_of_birth
+            has_partner_opponent
+            involvement_type
+            receives_qualifying_benefit
+          ],
+          properties: {
+            applicant: {
+              type: :object,
+              description: "Object describing pertinent applicant details",
+              properties: {
+                date_of_birth: {
+                  type: :string,
+                  format: :date,
+                  example: "1992-07-22",
+                  description: "Applicant date of birth",
+                },
+                employed: {
+                  type: :boolean,
+                  example: true,
+                  description: "Applicant is employed",
+                },
+                has_partner_opponent: {
+                  type: :boolean,
+                  example: false,
+                  description: "Applicant has partner opponent",
+                },
+                involvement_type: {
+                  type: :string,
+                  enum: %w[applicant],
+                  example: "applicant",
+                  description: "Applicant involvement type",
+                },
+                receives_qualifying_benefit: {
+                  type: :boolean,
+                  example: false,
+                  description: "Applicant receives qualifying benefit",
+                },
+                self_employed: {
+                  type: :boolean,
+                  example: false,
+                  description: "Applicant is self employed",
+                },
+              },
+            },
+          },
+        },
+      )
 
       response(200, "successful") do
         let(:assessment_id) { create(:assessment, version: "5").id }

--- a/spec/validators/json_validator_spec.rb
+++ b/spec/validators/json_validator_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe "JsonValidator" do
       applicant: {
         date_of_birth: dob,
         has_partner_opponent: opponent,
+        involvement_type:,
         receives_qualifying_benefit: benefit,
       },
     }.to_json
@@ -31,8 +32,10 @@ RSpec.describe "JsonValidator" do
     it { expect(validator).not_to be_valid }
 
     it "displays errors" do
-      expect(validator.errors)
-        .to include(match(/The property '#\/applicant\/date_of_birth' value "3002-12-23" did not match the rege/))
+      expect(validator.errors).to contain_exactly(
+        a_string_matching(/The property '#\/applicant\/date_of_birth' value "3002-12-23" did not match the regex/),
+        a_string_matching(/The property '#\/applicant\/involvement_type' value "defendant" did not match one of the following values: applicant, null/),
+      )
     end
   end
 
@@ -49,8 +52,10 @@ RSpec.describe "JsonValidator" do
     it { expect(validator).not_to be_valid }
 
     it "has the expected errors" do
-      expect(validator.errors)
-        .to include(match(/The property '#\/applicant' did not contain a required property of 'receives_qualifying_benefit' in schema/))
+      expect(validator.errors).to contain_exactly(
+        a_string_matching(/The property '#\/applicant' did not contain a required property of 'receives_qualifying_benefit' in schema/),
+        a_string_matching(/The property '#\/applicant' did not contain a required property of 'involvement_type' in schema/),
+      )
     end
   end
 end

--- a/swagger/v5/swagger.yaml
+++ b/swagger/v5/swagger.yaml
@@ -43,8 +43,8 @@ paths:
               type: object
               required:
               - date_of_birth
-              - involvement_type
               - has_partner_opponent
+              - involvement_type
               - receives_qualifying_benefit
               properties:
                 applicant:
@@ -56,14 +56,28 @@ paths:
                       format: date
                       example: '1992-07-22'
                       description: Applicant date of birth
+                    employed:
+                      type: boolean
+                      example: true
+                      description: Applicant is employed
                     has_partner_opponent:
                       type: boolean
                       example: false
                       description: Applicant has partner opponent
+                    involvement_type:
+                      type: string
+                      enum:
+                      - applicant
+                      example: applicant
+                      description: Applicant involvement type
                     receives_qualifying_benefit:
                       type: boolean
                       example: false
                       description: Applicant receives qualifying benefit
+                    self_employed:
+                      type: boolean
+                      example: false
+                      description: Applicant is self employed
         required: true
   "/assessments":
     post:


### PR DESCRIPTION
Both `involvement_type` and `self_employed` fields were omitted from the
applicant schema.

The `involvement_type` field has been defined as a required enum field,
that can take a value of `"applicant"` or `null`.

The `self_employed` field has been defined as an optional boolean field.

The swagger documentation for the applicant endpoint has also been updated to
reflect the schema.