### PR TITLE
Employed applicants with dependants receive child care allowance

### DIFF
--- a/app/models/dependant.rb
+++ b/app/models/dependant.rb
@@ -5,4 +5,8 @@ class Dependant < ApplicationRecord
   enum relationship: enum_hash_for(:child_relative, :adult_relative)
 
   validates :date_of_birth, comparison: { less_than_or_equal_to: Date.current }
+
+  def becomes_adult_on
+    date_of_birth.years_since(16)
+  end
 end

--- a/app/services/collators/childcare_collator.rb
+++ b/app/services/collators/childcare_collator.rb
@@ -9,7 +9,7 @@ module Collators
   private
 
     def eligible_for_childcare_costs?
-      applicant_has_dependant_child? && (applicant_employed? || applicant_has_student_loan?)
+      applicant_has_dependant_child? && (applicant_is_employed? || applicant_has_student_loan?)
     end
 
     def monthly_child_care_cash
@@ -22,10 +22,8 @@ module Collators
       end
     end
 
-    def applicant_employed?
-      # for now, no applicants are employed, but when they are, we will want to test this
-      # by checking for earned income
-      false
+    def applicant_is_employed?
+      !!applicant&.employed?
     end
 
     def applicant_has_student_loan?

--- a/app/services/collators/childcare_collator.rb
+++ b/app/services/collators/childcare_collator.rb
@@ -17,10 +17,9 @@ module Collators
     end
 
     def applicant_has_dependant_child?
-      assessment.dependants.each do |dependant|
-        return true if dependant.date_of_birth > assessment.submission_date - 15.years
+      assessment.dependants.any? do |dependant|
+        assessment.submission_date.before?(dependant.becomes_adult_on)
       end
-      false
     end
 
     def applicant_employed?

--- a/app/services/collators/childcare_collator.rb
+++ b/app/services/collators/childcare_collator.rb
@@ -9,14 +9,14 @@ module Collators
   private
 
     def eligible_for_childcare_costs?
-      applicant_has_dependent_child? && (applicant_employed? || applicant_has_student_loan?)
+      applicant_has_dependant_child? && (applicant_employed? || applicant_has_student_loan?)
     end
 
     def monthly_child_care_cash
       monthly_cash_transaction_amount_by(operation: :debit, category: :child_care)
     end
 
-    def applicant_has_dependent_child?
+    def applicant_has_dependant_child?
       assessment.dependants.each do |dependant|
         return true if dependant.date_of_birth > assessment.submission_date - 15.years
       end

--- a/app/services/decorators/v5/applicant_decorator.rb
+++ b/app/services/decorators/v5/applicant_decorator.rb
@@ -15,6 +15,7 @@ module Decorators
         {
           date_of_birth: @record.date_of_birth,
           involvement_type: @record.involvement_type,
+          employed: @record.employed,
           has_partner_opponent: @record.has_partner_opponent,
           receives_qualifying_benefit: @record.receives_qualifying_benefit,
           self_employed: @record.self_employed,

--- a/db/migrate/20221026151032_add_employed_to_applicants.rb
+++ b/db/migrate/20221026151032_add_employed_to_applicants.rb
@@ -1,0 +1,5 @@
+class AddEmployedToApplicants < ActiveRecord::Migration[7.0]
+  def change
+    add_column :applicants, :employed, :boolean, null: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_10_14_131213) do
+ActiveRecord::Schema[7.0].define(version: 2022_10_26_151032) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -24,6 +24,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_10_14_131213) do
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
     t.boolean "self_employed", default: false
+    t.boolean "employed"
     t.index ["assessment_id"], name: "index_applicants_on_assessment_id"
   end
 

--- a/public/schemas/applicant_v5.json.erb
+++ b/public/schemas/applicant_v5.json.erb
@@ -12,11 +12,14 @@
         "date_of_birth": {
           "$ref": "<%= "file://#{@schema_dir}/common.json#date" %>"
         },
+        "employed": {
+          "type": "boolean"
+        },
         "has_partner_opponent": {
           "type": "boolean"
         },
         "receives_qualifying_benefit": {
-           "type": "boolean"
+          "type": "boolean"
         }
       }
     }

--- a/spec/models/dependant_spec.rb
+++ b/spec/models/dependant_spec.rb
@@ -28,4 +28,12 @@ RSpec.describe Dependant, type: :model do
       end
     end
   end
+
+  describe "#becomes_adult_on" do
+    let(:dependant) { build_stubbed(:dependant, date_of_birth: Date.new(2000, 1, 1)) }
+
+    it "returns the dependant's 16th birthday" do
+      expect(dependant.becomes_adult_on).to eq Date.new(2016, 1, 1)
+    end
+  end
 end

--- a/spec/services/collators/childcare_collator_spec.rb
+++ b/spec/services/collators/childcare_collator_spec.rb
@@ -24,7 +24,9 @@ module Collators
         end
 
         context "Employed" do
-          before { allow_any_instance_of(described_class).to receive(:applicant_employed?).and_return(true) }
+          before do
+            create(:applicant, assessment:, employed: true)
+          end
 
           context "in receipt of Student grant in irregular income payments" do
             before { create :irregular_income_payment, gross_income_summary: }
@@ -73,7 +75,9 @@ module Collators
         end
 
         context "Employed" do
-          before { allow_any_instance_of(described_class).to receive(:applicant_employed?).and_return(true) }
+          before do
+            create(:applicant, assessment:, employed: true)
+          end
 
           context "in receipt of Student grant in irregular income payments" do
             before { create :irregular_income_payment, gross_income_summary: }

--- a/spec/services/decorators/v5/applicant_decorator_spec.rb
+++ b/spec/services/decorators/v5/applicant_decorator_spec.rb
@@ -17,10 +17,11 @@ module Decorators
         context "applicant exists" do
           let(:applicant) { create :applicant }
 
-          it "has all expected keys present int he returned hash" do
+          it "has all expected keys present in the returned hash" do
             expected_keys = %i[
               date_of_birth
               involvement_type
+              employed
               has_partner_opponent
               receives_qualifying_benefit
               self_employed


### PR DESCRIPTION
Before, employed applicants with child dependants were never able to receive the
child care cost allowance they were eligible for.

This was because the `#applicant_employed?` method in the childcare collator
always returned false.

Now that the method has been implemented, employed applicants that are eligible
will receive the correct child care cost allowance.

The applicant schema now defines an optional boolean employed attribute that
consumers can use to specify an applicant's employed status.