### PR TITLE
Define Faraday gem as an explicit dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,6 +20,8 @@ gem "puma", "~> 5.6"
 # Use ActiveStorage variant
 # gem 'mini_magick', '~> 4.8'
 
+gem "faraday", "~> 1.0"
+
 gem "sentry-rails", ">= 5.3.1"
 gem "sentry-ruby"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -440,6 +440,7 @@ DEPENDENCIES
   dotenv-rails (>= 2.7.6)
   factory_bot_rails (>= 6.2.0)
   faker
+  faraday (~> 1.0)
   google_drive (>= 3.0.7)
   guard
   guard-rspec


### PR DESCRIPTION
Throughout the application, we are using the [Faraday gem] to make requests to the Legal Framework API.

Until now, we have been relying on Faraday being pulled in by another of our dependencies.

Ideally we would be using [Net::HTTP] since it comes as part of Ruby, but at the very least we should be explicit about the dependencies our application needs.

[Faraday gem]: https://github.com/lostisland/faraday
[Net::HTTP]: https://rubyapi.org/3.1/o/net/http