### PR TITLE
EL-428: Acknowledge and account for SMOD assets

### DIFF
--- a/app/models/capital_item.rb
+++ b/app/models/capital_item.rb
@@ -1,3 +1,4 @@
 class CapitalItem < ApplicationRecord
   belongs_to :capital_summary
+  scope :disputed, -> { where(subject_matter_of_dispute: true) }
 end

--- a/app/models/capital_summary.rb
+++ b/app/models/capital_summary.rb
@@ -13,6 +13,9 @@ class CapitalSummary < ApplicationRecord
            foreign_key: :parent_id,
            inverse_of: :capital_summary,
            dependent: :destroy
+  has_many :disputed_capital_items, -> { disputed }, class_name: "CapitalItem"
+  has_many :disputed_vehicles, -> { disputed }, class_name: "Vehicle"
+  has_many :disputed_properties, -> { disputed }, class_name: "Property"
 
   def summarized_assessment_result
     Utilities::ResultSummarizer.call(eligibilities.map(&:assessment_result))

--- a/app/models/property.rb
+++ b/app/models/property.rb
@@ -3,6 +3,7 @@ class Property < ApplicationRecord
 
   scope :main_home, -> { where(main_home: true) }
   scope :additional, -> { where(main_home: false) }
+  scope :disputed, -> { where(subject_matter_of_dispute: true) }
 
   delegate :assessment, to: :capital_summary
   delegate :submission_date, to: :assessment

--- a/app/models/vehicle.rb
+++ b/app/models/vehicle.rb
@@ -6,6 +6,8 @@ class Vehicle < ApplicationRecord
 
   validates :date_of_purchase, cfe_date: { not_in_the_future: true }
 
+  scope :disputed, -> { where(subject_matter_of_dispute: true) }
+
   def assess!
     in_regular_use? ? assess_vehicle_in_regular_use : assess_vehicle_not_in_regular_use
     save!

--- a/app/services/calculators/subject_matter_of_dispute_disregard_calculator.rb
+++ b/app/services/calculators/subject_matter_of_dispute_disregard_calculator.rb
@@ -1,5 +1,7 @@
 module Calculators
   class SubjectMatterOfDisputeDisregardCalculator < BaseWorkflowService
+    delegate :disputed_capital_items, :disputed_vehicles, :disputed_properties, to: :capital_summary
+
     def value
       total_disputed_asset_value = disputed_capital_value +
         disputed_property_value +
@@ -19,15 +21,15 @@ module Calculators
     end
 
     def disputed_capital_value
-      capital_summary.capital_items.select(&:subject_matter_of_dispute).sum(&:value)
+      disputed_capital_items.sum(:value)
     end
 
     def disputed_property_value
-      capital_summary.properties.select(&:subject_matter_of_dispute).sum(&:assessed_equity)
+      disputed_properties.sum(:assessed_equity)
     end
 
     def disputed_vehicle_value
-      vehicles.select(&:subject_matter_of_dispute).sum(&:assessed_value)
+      disputed_vehicles.sum(:assessed_value)
     end
   end
 end

--- a/app/services/calculators/subject_matter_of_dispute_disregard_calculator.rb
+++ b/app/services/calculators/subject_matter_of_dispute_disregard_calculator.rb
@@ -1,0 +1,29 @@
+module Calculators
+  class SubjectMatterOfDisputeDisregardCalculator < BaseWorkflowService
+    def value
+      total_disputed_asset_value = disputed_capital_value +
+        disputed_property_value +
+        disputed_vehicle_value
+
+      [total_disputed_asset_value, threshold].min
+    end
+
+  private
+
+    def threshold
+      @threshold ||= Threshold.value_for(:subject_matter_of_dispute_disregard, at: submission_date) || 0
+    end
+
+    def disputed_capital_value
+      capital_summary.capital_items.select(&:subject_matter_of_dispute).sum(&:value)
+    end
+
+    def disputed_property_value
+      capital_summary.properties.select(&:subject_matter_of_dispute).sum(&:assessed_equity)
+    end
+
+    def disputed_vehicle_value
+      vehicles.select(&:subject_matter_of_dispute).sum(&:assessed_value)
+    end
+  end
+end

--- a/app/services/calculators/subject_matter_of_dispute_disregard_calculator.rb
+++ b/app/services/calculators/subject_matter_of_dispute_disregard_calculator.rb
@@ -5,13 +5,17 @@ module Calculators
         disputed_property_value +
         disputed_vehicle_value
 
-      [total_disputed_asset_value, threshold].min
+      if total_disputed_asset_value.positive? && threshold.nil?
+        raise "SMOD assets listed but no threshold data found for #{submission_date}"
+      end
+
+      [total_disputed_asset_value, threshold].compact.min
     end
 
   private
 
     def threshold
-      @threshold ||= Threshold.value_for(:subject_matter_of_dispute_disregard, at: submission_date) || 0
+      @threshold ||= Threshold.value_for(:subject_matter_of_dispute_disregard, at: submission_date)
     end
 
     def disputed_capital_value

--- a/app/services/collators/capital_collator.rb
+++ b/app/services/collators/capital_collator.rb
@@ -7,6 +7,7 @@ module Collators
       total_mortgage_allowance: "property_maximum_mortgage_allowance_threshold",
       total_property: "property",
       pensioner_capital_disregard: "pensioner_capital_disregard",
+      subject_matter_of_dispute_disregard: "subject_matter_of_dispute_disregard",
       total_capital: "total_capital",
       assessed_capital: "assessed_capital",
       capital_contribution: "capital_contribution",
@@ -19,7 +20,7 @@ module Collators
   private
 
     def assessed_capital
-      total_capital - pensioner_capital_disregard
+      total_capital - pensioner_capital_disregard - subject_matter_of_dispute_disregard
     end
 
     def total_capital
@@ -48,6 +49,10 @@ module Collators
 
     def pensioner_capital_disregard
       @pensioner_capital_disregard ||= Calculators::PensionerCapitalDisregardCalculator.new(assessment).value
+    end
+
+    def subject_matter_of_dispute_disregard
+      @subject_matter_of_dispute_disregard ||= Calculators::SubjectMatterOfDisputeDisregardCalculator.new(assessment).value
     end
 
     def lower_threshold

--- a/app/services/creators/capitals_creator.rb
+++ b/app/services/creators/capitals_creator.rb
@@ -33,7 +33,7 @@ module Creators
       return if bank_accounts_attributes.nil?
 
       bank_accounts_attributes.each do |attrs|
-        capital_summary.liquid_capital_items.create!(description: attrs[:description], value: attrs[:value])
+        capital_summary.liquid_capital_items.create!(attrs.slice(:value, :description, :subject_matter_of_dispute))
       end
     end
 
@@ -41,7 +41,7 @@ module Creators
       return if non_liquid_capital_attributes.nil?
 
       non_liquid_capital_attributes.each do |attrs|
-        capital_summary.non_liquid_capital_items.create!(description: attrs[:description], value: attrs[:value])
+        capital_summary.non_liquid_capital_items.create!(attrs.slice(:value, :description, :subject_matter_of_dispute))
       end
     end
 

--- a/app/services/decorators/v5/capital_result_decorator.rb
+++ b/app/services/decorators/v5/capital_result_decorator.rb
@@ -14,6 +14,7 @@ module Decorators
           total_mortgage_allowance: summary.total_mortgage_allowance.to_f,
           total_capital: summary.total_capital.to_f,
           pensioner_capital_disregard: summary.pensioner_capital_disregard.to_f,
+          subject_matter_of_dispute_disregard: summary.subject_matter_of_dispute_disregard.to_f,
           capital_contribution: summary.capital_contribution.to_f,
           assessed_capital: summary.assessed_capital.to_f,
           proceeding_types: ProceedingTypesResultDecorator.new(summary).as_json,

--- a/app/services/decorators/v5/capital_summary_decorator.rb
+++ b/app/services/decorators/v5/capital_summary_decorator.rb
@@ -29,6 +29,7 @@ module Decorators
           total_mortgage_allowance: @record.total_mortgage_allowance,
           total_capital: @record.total_capital,
           pensioner_capital_disregard: @record.pensioner_capital_disregard,
+          subject_matter_of_dispute_disregard: @record.subject_matter_of_dispute_disregard,
           assessed_capital: @record.assessed_capital,
           lower_threshold: @record.eligibilities.first.lower_threshold,
           upper_threshold: @record.eligibilities.first.upper_threshold,

--- a/config/thresholds/2021-04-12.yml
+++ b/config/thresholds/2021-04-12.yml
@@ -65,3 +65,4 @@ disposable_income_contribution_bands:
 
 fixed_employment_allowance: 45.0
 employment_income_variance: 60.0
+subject_matter_of_dispute_disregard: 100000.0

--- a/config/thresholds/2022-04-11.yml
+++ b/config/thresholds/2022-04-11.yml
@@ -65,3 +65,4 @@ disposable_income_contribution_bands:
 
 fixed_employment_allowance: 45.0
 employment_income_variance: 60.0
+subject_matter_of_dispute_disregard: 100000.0

--- a/db/migrate/20221027150350_add_smod_to_capital_items.rb
+++ b/db/migrate/20221027150350_add_smod_to_capital_items.rb
@@ -1,8 +1,8 @@
 class AddSmodToCapitalItems < ActiveRecord::Migration[7.0]
   def change
-    add_column :capital_items, :subject_matter_of_dispute, :boolean, default: false
-    add_column :vehicles, :subject_matter_of_dispute, :boolean, default: false
-    add_column :properties, :subject_matter_of_dispute, :boolean, default: false
+    add_column :capital_items, :subject_matter_of_dispute, :boolean, nullable: true
+    add_column :vehicles, :subject_matter_of_dispute, :boolean, nullable: true
+    add_column :properties, :subject_matter_of_dispute, :boolean, nullable: true
     add_column :capital_summaries, :subject_matter_of_dispute_disregard, :decimal, default: "0.0", null: false
   end
 end

--- a/db/migrate/20221027150350_add_smod_to_capital_items.rb
+++ b/db/migrate/20221027150350_add_smod_to_capital_items.rb
@@ -1,0 +1,8 @@
+class AddSmodToCapitalItems < ActiveRecord::Migration[7.0]
+  def change
+    add_column :capital_items, :subject_matter_of_dispute, :boolean, default: false
+    add_column :vehicles, :subject_matter_of_dispute, :boolean, default: false
+    add_column :properties, :subject_matter_of_dispute, :boolean, default: false
+    add_column :capital_summaries, :subject_matter_of_dispute_disregard, :decimal, default: "0.0", null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -61,7 +61,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_10_27_150350) do
     t.decimal "value", default: "0.0", null: false
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
-    t.boolean "subject_matter_of_dispute", default: false
+    t.boolean "subject_matter_of_dispute"
     t.index ["capital_summary_id"], name: "index_capital_items_on_capital_summary_id"
   end
 
@@ -306,7 +306,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_10_27_150350) do
     t.decimal "net_equity", default: "0.0", null: false
     t.decimal "assessed_equity", default: "0.0", null: false
     t.decimal "main_home_equity_disregard", default: "0.0", null: false
-    t.boolean "subject_matter_of_dispute", default: false
+    t.boolean "subject_matter_of_dispute"
     t.index ["capital_summary_id"], name: "index_properties_on_capital_summary_id"
   end
 
@@ -377,7 +377,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_10_27_150350) do
     t.uuid "capital_summary_id"
     t.boolean "included_in_assessment", default: false, null: false
     t.decimal "assessed_value", default: "0.0", null: false
-    t.boolean "subject_matter_of_dispute", default: false
+    t.boolean "subject_matter_of_dispute"
     t.index ["capital_summary_id"], name: "index_vehicles_on_capital_summary_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_10_26_151032) do
+ActiveRecord::Schema[7.0].define(version: 2022_10_27_150350) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -61,6 +61,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_10_26_151032) do
     t.decimal "value", default: "0.0", null: false
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
+    t.boolean "subject_matter_of_dispute", default: false
     t.index ["capital_summary_id"], name: "index_capital_items_on_capital_summary_id"
   end
 
@@ -80,6 +81,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_10_26_151032) do
     t.string "assessment_result", default: "pending", null: false
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
+    t.decimal "subject_matter_of_dispute_disregard", default: "0.0", null: false
     t.index ["assessment_id"], name: "index_capital_summaries_on_assessment_id"
   end
 
@@ -304,6 +306,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_10_26_151032) do
     t.decimal "net_equity", default: "0.0", null: false
     t.decimal "assessed_equity", default: "0.0", null: false
     t.decimal "main_home_equity_disregard", default: "0.0", null: false
+    t.boolean "subject_matter_of_dispute", default: false
     t.index ["capital_summary_id"], name: "index_properties_on_capital_summary_id"
   end
 
@@ -374,6 +377,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_10_26_151032) do
     t.uuid "capital_summary_id"
     t.boolean "included_in_assessment", default: false, null: false
     t.decimal "assessed_value", default: "0.0", null: false
+    t.boolean "subject_matter_of_dispute", default: false
     t.index ["capital_summary_id"], name: "index_vehicles_on_capital_summary_id"
   end
 

--- a/public/schemas/capital.json.erb
+++ b/public/schemas/capital.json.erb
@@ -16,6 +16,10 @@
           },
           "value": {
             "$ref": "<%= "file://#{@schema_dir}/common.json#currency" %>"
+          },
+          "subject_matter_of_dispute": {
+            "description": "Whether the contents of this bank account are the subject of a dispute",
+            "type": "boolean"
           }
         },
         "additionalProperties": false,
@@ -37,6 +41,10 @@
           },
           "value": {
             "$ref": "<%= "file://#{@schema_dir}/common.json#positive_currency" %>"
+          },
+          "subject_matter_of_dispute": {
+            "description": "Whether the item is the subject of a dispute",
+            "type": "boolean"
           }
         },
         "additionalProperties": false,

--- a/public/schemas/properties.json.erb
+++ b/public/schemas/properties.json.erb
@@ -24,6 +24,10 @@
             },
             "shared_with_housing_assoc": {
               "type": "boolean"
+            },
+            "subject_matter_of_dispute": {
+              "description": "Whether this property is the subject of a dispute",
+              "type": "boolean"
             }
           }
         },
@@ -43,6 +47,10 @@
                 "$ref": "<%= "file://#{@schema_dir}/common.json#currency" %>"
               },
               "shared_with_housing_assoc": {
+                "type": "boolean"
+              },
+              "subject_matter_of_dispute": {
+                "description": "Whether this property is the subject of a dispute",
                 "type": "boolean"
               }
             }

--- a/public/schemas/vehicles.json.erb
+++ b/public/schemas/vehicles.json.erb
@@ -21,6 +21,10 @@
           },
           "in_regular_use": {
             "type": "boolean"
+          },
+          "subject_matter_of_dispute": {
+            "description": "Whether this vehicle is the subject of a dispute",
+            "type": "boolean"
           }
         }
       }

--- a/spec/factories/capital_item_factory.rb
+++ b/spec/factories/capital_item_factory.rb
@@ -3,12 +3,14 @@ FactoryBot.define do
     capital_summary
     description { Faker::Lorem.unique.sentence }
     value { Faker::Number.decimal(l_digits: 4, r_digits: 2).to_d(Float::DIG) }
+    subject_matter_of_dispute { Faker::Boolean.boolean }
   end
 
   factory :liquid_capital_item do
     capital_summary
     description { Faker::Lorem.unique.sentence }
     value { Faker::Number.decimal(l_digits: 4, r_digits: 2).to_d(Float::DIG) }
+    subject_matter_of_dispute { Faker::Boolean.boolean }
 
     trait :negative do
       value { Faker::Number.decimal(l_digits: 4, r_digits: 2).to_d(Float::DIG) * -1 }

--- a/spec/factories/capital_item_factory.rb
+++ b/spec/factories/capital_item_factory.rb
@@ -3,14 +3,14 @@ FactoryBot.define do
     capital_summary
     description { Faker::Lorem.unique.sentence }
     value { Faker::Number.decimal(l_digits: 4, r_digits: 2).to_d(Float::DIG) }
-    subject_matter_of_dispute { Faker::Boolean.boolean }
+    subject_matter_of_dispute { false }
   end
 
   factory :liquid_capital_item do
     capital_summary
     description { Faker::Lorem.unique.sentence }
     value { Faker::Number.decimal(l_digits: 4, r_digits: 2).to_d(Float::DIG) }
-    subject_matter_of_dispute { Faker::Boolean.boolean }
+    subject_matter_of_dispute { false }
 
     trait :negative do
       value { Faker::Number.decimal(l_digits: 4, r_digits: 2).to_d(Float::DIG) * -1 }

--- a/spec/factories/property_factory.rb
+++ b/spec/factories/property_factory.rb
@@ -7,7 +7,7 @@ FactoryBot.define do
     percentage_owned { Faker::Number.decimal(l_digits: 1, r_digits: 2).to_f }
     main_home { [true, false].sample }
     shared_with_housing_assoc { [true, false].sample }
-    subject_matter_of_dispute { [true, false].sample }
+    subject_matter_of_dispute { false }
 
     trait :main_home do
       main_home { true }

--- a/spec/factories/property_factory.rb
+++ b/spec/factories/property_factory.rb
@@ -7,6 +7,7 @@ FactoryBot.define do
     percentage_owned { Faker::Number.decimal(l_digits: 1, r_digits: 2).to_f }
     main_home { [true, false].sample }
     shared_with_housing_assoc { [true, false].sample }
+    subject_matter_of_dispute { [true, false].sample }
 
     trait :main_home do
       main_home { true }

--- a/spec/factories/vehicle_factory.rb
+++ b/spec/factories/vehicle_factory.rb
@@ -5,6 +5,6 @@ FactoryBot.define do
     loan_amount_outstanding { Faker::Number.decimal(l_digits: 4, r_digits: 2) }
     date_of_purchase { Faker::Date.between(from: 6.years.ago, to: 2.months.ago) }
     in_regular_use { Faker::Boolean.boolean }
-    subject_matter_of_dispute { Faker::Boolean.boolean }
+    subject_matter_of_dispute { false }
   end
 end

--- a/spec/factories/vehicle_factory.rb
+++ b/spec/factories/vehicle_factory.rb
@@ -5,5 +5,6 @@ FactoryBot.define do
     loan_amount_outstanding { Faker::Number.decimal(l_digits: 4, r_digits: 2) }
     date_of_purchase { Faker::Date.between(from: 6.years.ago, to: 2.months.ago) }
     in_regular_use { Faker::Boolean.boolean }
+    subject_matter_of_dispute { Faker::Boolean.boolean }
   end
 end

--- a/spec/integration/v5_full_assessment_spec.rb
+++ b/spec/integration/v5_full_assessment_spec.rb
@@ -17,19 +17,27 @@ RSpec.describe "Full V5 passported spec", :vcr do
   context "when applicant is passported" do
     let(:qualifying_benefit) { true }
 
-    it "returns the expected payload without remarks" do
+    before do
       assessment_id = post_assessment
       post_proceeding_types(assessment_id)
       post_applicant(assessment_id)
 
       post_capitals(assessment_id)
       post_vehicles(assessment_id)
+      post_properties(assessment_id)
 
       get assessment_path(assessment_id), headers: v5_headers
       output_response(:get, :assessment)
+    end
 
+    it "returns the expected payload without remarks" do
       remarks = parsed_response[:assessment][:remarks]
       expect(remarks).to eq({})
+    end
+
+    it "returns the expected capital summary" do
+      capital_summary = parsed_response.dig(:result_summary, :capital)
+      expect(capital_summary).to include(expected_capital_summary)
     end
   end
 
@@ -165,6 +173,11 @@ RSpec.describe "Full V5 passported spec", :vcr do
     output_response(:post, :vehicles)
   end
 
+  def post_properties(assessment_id)
+    post assessment_properties_path(assessment_id), params: property_params, headers: headers
+    output_response(:post, :properties)
+  end
+
   def post_dependants(assessment_id)
     post assessment_dependants_path(assessment_id), params: dependants_params, headers: headers
     output_response(:post, :dependants)
@@ -205,7 +218,7 @@ RSpec.describe "Full V5 passported spec", :vcr do
   def assessment_params
     {
       "client_reference_id" => "L-YYV-4N6",
-      "submission_date" => "2020-06-11",
+      "submission_date" => "2022-06-11",
     }.to_json
   end
 
@@ -233,7 +246,8 @@ RSpec.describe "Full V5 passported spec", :vcr do
         [{ "description" => "Money not in a bank account", "value" => "50.0" }],
       "non_liquid_capital" =>
         [{ "description" => "Any valuable items worth more than £500",
-           "value" => "700.0" }] }.to_json
+           "value" => "700.0",
+           "subject_matter_of_dispute" => true }] }.to_json
   end
 
   def vehicle_params
@@ -244,8 +258,37 @@ RSpec.describe "Full V5 passported spec", :vcr do
           "loan_amount_outstanding" => "0.0",
           "date_of_purchase" => "2020-08-18",
           "in_regular_use" => true,
+          "subject_matter_of_dispute" => true,
         },
       ],
+    }.to_json
+  end
+
+  def property_params
+    {
+      "properties": {
+        "main_home": {
+          "value": 500_000.01,
+          "outstanding_mortgage": 999.99,
+          "percentage_owned": 15,
+          "shared_with_housing_assoc": true,
+        },
+        "additional_properties": [
+          {
+            "value": 1000.01,
+            "outstanding_mortgage": 1,
+            "percentage_owned": 99.99,
+            "shared_with_housing_assoc": false,
+          },
+          {
+            "value": 10_000.01,
+            "outstanding_mortgage": 40,
+            "percentage_owned": 80,
+            "shared_with_housing_assoc": true,
+            "subject_matter_of_dispute": true,
+          },
+        ],
+      },
     }.to_json
   end
 
@@ -551,13 +594,13 @@ RSpec.describe "Full V5 passported spec", :vcr do
 
   def expected_disposable_income
     {
-      dependant_allowance: 296.65,
+      dependant_allowance: 307.64,
       gross_housing_costs: 61.14,
       housing_benefit: 37.59,
       net_housing_costs: 23.55,
       maintenance_allowance: 4.33,
-      total_outgoings_and_allowances: 375.25,
-      total_disposable_income: -21.936666666666667,
+      total_outgoings_and_allowances: 386.24,
+      total_disposable_income: -32.92666666666667,
       employment_income: { gross_income: 0.0, benefits_in_kind: 0.0, tax: 0.0, national_insurance: 0.0, fixed_employment_deduction: 0.0, net_employment_income: 0.0 },
       income_contribution: 0.0,
       proceeding_types: contain_exactly(
@@ -566,6 +609,21 @@ RSpec.describe "Full V5 passported spec", :vcr do
         { ccms_code: "SE004", client_involvement_type: "A", upper_threshold: 733.0, lower_threshold: 315.0, result: "eligible" },
         { ccms_code: "SE013", client_involvement_type: "A", upper_threshold: 733.0, lower_threshold: 315.0, result: "eligible" },
       ),
+    }
+  end
+
+  def expected_capital_summary
+    {
+      total_liquid: 50.0,
+      total_non_liquid: 700.0,
+      total_vehicle: 0.0,
+      total_property: 8628.92,
+      total_mortgage_allowance: 999_999_999_999.0,
+      total_capital: 9378.92,
+      pensioner_capital_disregard: 0.0,
+      subject_matter_of_dispute_disregard: 8360.01,
+      capital_contribution: 0.0,
+      assessed_capital: 1018.91,
     }
   end
 

--- a/spec/integration/v5_full_assessment_spec.rb
+++ b/spec/integration/v5_full_assessment_spec.rb
@@ -35,9 +35,14 @@ RSpec.describe "Full V5 passported spec", :vcr do
       expect(remarks).to eq({})
     end
 
-    it "returns the expected capital summary" do
+    it "returns a SMOD disregard" do
       capital_summary = parsed_response.dig(:result_summary, :capital)
-      expect(capital_summary).to include(expected_capital_summary)
+      expect(capital_summary[:subject_matter_of_dispute_disregard]).to eq(700)
+      expect(capital_summary[:assessed_capital]).to eq(
+        capital_summary[:total_capital] -
+          capital_summary[:subject_matter_of_dispute_disregard] -
+          capital_summary[:pensioner_capital_disregard],
+      )
     end
   end
 
@@ -285,7 +290,7 @@ RSpec.describe "Full V5 passported spec", :vcr do
             "outstanding_mortgage": 40,
             "percentage_owned": 80,
             "shared_with_housing_assoc": true,
-            "subject_matter_of_dispute": true,
+            "subject_matter_of_dispute": false,
           },
         ],
       },
@@ -609,21 +614,6 @@ RSpec.describe "Full V5 passported spec", :vcr do
         { ccms_code: "SE004", client_involvement_type: "A", upper_threshold: 733.0, lower_threshold: 315.0, result: "eligible" },
         { ccms_code: "SE013", client_involvement_type: "A", upper_threshold: 733.0, lower_threshold: 315.0, result: "eligible" },
       ),
-    }
-  end
-
-  def expected_capital_summary
-    {
-      total_liquid: 50.0,
-      total_non_liquid: 700.0,
-      total_vehicle: 0.0,
-      total_property: 8628.92,
-      total_mortgage_allowance: 999_999_999_999.0,
-      total_capital: 9378.92,
-      pensioner_capital_disregard: 0.0,
-      subject_matter_of_dispute_disregard: 8360.01,
-      capital_contribution: 0.0,
-      assessed_capital: 1018.91,
     }
   end
 

--- a/spec/requests/swagger_docs/v5/capitals_spec.rb
+++ b/spec/requests/swagger_docs/v5/capitals_spec.rb
@@ -32,7 +32,8 @@ RSpec.describe "capitals", type: :request, swagger_doc: "v5/swagger.yaml" do
                     bank_accounts: {
                       type: :array,
                       description: "One or more account details",
-                      example: [{ value: 1.01, description: "test name 1" }, { value: 100.01, description: "test name 2" }],
+                      example: [{ value: 1.01, description: "test name 1" },
+                                { value: 100.01, description: "test name 2", subject_matter_of_dispute: true }],
                       items: {
                         type: :object,
                         description: "Account detail",
@@ -43,6 +44,9 @@ RSpec.describe "capitals", type: :request, swagger_doc: "v5/swagger.yaml" do
                           },
                           description: {
                             type: :string,
+                          },
+                          subject_matter_of_dispute: {
+                            type: :boolean,
                           },
                         },
                       },
@@ -63,12 +67,14 @@ RSpec.describe "capitals", type: :request, swagger_doc: "v5/swagger.yaml" do
               {
                 description: "SANTANDER UK PLC 68346475",
                 value: 59_389.67,
+                subject_matter_of_dispute: true,
               },
             ],
             non_liquid_capital: [
               {
                 description: "FTSE tracker unit trust",
                 value: 61_192.56,
+                subject_matter_of_dispute: false,
               },
               {
                 description: "Aramco shares",

--- a/spec/requests/swagger_docs/v5/capitals_spec.rb
+++ b/spec/requests/swagger_docs/v5/capitals_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe "capitals", type: :request, swagger_doc: "v5/swagger.yaml" do
                     bank_accounts: {
                       type: :array,
                       description: "One or more account details",
-                      example: [{ value: 1.01, description: "test name 1" },
+                      example: [{ value: 1.01, description: "test name 1", subject_matter_of_dispute: false },
                                 { value: 100.01, description: "test name 2", subject_matter_of_dispute: true }],
                       items: {
                         type: :object,

--- a/spec/requests/swagger_docs/v5/properties_spec.rb
+++ b/spec/requests/swagger_docs/v5/properties_spec.rb
@@ -54,6 +54,10 @@ RSpec.describe "properties", type: :request, swagger_doc: "v5/swagger.yaml" do
                               type: :boolean,
                               description: "Property is shared with a housing association",
                             },
+                            subject_matter_of_dispute: {
+                              type: :boolean,
+                              description: "Property is the subject of a dispute",
+                            },
                           },
                         },
                         additional_properties: {
@@ -85,6 +89,10 @@ RSpec.describe "properties", type: :request, swagger_doc: "v5/swagger.yaml" do
                               shared_with_housing_assoc: {
                                 type: :boolean,
                                 description: "Property is shared with a housing association",
+                              },
+                              subject_matter_of_dispute: {
+                                type: :boolean,
+                                description: "Property is the subject of a dispute",
                               },
                             },
                           },
@@ -123,6 +131,7 @@ RSpec.describe "properties", type: :request, swagger_doc: "v5/swagger.yaml" do
                 outstanding_mortgage: 999.99,
                 percentage_owned: 15.0,
                 shared_with_housing_assoc: true,
+                subject_matter_of_dispute: false,
               },
               additional_properties: [],
             },

--- a/spec/requests/swagger_docs/v5/vehicles_spec.rb
+++ b/spec/requests/swagger_docs/v5/vehicles_spec.rb
@@ -47,6 +47,10 @@ RSpec.describe "vehicles", type: :request, swagger_doc: "v5/swagger.yaml" do
                             type: :boolean,
                             description: "Vehicle in regular use or not",
                           },
+                          subject_matter_of_dispute: {
+                            type: :boolean,
+                            description: "Whether this vehicle is the subject of a dispute",
+                          },
                         },
                       },
                     },
@@ -64,6 +68,7 @@ RSpec.describe "vehicles", type: :request, swagger_doc: "v5/swagger.yaml" do
                 loan_amount_outstanding: 1361.65,
                 date_of_purchase: "2021-02-14",
                 in_regular_use: true,
+                subject_matter_of_dispute: true,
               },
             ],
           }

--- a/spec/services/calculators/subject_matter_of_dispute_disregard_calculator_spec.rb
+++ b/spec/services/calculators/subject_matter_of_dispute_disregard_calculator_spec.rb
@@ -77,8 +77,8 @@ module Calculators
         let(:property) { create :property, assessed_equity: 9_000, subject_matter_of_dispute: true }
         let(:threshold_value) { nil }
 
-        it "returns 0" do
-          expect(value).to eq 0
+        it "raises an exception" do
+          expect { value }.to raise_error RuntimeError
         end
       end
     end

--- a/spec/services/calculators/subject_matter_of_dispute_disregard_calculator_spec.rb
+++ b/spec/services/calculators/subject_matter_of_dispute_disregard_calculator_spec.rb
@@ -1,0 +1,86 @@
+require "rails_helper"
+
+module Calculators
+  RSpec.describe SubjectMatterOfDisputeDisregardCalculator do
+    subject(:value) { described_class.new(assessment).value }
+
+    let(:assessment) { create :assessment, capital_summary: }
+    let(:capital_summary) do
+      create :capital_summary,
+             vehicles: [vehicle],
+             capital_items: [capital_item],
+             properties: [property]
+    end
+    let(:vehicle) { create :vehicle, subject_matter_of_dispute: false }
+    let(:capital_item) { create :liquid_capital_item, subject_matter_of_dispute: false }
+    let(:property) { create :property, subject_matter_of_dispute: false }
+    let(:threshold_value) { 10_000 }
+
+    before do
+      allow(Threshold).to receive(:value_for).and_return(threshold_value)
+    end
+
+    describe "#value" do
+      context "without any SMOD assets" do
+        it "returns 0" do
+          expect(value).to eq 0
+        end
+      end
+
+      context "with a SMOD vehicle worth less than the disregard" do
+        let(:vehicle) { create :vehicle, assessed_value: 1_000, subject_matter_of_dispute: true }
+
+        it "returns the value of the vehicle" do
+          expect(value).to eq 1_000
+        end
+      end
+
+      context "with a SMOD property worth less than the disregard" do
+        let(:property) { create :property, assessed_equity: 5_000, subject_matter_of_dispute: true }
+
+        it "returns the value of the property" do
+          expect(value).to eq 5_000
+        end
+      end
+
+      context "with a SMOD capital item worth less than the disregard" do
+        let(:capital_item) { create :liquid_capital_item, value: 3_000, subject_matter_of_dispute: true }
+
+        it "returns the value of the capital item" do
+          expect(value).to eq 3_000
+        end
+      end
+
+      context "with multiple SMOD assets worth less than the disregard" do
+        let(:capital_item) { create :liquid_capital_item, value: 3_000, subject_matter_of_dispute: true }
+        let(:vehicle) { create :vehicle, assessed_value: 1_000, subject_matter_of_dispute: true }
+        let(:property) { create :property, assessed_equity: 5_000, subject_matter_of_dispute: true }
+
+        it "returns the combined value of the assets" do
+          expect(value).to eq 9_000
+        end
+      end
+
+      context "with multiple SMOD assets worth more than the disregard" do
+        let(:capital_item) { create :liquid_capital_item, value: 3_000, subject_matter_of_dispute: true }
+        let(:vehicle) { create :vehicle, assessed_value: 1_000, subject_matter_of_dispute: true }
+        let(:property) { create :property, assessed_equity: 9_000, subject_matter_of_dispute: true }
+
+        it "returns the disregard value" do
+          expect(value).to eq 10_000
+        end
+      end
+
+      context "if there is no valid threshold provided" do
+        let(:capital_item) { create :liquid_capital_item, value: 3_000, subject_matter_of_dispute: true }
+        let(:vehicle) { create :vehicle, assessed_value: 1_000, subject_matter_of_dispute: true }
+        let(:property) { create :property, assessed_equity: 9_000, subject_matter_of_dispute: true }
+        let(:threshold_value) { nil }
+
+        it "returns 0" do
+          expect(value).to eq 0
+        end
+      end
+    end
+  end
+end

--- a/spec/services/collators/capital_collator_spec.rb
+++ b/spec/services/collators/capital_collator_spec.rb
@@ -64,6 +64,16 @@ module Collators
         end
       end
 
+      context "subject matter of dispute disregard" do
+        it "instantiates and calls the SubjectMatterOfDisputeDiregardCalculator service" do
+          smod = instance_double Calculators::SubjectMatterOfDisputeDisregardCalculator
+          allow(Calculators::SubjectMatterOfDisputeDisregardCalculator).to receive(:new).with(assessment).and_return(smod)
+          allow(smod).to receive(:value).and_return(50_000)
+          collator
+          expect(collator[:subject_matter_of_dispute_disregard]).to eq 50_000
+        end
+      end
+
       context "summarization of result_fields" do
         it "summarizes the results it gets from the subservices" do
           liquid_capital_service = instance_double Assessors::LiquidCapitalAssessor
@@ -71,18 +81,21 @@ module Collators
           vehicle_service = instance_double Assessors::VehicleAssessor
           property_service = instance_double Calculators::PropertyCalculator
           pcd = instance_double Calculators::PensionerCapitalDisregardCalculator
+          smod = instance_double Calculators::SubjectMatterOfDisputeDisregardCalculator
 
           allow(Assessors::LiquidCapitalAssessor).to receive(:new).with(assessment).and_return(liquid_capital_service)
           allow(Assessors::NonLiquidCapitalAssessor).to receive(:new).with(assessment).and_return(nlcas)
           allow(Assessors::VehicleAssessor).to receive(:new).with(assessment).and_return(vehicle_service)
           allow(Calculators::PropertyCalculator).to receive(:new).and_return(property_service)
           allow(Calculators::PensionerCapitalDisregardCalculator).to receive(:new).and_return(pcd)
+          allow(Calculators::SubjectMatterOfDisputeDisregardCalculator).to receive(:new).with(assessment).and_return(smod)
 
           allow(liquid_capital_service).to receive(:call).and_return(145.83)
           allow(nlcas).to receive(:call).and_return(500)
           allow(vehicle_service).to receive(:call).and_return(2_500.0)
           allow(property_service).to receive(:call).and_return(23_000.0)
           allow(pcd).to receive(:value).and_return(100_000)
+          allow(smod).to receive(:value).and_return(5_000)
 
           collator
 
@@ -93,7 +106,8 @@ module Collators
           expect(collator[:total_mortgage_allowance]).to eq 999_999_999_999
           expect(collator[:total_capital]).to eq 26_145.83
           expect(collator[:pensioner_capital_disregard]).to eq 100_000
-          expect(collator[:assessed_capital]).to eq(-73_854.17)
+          expect(collator[:subject_matter_of_dispute_disregard]).to eq 5_000
+          expect(collator[:assessed_capital]).to eq(-78_854.17)
         end
       end
     end

--- a/spec/services/creators/capitals_creator_spec.rb
+++ b/spec/services/creators/capitals_creator_spec.rb
@@ -12,8 +12,8 @@ module Creators
     let(:item1) { Faker::Appliance.equipment }
     let(:value1) { BigDecimal(Faker::Number.decimal(r_digits: 2), 2) }
     let(:value2) { BigDecimal(Faker::Number.decimal(r_digits: 2), 2) }
-    let(:smod1) { true }
-    let(:smod2) { false }
+    let(:smod_true) { true }
+    let(:smod_false) { false }
 
     subject(:creator) do
       described_class.call(
@@ -47,10 +47,10 @@ module Creators
 
           expect(items.first.description).to eq bank_name1
           expect(items.first.value).to eq value1
-          expect(items.first.subject_matter_of_dispute).to eq smod1
+          expect(items.first.subject_matter_of_dispute).to eq smod_true
           expect(items.last.description).to eq bank_name2
           expect(items.last.value).to eq value2
-          expect(items.last.subject_matter_of_dispute).to eq smod2
+          expect(items.last.subject_matter_of_dispute).to eq smod_false
         end
 
         it "does not create non-liquid capital items" do
@@ -68,7 +68,7 @@ module Creators
           expect(capital_summary.non_liquid_capital_items.size).to eq 1
           expect(capital_summary.non_liquid_capital_items.first.description).to eq item1
           expect(capital_summary.non_liquid_capital_items.first.value).to eq value1
-          expect(capital_summary.non_liquid_capital_items.first.subject_matter_of_dispute).to eq smod1
+          expect(capital_summary.non_liquid_capital_items.first.subject_matter_of_dispute).to eq smod_true
         end
       end
 
@@ -110,12 +110,12 @@ module Creators
           {
             description: bank_name1,
             value: value1,
-            subject_matter_of_dispute: smod1,
+            subject_matter_of_dispute: smod_true,
           },
           {
             description: bank_name2,
             value: value2,
-            subject_matter_of_dispute: smod2,
+            subject_matter_of_dispute: smod_false,
           },
         ],
       }
@@ -127,7 +127,7 @@ module Creators
           {
             description: item1,
             value: value1,
-            subject_matter_of_dispute: smod1,
+            subject_matter_of_dispute: smod_true,
           },
         ],
       }

--- a/spec/services/creators/capitals_creator_spec.rb
+++ b/spec/services/creators/capitals_creator_spec.rb
@@ -12,6 +12,8 @@ module Creators
     let(:item1) { Faker::Appliance.equipment }
     let(:value1) { BigDecimal(Faker::Number.decimal(r_digits: 2), 2) }
     let(:value2) { BigDecimal(Faker::Number.decimal(r_digits: 2), 2) }
+    let(:smod1) { true }
+    let(:smod2) { false }
 
     subject(:creator) do
       described_class.call(
@@ -45,8 +47,10 @@ module Creators
 
           expect(items.first.description).to eq bank_name1
           expect(items.first.value).to eq value1
+          expect(items.first.subject_matter_of_dispute).to eq smod1
           expect(items.last.description).to eq bank_name2
           expect(items.last.value).to eq value2
+          expect(items.last.subject_matter_of_dispute).to eq smod2
         end
 
         it "does not create non-liquid capital items" do
@@ -64,6 +68,7 @@ module Creators
           expect(capital_summary.non_liquid_capital_items.size).to eq 1
           expect(capital_summary.non_liquid_capital_items.first.description).to eq item1
           expect(capital_summary.non_liquid_capital_items.first.value).to eq value1
+          expect(capital_summary.non_liquid_capital_items.first.subject_matter_of_dispute).to eq smod1
         end
       end
 
@@ -105,10 +110,12 @@ module Creators
           {
             description: bank_name1,
             value: value1,
+            subject_matter_of_dispute: smod1,
           },
           {
             description: bank_name2,
             value: value2,
+            subject_matter_of_dispute: smod2,
           },
         ],
       }
@@ -120,6 +127,7 @@ module Creators
           {
             description: item1,
             value: value1,
+            subject_matter_of_dispute: smod1,
           },
         ],
       }

--- a/spec/services/creators/properties_creator_spec.rb
+++ b/spec/services/creators/properties_creator_spec.rb
@@ -11,6 +11,7 @@ module Creators
         outstanding_mortgage: 200,
         percentage_owned: 15,
         shared_with_housing_assoc: true,
+        subject_matter_of_dispute: true,
       }
     end
     let(:additional_properties) do
@@ -20,6 +21,7 @@ module Creators
           outstanding_mortgage: 0,
           percentage_owned: 99,
           shared_with_housing_assoc: false,
+          subject_matter_of_dispute: false,
         },
         {
           value: 10_000,

--- a/spec/services/decorators/v5/capital_result_decorator_spec.rb
+++ b/spec/services/decorators/v5/capital_result_decorator_spec.rb
@@ -22,6 +22,7 @@ module Decorators
                total_mortgage_allowance: 750_000,
                total_capital: 24_000,
                pensioner_capital_disregard: 10_000,
+               subject_matter_of_dispute_disregard: 3_000,
                capital_contribution: 0.0,
                assessed_capital: 9_355
       end
@@ -35,6 +36,7 @@ module Decorators
           total_mortgage_allowance: 750_000,
           total_capital: 24_000,
           pensioner_capital_disregard: 10_000,
+          subject_matter_of_dispute_disregard: 3_000,
           capital_contribution: 0.0,
           assessed_capital: 9_355,
           proceeding_types: [

--- a/spec/services/decorators/v5/capital_summary_decorator_spec.rb
+++ b/spec/services/decorators/v5/capital_summary_decorator_spec.rb
@@ -27,6 +27,7 @@ module Decorators
               total_mortgage_allowance
               total_capital
               pensioner_capital_disregard
+              subject_matter_of_dispute_disregard
               assessed_capital
               lower_threshold
               upper_threshold

--- a/swagger/v5/swagger.yaml
+++ b/swagger/v5/swagger.yaml
@@ -150,6 +150,7 @@ paths:
                     description: test name 1
                   - value: 100.01
                     description: test name 2
+                    subject_matter_of_dispute: true
                   items:
                     type: object
                     description: Account detail
@@ -159,6 +160,8 @@ paths:
                         format: decimal
                       description:
                         type: string
+                      subject_matter_of_dispute:
+                        type: boolean
         required: true
   "/assessments/{assessment_id}/cash_transactions":
     post:
@@ -962,6 +965,9 @@ paths:
                         shared_with_housing_assoc:
                           type: boolean
                           description: Property is shared with a housing association
+                        subject_matter_of_dispute:
+                          type: boolean
+                          description: Property is the subject of a dispute
                     additional_properties:
                       type: array
                       required:
@@ -995,6 +1001,9 @@ paths:
                           shared_with_housing_assoc:
                             type: boolean
                             description: Property is shared with a housing association
+                          subject_matter_of_dispute:
+                            type: boolean
+                            description: Property is the subject of a dispute
         required: true
   "/assessments/{assessment_id}/regular_transactions":
     post:
@@ -1250,4 +1259,7 @@ paths:
                       in_regular_use:
                         type: boolean
                         description: Vehicle in regular use or not
+                      subject_matter_of_dispute:
+                        type: boolean
+                        description: Whether this vehicle is the subject of a dispute
         required: true

--- a/swagger/v5/swagger.yaml
+++ b/swagger/v5/swagger.yaml
@@ -148,6 +148,7 @@ paths:
                   example:
                   - value: 1.01
                     description: test name 1
+                    subject_matter_of_dispute: false
                   - value: 100.01
                     description: test name 2
                     subject_matter_of_dispute: true


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/EL-428)

'Subject matter of dispute' is an additional capital disregard that works somewhat similarly to the pensioner disregard. The requirement is for the disposable capital calculated result to disregard all assets that are marked as "subject matter of dispute", UP TO a threshold that is currently set at £100,000.00. Any disputed asset value above that threshold is included in the disposable capital calculation.

To that end, this PR adds the following:

- API additional optional fields to tell CFE when capital items, properties and vehicles are the subject matter of dispute
- Logic to disregard assets up to the SMOD disregard threshold from the disposable capital calculation
- SMOD disregard summary in result payload


