### PR TITLE
Allow null employment type for applicants

### DIFF
--- a/public/schemas/applicant_v5.json.erb
+++ b/public/schemas/applicant_v5.json.erb
@@ -13,7 +13,7 @@
           "$ref": "<%= "file://#{@schema_dir}/common.json#date" %>"
         },
         "employed": {
-          "type": "boolean"
+          "type": ["boolean", "null"]
         },
         "has_partner_opponent": {
           "type": "boolean"


### PR DESCRIPTION
The employed attribute is not always present when submitting applicant data to CFE.

This led to this
[bug](https://sentry.io/organizations/ministryofjustice/issues/3710598042/?project=5404900&query=is%3Aunresolved&referrer=issue-stream).

The updates the applicant schema to allow null types.
