### PR TITLE
Allow null employed attribute values

### DIFF
--- a/public/schemas/applicant_v5.json.erb
+++ b/public/schemas/applicant_v5.json.erb
@@ -13,7 +13,7 @@
           "$ref": "<%= "file://#{@schema_dir}/common.json#date" %>"
         },
         "employed": {
-          "type": "boolean"
+          "type": ["boolean", "null"]
         },
         "has_partner_opponent": {
           "type": "boolean"

--- a/spec/requests/applicants_controller_spec.rb
+++ b/spec/requests/applicants_controller_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe ApplicantsController, type: :request do
           date_of_birth: 20.years.ago.to_date,
           has_partner_opponent: false,
           receives_qualifying_benefit: true,
+          employed: false,
         },
       }
     end
@@ -60,7 +61,7 @@ RSpec.describe ApplicantsController, type: :request do
       end
     end
 
-    context "with invalid payload" do
+    context "with non existent assessment id" do
       let(:non_existent_assessment_id) { SecureRandom.uuid }
 
       before do
@@ -69,6 +70,27 @@ RSpec.describe ApplicantsController, type: :request do
       end
 
       it_behaves_like "it fails with message", "No such assessment id"
+    end
+
+    context "with employed of null" do
+      let(:params) do
+        {
+          applicant: {
+            date_of_birth: 20.years.ago.to_date,
+            has_partner_opponent: false,
+            receives_qualifying_benefit: true,
+            employed: nil,
+          },
+        }
+      end
+
+      before do
+        post assessment_applicant_path(assessment.id), params: params.to_json, headers:
+      end
+
+      it "returns success" do
+        expect(response).to have_http_status(:success)
+      end
     end
 
     context "with malformed JSON payload" do


### PR DESCRIPTION
## What
Allow null employed attribute values

This is probably not preferable to a fix in
the consumer to ensure nil/null is sent as
false, however passported applicants may
be either employed or not and we may 
not need to know.

Fixes: [sentry error](https://sentry.io/organizations/ministryofjustice/issues/3710598017/?project=5416054&referrer=slack)



## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
