### PR TITLE
Add SE007 to list of valid procceding types

### DIFF
--- a/app/constants/cfe_constants.rb
+++ b/app/constants/cfe_constants.rb
@@ -6,7 +6,7 @@ module CFEConstants
 
   # Valid CCMS Codes for proceeding types - probably need to get this from LFA in future
   #
-  VALID_PROCEEDING_TYPE_CCMS_CODES = %i[DA001 DA002 DA003 DA004 DA005 DA006 DA007 DA020 SE003 SE004 SE013 SE014].freeze
+  VALID_PROCEEDING_TYPE_CCMS_CODES = %i[DA001 DA002 DA003 DA004 DA005 DA006 DA007 DA020 SE003 SE007 SE004 SE013 SE014].freeze
 
   # Income categories
   #


### PR DESCRIPTION
This was added to seeds in LFA but not added as an allowed
type in CFE.


## What

[Came out of UAT on story](https://dsdmoj.atlassian.net/browse/AP-3489)

Add missing section 8 proceeding type to list of those allowed
by CFE.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
