### PR TITLE
Fix for child care eligibility rules with regular transaction

### DIFF
--- a/app/services/collators/childcare_collator.rb
+++ b/app/services/collators/childcare_collator.rb
@@ -1,6 +1,7 @@
 module Collators
   class ChildcareCollator < BaseWorkflowService
     include Transactions
+    include ChildcareEligibility
 
     def call
       disposable_income_summary.calculate_monthly_childcare_amount!(eligible_for_childcare_costs?, monthly_child_care_cash)
@@ -8,26 +9,8 @@ module Collators
 
   private
 
-    def eligible_for_childcare_costs?
-      applicant_has_dependant_child? && (applicant_is_employed? || applicant_has_student_loan?)
-    end
-
     def monthly_child_care_cash
       monthly_cash_transaction_amount_by(operation: :debit, category: :child_care)
-    end
-
-    def applicant_has_dependant_child?
-      assessment.dependants.any? do |dependant|
-        assessment.submission_date.before?(dependant.becomes_adult_on)
-      end
-    end
-
-    def applicant_is_employed?
-      !!applicant&.employed?
-    end
-
-    def applicant_has_student_loan?
-      student_loan_payments.any?
     end
   end
 end

--- a/app/services/concerns/childcare_eligibility.rb
+++ b/app/services/concerns/childcare_eligibility.rb
@@ -1,0 +1,21 @@
+module ChildcareEligibility
+private
+
+  def eligible_for_childcare_costs?
+    applicant_has_dependant_child? && (applicant_is_employed? || applicant_has_student_loan?)
+  end
+
+  def applicant_has_dependant_child?
+    assessment.dependants.any? do |dependant|
+      assessment.submission_date.before?(dependant.becomes_adult_on)
+    end
+  end
+
+  def applicant_is_employed?
+    !!applicant&.employed?
+  end
+
+  def applicant_has_student_loan?
+    student_loan_payments.any?
+  end
+end

--- a/lib/integration_helpers/test_case/applicant.rb
+++ b/lib/integration_helpers/test_case/applicant.rb
@@ -1,8 +1,7 @@
 module TestCase
   class Applicant
     def initialize(rows)
-      @rows = rows
-      @rows.each { |row| populate_instance_vars(row) }
+      @rows = rows.reject { |row| row[2].nil? }
     end
 
     def url_method
@@ -11,12 +10,7 @@ module TestCase
 
     def payload
       {
-        applicant: {
-          date_of_birth: @date_of_birth,
-          involvement_type: @involvement_type,
-          has_partner_opponent: @has_partner_opponent,
-          receives_qualifying_benefit: @receives_qualifying_benefit,
-        },
+        applicant: { **attributes_from_rows },
       }
     end
 
@@ -26,16 +20,9 @@ module TestCase
 
   private
 
-    def populate_instance_vars(row)
-      case row[2]
-      when "date_of_birth"
-        @date_of_birth = row[3]
-      when "has_partner_opponent"
-        @has_partner_opponent = row[3]
-      when "receives_qualifying_benefit"
-        @receives_qualifying_benefit = row[3]
-      when "involvement_type"
-        @involvement_type = row[3]
+    def attributes_from_rows
+      @rows.each_with_object({}) do |row, h|
+        h[row[2].to_sym] = row[3]
       end
     end
   end

--- a/spec/factories/dependant_factory.rb
+++ b/spec/factories/dependant_factory.rb
@@ -9,10 +9,12 @@ FactoryBot.define do
 
     trait :child_relative do
       relationship { :child_relative }
+      date_of_birth { assessment.submission_date - 16.years + 1.day }
     end
 
     trait :adult_relative do
       relationship { :adult_relative }
+      date_of_birth { assessment.submission_date - 16.years }
     end
 
     trait :under15 do


### PR DESCRIPTION
## What
Fix missing child care eligibility logic for regular transactions

[Link to story](https://dsdmoj.atlassian.net/browse/AP-3632)

Prevent regular transactions of the child care category
from incrementing/decrementing totals and `_all_sources` inline
with similar behaviour for bank and cash transactions.

This was an omission of required logic identified by
EFE team. It should have been handled as part of the
regular transaction implementation.

Child care costs (outgoings) should only ever be applied
if the applicant has dependants under 16 AND is employed
or is a student (receiving a student loan).


## Integration tests
5 new integration worksheet tests have been added to exercise child care scenarios, These can be found on 
this [spreadsheet](https://docs.google.com/spreadsheets/d/1WHg-BrR263L3SxWMrzxS_2Xvo6eM8tAU1B51Vx2Gn2o/edit#gid=1368960793) named `III_REGTR_[1-5]_CHILDCARE-V5`
and will be enabled once merged.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
