### PR TITLE
Remove redundant dependabot ignore rule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,3 @@ updates:
     time: "03:00"
     timezone: Europe/London
   open-pull-requests-limit: 10
-  ignore:
-  - dependency-name: sentry-raven
-    versions:
-    - 3.1.2


### PR DESCRIPTION
We don't use the `sentry-raven` gem anymore, so we don't need to ignore it anymore.