### PR TITLE
Only eager load Ruby code when running tests in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,8 +16,8 @@ executors:
     docker:
       - image: cimg/ruby:3.1.3-node
         environment:
-          - RAILS_ENV=test
-          - TZ: "Europe/London"
+          RAILS_ENV: test
+          TZ: "Europe/London"
   notification-executor:
     docker:
       - image: 'cibuilds/base:latest'
@@ -28,11 +28,11 @@ executors:
     docker:
       - image: cimg/ruby:3.1.3-node
         environment:
-          - RAILS_ENV=test
-          - PGHOST=localhost
-          - PGUSER=user
-          - TZ: "Europe/London"
-          - ALLOW_FUTURE_SUBMISSION_DATE: true
+          RAILS_ENV: test
+          PGHOST: localhost
+          PGUSER: user
+          TZ: "Europe/London"
+          ALLOW_FUTURE_SUBMISSION_DATE: true
       - image: cimg/postgres:10.18
         environment:
           - POSTGRES_USER=user

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -7,9 +7,9 @@ Rails.application.configure do
   # and recreated between test runs. Don't rely on the data there!
   config.cache_classes = false
 
-  # Do not eager load code on boot. This avoids loading your whole application
-  # just for the purpose of running a single test. If you are using a tool that
-  # preloads Rails for running tests, you may have to set it to true.
+  # Eager loading loads your whole application. When running a single test locally,
+  # this probably isn't necessary. It's a good idea to do in a continuous integration
+  # system, or in some way before deploying your code.
   config.eager_load = ENV["CI"].present?
 
   # Configure public file server for tests with Cache-Control for performance.


### PR DESCRIPTION
Before, the code was eager loaded every time a test was run.

When you're running a single test, this doesn't make much sense.

This updates the test configuration to eager load only when the `CI` environment
variable is set (i.e default Rails behaviour).