### PR TITLE
Rename cluster cert var

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,7 +77,7 @@ references:
     run:
       name: Authenticate with cluster
       command: |
-        echo -n ${K8S_CLUSTER_CERT_UAT_LIVE} | base64 -d > ./ca.crt
+        echo -n ${K8S_CLUSTER_CERT_LIVE} | base64 -d > ./ca.crt
         kubectl config set-cluster ${K8S_CLUSTER_NAME} --certificate-authority=./ca.crt --server=https://${K8S_CLUSTER_NAME}
         kubectl config set-credentials circleci --token=${K8S_TOKEN}
         kubectl config set-context ${K8S_CLUSTER_NAME} --cluster=${K8S_CLUSTER_NAME} --user=circleci --namespace=${K8S_NAMESPACE}


### PR DESCRIPTION
## What
Rename cluster cert var

For clarity as there is only one cluster certificate regardless
of namespace. tidy up following circleci incident

**Have added the new var, will delete the old var assuming deploy goes out to production ok**

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
