### PR TITLE
Fix typo in Brakeman scan GitHub Action

### DIFF
--- a/.github/workflows/brakeman-analysis.yml
+++ b/.github/workflows/brakeman-analysis.yml
@@ -1,7 +1,7 @@
 name: Brakeman Scan
 
 on:
-  pull_requent:
+  pull_request:
     branches: [main]
 
 jobs:


### PR DESCRIPTION
The workflow incorrectly specified `pull_requent` as its trigger...