### PR TITLE
AP-3786 add nullable currency field type

### DIFF
--- a/public/schemas/common.json
+++ b/public/schemas/common.json
@@ -23,5 +23,10 @@
     "description": "A negative or positive number (including zero) with two decimal places",
     "not": {"type": "null"},
     "pattern": "^[-+]?\\d+(\\.\\d{1,2})?$"
+  },
+  "nullable_currency": {
+    "id": "common/nullable_currency",
+    "description": "A negative or positive number (including zero) with two decimal places, or nil",
+    "pattern": "^[-+]?\\d+(\\.\\d{1,2})?$"
   }
 }

--- a/public/schemas/vehicles.json.erb
+++ b/public/schemas/vehicles.json.erb
@@ -14,7 +14,7 @@
             "$ref": "<%= "file://#{@schema_dir}/common.json#positive_currency" %>"
           },
           "loan_amount_outstanding": {
-            "$ref": "<%= "file://#{@schema_dir}/common.json#currency" %>"
+            "$ref": "<%= "file://#{@schema_dir}/common.json#nullable_currency" %>"
           },
           "date_of_purchase": {
             "$ref": "<%= "file://#{@schema_dir}/common.json#date" %>"

--- a/spec/requests/swagger_docs/v5/vehicles_spec.rb
+++ b/spec/requests/swagger_docs/v5/vehicles_spec.rb
@@ -70,6 +70,13 @@ RSpec.describe "vehicles", type: :request, swagger_doc: "v5/swagger.yaml" do
                 in_regular_use: true,
                 subject_matter_of_dispute: true,
               },
+              {
+                value: 2098.16,
+                loan_amount_outstanding: nil,
+                date_of_purchase: "2022-03-07",
+                in_regular_use: true,
+                subject_matter_of_dispute: true,
+              },
             ],
           }
         end


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-XXX)

Add nullable_currency field type to allow nil values for currency fields
Set `loan_amount_outstanding` to this field type for validation
Update vehicles rspec to test a nil value for this field

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
