### PR TITLE
Fix: Update cloud-platform-tools-image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
 executors:
   cloud-platform-executor:
     docker:
-      - image: ministryofjustice/cloud-platform-tools:2.1
+      - image: ministryofjustice/cloud-platform-tools:2.3.0
         environment:
           GITHUB_TEAM_NAME_SLUG: laa-apply-for-legal-aid
   linting-executor:
@@ -43,7 +43,7 @@ references:
     run:
       name: Push image to ecr repo
       command: |
-        $(aws ecr get-login --no-include-email)
+        aws ecr get-login-password --region eu-west-2 | docker login --username AWS --password-stdin ${ECR_ENDPOINT}
         docker tag app "${ECR_ENDPOINT}/laa-apply-for-legal-aid/check-financial-eligibility-service:${CIRCLE_SHA1}"
         docker push "${ECR_ENDPOINT}/laa-apply-for-legal-aid/check-financial-eligibility-service:${CIRCLE_SHA1}"
 


### PR DESCRIPTION
## What

Update the cloud platform tool image to 2.3.0
Update the AWS login command to use the aws cli V2

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
