### PR TITLE
Update dependant allowances

### DIFF
--- a/config/thresholds/2023-04-10.yml
+++ b/config/thresholds/2023-04-10.yml
@@ -1,0 +1,68 @@
+---
+gross_income_upper: 2657
+infinite_gross_income_upper: 999_999_999_999
+dependant_step: 222
+dependant_increase_starts_after: 4
+disposable_income_lower: 315
+disposable_income_upper: 733
+capital_lower: 3_000
+capital_upper: 8_000
+pensioner_capital_disregard:
+  minimum_age_in_years: 60
+  passported: 100_000
+  non_passported: 100_000
+  # capital to disregard if monthly disposable income (excluding income derived from capital) is below these figures
+  monthly_income_values:
+    [-.inf, 25.99]: 100_000
+    [26.0, 50.99]: 90_000
+    [51.0, 75.99]: 80_000
+    [76.0, 100.99]: 70_000
+    [101.0, 125.99]: 60_000
+    [126.0, 150.99]: 50_000
+    [151.0, 175.99]: 40_000
+    [176.0, 200.99]: 30_000
+    [201.0, 225.99]: 20_000
+    [226.0, 315.99]: 10_000
+    [316.0]: 0
+property_notional_sale_costs_percentage: 3.0
+property_maximum_mortgage_allowance: 999_999_999_999
+property_disregard:
+  main_home: 100_000
+  additional_property: 0.0
+vehicle_disregard: 15_000
+vehicle_out_of_scope_months: 36
+
+dependant_allowances:
+  child_under_15: 338.90
+  child_aged_15: 338.90
+  child_16_and_over: 338.90
+  adult: 338.90
+  adult_capital_threshold: 8_000
+
+single_monthly_housing_costs_cap: 545
+
+disposable_income_contribution_bands:
+  band_zero:
+    threshold: -.inf
+    disregard: 0.0
+    percentage: 0.0
+    base: 0.0
+  band_a:
+    threshold: 315.0
+    disregard: 311.0
+    percentage: 35.0
+    base: 0
+  band_b:
+    threshold: 466
+    disregard: 465
+    percentage: 45.0
+    base: 53.90
+  band_c:
+    threshold: 617
+    disregard: 616
+    percentage: 70.0
+    base: 121.85
+
+fixed_employment_allowance: 45.0
+employment_income_variance: 60.0
+subject_matter_of_dispute_disregard: 100000.0

--- a/config/thresholds/values.yml
+++ b/config/thresholds/values.yml
@@ -6,3 +6,4 @@
 2021-01-28: config/thresholds/2021-01-28.yml
 2021-04-12: config/thresholds/2021-04-12.yml
 2022-04-11: config/thresholds/2022-04-11.yml
+2023-04-10: config/thresholds/2023-04-10.yml

--- a/spec/services/calculators/dependant_allowance_calculator_spec.rb
+++ b/spec/services/calculators/dependant_allowance_calculator_spec.rb
@@ -274,5 +274,38 @@ module Calculators
         end
       end
     end
+
+    describe "retrieving threshold values for 2023" do
+      subject(:calculator) { described_class.new(dependant) }
+
+      let(:dependant) { build_stubbed(:dependant, assessment:) }
+      let(:assessment) { build_stubbed(:assessment, submission_date:) }
+
+      context "when the submission date is before the new allowances date" do
+        let(:submission_date) { Date.new(2023, 4, 9) }
+
+        it "returns the correct allowances" do
+          expect(calculator).to have_attributes(
+            child_under_15_allowance: 307.64,
+            child_aged_15_allowance: 307.64,
+            child_16_and_over_allowance: 307.64,
+            adult_allowance: 307.64,
+          )
+        end
+      end
+
+      context "when the submission date is after the new allowances date" do
+        let(:submission_date) { Date.new(2023, 4, 10) }
+
+        it "returns the correct allowances" do
+          expect(calculator).to have_attributes(
+            child_under_15_allowance: 338.90,
+            child_aged_15_allowance: 338.90,
+            child_16_and_over_allowance: 338.90,
+            adult_allowance: 338.90,
+          )
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
From 10th April 2023, changes to means assessment fixed allowances for dependants will go live.

This updates the dependant allowances to the new amounts. All other thresholds have been left unchanged.

There is an allowance for dependant partners, but this hasn't been captured since we expect to integrate with the new `CFE-Civil` service before releasing partner means functionality in Apply.

These allowances should be applied for applications with submission dates on or after 2023-04-10.

Apply handles the logic surrounding application submission dates and delegated functions.

The Apply service passes the submission date when making requests to the assessment endpoint, so we do not need to worry about calculating it for an application.

[Link to story](https://dsdmoj.atlassian.net/browse/AP-3950)